### PR TITLE
Remove the dependency parser from the left pane.

### DIFF
--- a/demo/src/components/Menu.js
+++ b/demo/src/components/Menu.js
@@ -40,7 +40,6 @@ class Menu extends React.Component {
                 {buildLink("coreference-resolution", "Coreference Resolution")}
                 {buildLink("named-entity-recognition", "Named Entity Recognition")}
                 {buildLink("constituency-parsing", "Constituency Parsing")}
-                {buildLink("dependency-parsing", "Dependency Parsing")}
                 {buildLink("user-models", "Your model here!")}
               </ul>
             </nav>


### PR DESCRIPTION
I'd like to deploy some new changes today, but we have some outstanding issues with the dependency parser.  Until we can resolve those I'd like to simply remove it from our list of options.  It will still be available if you navigate directly to the dependency parser, but I think that's a feature because it allows us to play with it easily via the demo if desired.