### PR TITLE
Adding (hidden) demo for wikitables parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+__pycache__
+demo/build/
+
 # Logs
 logs
 *.log

--- a/app.py
+++ b/app.py
@@ -40,6 +40,7 @@ class ServerError(Exception):
 
     def __init__(self, message, status_code=None, payload=None):
         Exception.__init__(self)
+        logger.error(message)
         self.message = message
         if status_code is not None:
             self.status_code = status_code
@@ -228,6 +229,9 @@ def make_app(build_dir: str = None, demo_db: Optional[DemoDatabase] = None) -> F
 
         elif model_name == "constituency-parsing":
             log_blob["outputs"]["trees"] = prediction["trees"]
+        elif model_name == "wikitables-parser":
+             log_blob['outputs']['logical_form'] = prediction['logical_form']
+             log_blob['outputs']['answer'] = prediction['answer']
 
         logger.info("prediction: %s", json.dumps(log_blob))
 
@@ -260,6 +264,7 @@ def make_app(build_dir: str = None, demo_db: Optional[DemoDatabase] = None) -> F
     @app.route('/textual-entailment')
     @app.route('/coreference-resolution')
     @app.route('/named-entity-recognition')
+    @app.route('/wikitables-parser')
     @app.route('/semantic-role-labeling/<permalink>')
     @app.route('/constituency-parsing/<permalink>')
     @app.route('/dependency-parsing/<permalink>')
@@ -267,6 +272,7 @@ def make_app(build_dir: str = None, demo_db: Optional[DemoDatabase] = None) -> F
     @app.route('/textual-entailment/<permalink>')
     @app.route('/coreference-resolution/<permalink>')
     @app.route('/named-entity-recognition/<permalink>')
+    @app.route('/wikitables-parser/<permalink>')
     def return_page(permalink: str = None) -> Response:  # pylint: disable=unused-argument, unused-variable
         """return the page"""
         return send_file(os.path.join(build_dir, 'index.html'))

--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -8,6 +8,7 @@ import CorefComponent from './components/CorefComponent'
 import NamedEntityComponent from './components/NamedEntityComponent'
 import ConstituencyParserComponent from './components/ConstituencyParserComponent'
 import DependencyParserComponent from './components/DependencyParserComponent'
+import WikiTablesComponent from './components/WikiTablesComponent'
 import Menu from './components/Menu';
 import ModelIntro from './components/ModelIntro'
 import { PaneTop } from './components/Pane'
@@ -125,6 +126,9 @@ class Demo extends React.Component {
       }
       else if (selectedModel === "dependency-parsing") {
         return (<DependencyParserComponent requestData={requestData} responseData={responseData}/>)
+      }
+      else if (selectedModel === "wikitables-parser") {
+        return (<WikiTablesComponent requestData={requestData} responseData={responseData}/>)
       }
       else if (selectedModel === "user-models") {
         const modelRequest = "User Contributed Models"

--- a/demo/src/components/WikiTablesComponent.js
+++ b/demo/src/components/WikiTablesComponent.js
@@ -1,0 +1,316 @@
+import React from 'react';
+import HeatMap from './heatmap/HeatMap'
+import Collapsible from 'react-collapsible'
+import { API_ROOT } from '../api-config';
+import { withRouter } from 'react-router-dom';
+import {PaneLeft, PaneRight} from './Pane'
+import Button from './Button'
+import ModelIntro from './ModelIntro'
+
+
+/*******************************************************************************
+  <McInput /> Component
+*******************************************************************************/
+
+const parserExamples = [
+    {
+      table: "Season\tLevel\tDivision\tSection\tPosition\tMovements\n" +
+             "1993\tTier 3\tDivision 2\tÖstra Svealand\t1st\tPromoted\n" +
+             "1994\tTier 2\tDivision 1\tNorra\t11th\tRelegation Playoffs\n" +
+             "1995\tTier 2\tDivision 1\tNorra\t4th\t\n" +
+             "1996\tTier 2\tDivision 1\tNorra\t11th\tRelegation Playoffs - Relegated\n" +
+             "1997\tTier 3\tDivision 2\tÖstra Svealand\t3rd\t\n" +
+             "1998\tTier 3\tDivision 2\tÖstra Svealand\t7th\t\n" +
+             "1999\tTier 3\tDivision 2\tÖstra Svealand\t3rd\t\n" +
+             "2000\tTier 3\tDivision 2\tÖstra Svealand\t9th\t\n" +
+             "2001\tTier 3\tDivision 2\tÖstra Svealand\t7th\t\n" +
+             "2002\tTier 3\tDivision 2\tÖstra Svealand\t2nd\t\n" +
+             "2003\tTier 3\tDivision 2\tÖstra Svealand\t3rd\t\n" +
+             "2004\tTier 3\tDivision 2\tÖstra Svealand\t6th\t\n" +
+             "2005\tTier 3\tDivision 2\tÖstra Svealand\t4th\tPromoted\n" +
+             "2006*\tTier 3\tDivision 1\tNorra\t5th\t\n" +
+             "2007\tTier 3\tDivision 1\tSödra\t14th\tRelegated",
+      question: "What is the only year with the 1st position?",
+    },
+    {
+      table: "#\tEvent Year\tSeason\tFlag bearer\n" +
+             "7\t2012\tSummer\tEle Opeloge\n" +
+             "6\t2008\tSummer\tEle Opeloge\n" +
+             "5\t2004\tSummer\tUati Maposua\n" +
+             "4\t2000\tSummer\tPauga Lalau\n" +
+             "3\t1996\tSummer\tBob Gasio\n" +
+             "2\t1988\tSummer\tHenry Smith\n" +
+             "1\t1984\tSummer\tApelu Ioane",
+      question: "How many years were held in summer?\n",
+    },
+];
+
+const title = "WikiTables Semantic Parsing";
+const description = (
+  <span>
+    <span>
+      Semantic parsing maps natural language to machine language.  This page demonstrates a semantic
+      parsing model on the
+      <a href="https://nlp.stanford.edu/software/sempre/wikitable/">WikiTableQuestions</a> dataset.
+      The model is a re-implementation of the parser in the
+      <a href="https://www.semanticscholar.org/paper/Neural-Semantic-Parsing-with-Type-Constraints-for-Krishnamurthy-Dasigi/8c6f58ed0ebf379858c0bbe02c53ee51b3eb398a">
+      EMNLP 2017 paper by Krishnamurthy, Dasigi and Gardner</a>, which achieved state-of-the-art results
+      on this dataset at the time.
+    </span>
+  </span>
+);
+
+
+class WikiTablesInput extends React.Component {
+constructor(props) {
+    super(props);
+
+    // If we're showing a permalinked result,
+    // we'll get passed in a table and question.
+    const { table, question } = props;
+
+    this.state = {
+      tableValue: table || "",
+      questionValue: question || ""
+    };
+    this.handleListChange = this.handleListChange.bind(this);
+    this.handleQuestionChange = this.handleQuestionChange.bind(this);
+    this.handleTableChange = this.handleTableChange.bind(this);
+}
+
+handleListChange(e) {
+    if (e.target.value !== "") {
+      this.setState({
+          tableValue: parserExamples[e.target.value].table,
+          questionValue: parserExamples[e.target.value].question,
+      });
+    }
+}
+
+handleTableChange(e) {
+    this.setState({
+      tableValue: e.target.value,
+    });
+}
+
+handleQuestionChange(e) {
+    this.setState({
+    questionValue: e.target.value,
+    });
+}
+
+render() {
+
+    const { tableValue, questionValue } = this.state;
+    const { outputState, runParser } = this.props;
+
+    const parserInputs = {
+    "tableValue": tableValue,
+    "questionValue": questionValue
+    };
+
+    return (
+        <div className="model__content">
+        <ModelIntro title={title} description={description} />
+            <div className="form__instructions"><span>Enter text or</span>
+            <select disabled={outputState === "working"} onChange={this.handleListChange}>
+                <option value="">Choose an example...</option>
+                {parserExamples.map((example, index) => {
+                  return (
+                      <option value={index} key={index}>{example.table.substring(0,60) + "..."}</option>
+                  );
+                })}
+            </select>
+            </div>
+            <div className="form__field">
+            <label htmlFor="#input--mc-passage">Table</label>
+            <textarea onChange={this.handleTableChange} id="input--mc-passage" type="text" required="true" autoFocus="true" placeholder="E.g. &quot;Season\tLevel\tDivision\tSection\tPosition\tMovements\n1993\tTier 3\tDivision 2\tÖstra Svealand\t1st\tPromoted\n1994\tTier 2\tDivision 1\tNorra\t11th\tRelegation Playoffs\n&quot;" value={tableValue} disabled={outputState === "working"}></textarea>
+            </div>
+            <div className="form__field">
+            <label htmlFor="#input--mc-question">Question</label>
+            <input onChange={this.handleQuestionChange} id="input--mc-question" type="text" required="true" value={questionValue} placeholder="E.g. &quot;What is the only year with the 1st position?&quot;" disabled={outputState === "working"} />
+            </div>
+            <div className="form__field form__field--btn">
+            <Button enabled={outputState !== "working"} runModel={runParser} inputs={parserInputs} />
+            </div>
+        </div>
+        );
+    }
+}
+
+
+/*******************************************************************************
+  <WikiTablesOutput /> Component
+*******************************************************************************/
+
+class WikiTablesOutput extends React.Component {
+    render() {
+      const { answer, logicalForm, actions, linking_scores, feature_scores, similarity_scores, entities, question_tokens } = this.props;
+
+      return (
+        <div className="model__content">
+          <div className="form__field">
+            <label>Answer</label>
+            <div className="model__content__summary">{ answer }</div>
+          </div>
+
+          <div className="form__field">
+            <label>Logical Form</label>
+            <div className="model__content__summary">{ logicalForm }</div>
+          </div>
+
+          <div className="form__field">
+            <Collapsible trigger="Model internals (beta)">
+              <Collapsible trigger="Predicted actions">
+                {actions.map((action, action_index) => (
+                  <Collapsible key={"action_" + action_index} trigger={action['predicted_action']}>
+                    <ActionInfo action={action} question_tokens={question_tokens}/>
+                  </Collapsible>
+                ))}
+              </Collapsible>
+              <Collapsible trigger="Entity linking scores">
+                  <HeatMap xLabels={question_tokens} yLabels={entities} data={linking_scores} xLabelWidth={250} />
+              </Collapsible>
+              {feature_scores &&
+                <Collapsible trigger="Entity linking scores (features only)">
+                    <HeatMap xLabels={question_tokens} yLabels={entities} data={feature_scores} xLabelWidth={250} />
+                </Collapsible>
+              }
+              <Collapsible trigger="Entity linking scores (similarity only)">
+                  <HeatMap xLabels={question_tokens} yLabels={entities} data={similarity_scores} xLabelWidth={250} />
+              </Collapsible>
+            </Collapsible>
+          </div>
+        </div>
+      );
+    }
+  }
+
+
+class ActionInfo extends React.Component {
+  render() {
+    const { action, question_tokens } = this.props;
+    const question_attention = action['question_attention'].map(x => [x]);
+    const considered_actions = action['considered_actions'];
+    const action_probs = action['action_probabilities'].map(x => [x]);
+
+    const probability_heatmap = (
+      <div className="heatmap">
+        <HeatMap xLabels={['Prob']} yLabels={considered_actions} data={action_probs} xLabelWidth={250} />
+      </div>
+    );
+    const question_attention_heatmap = question_attention.length > 0 ? (
+      <div className="heatmap">
+        <HeatMap xLabels={['Prob']} yLabels={question_tokens} data={question_attention} xLabelWidth={70} />
+      </div>
+    ) : (
+      ""
+    )
+
+
+    return (
+      <div>
+        {probability_heatmap}
+        {question_attention_heatmap}
+      </div>
+    )
+  }
+}
+
+
+/*******************************************************************************
+  <McComponent /> Component
+*******************************************************************************/
+
+class _WikiTablesComponent extends React.Component {
+    constructor(props) {
+      super(props);
+
+      const { requestData, responseData } = props;
+
+      this.state = {
+        outputState: responseData ? "received" : "empty", // valid values: "working", "empty", "received", "error"
+        requestData: requestData,
+        responseData: responseData
+      };
+
+      this.runParser = this.runParser.bind(this);
+    }
+
+    runParser(event, inputs) {
+      this.setState({outputState: "working"});
+
+      var payload = {
+        table: inputs.tableValue,
+        question: inputs.questionValue,
+      };
+      fetch(`${API_ROOT}/predict/wikitables-parser`, {
+        method: 'POST',
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload)
+      }).then((response) => {
+        return response.json();
+      }).then((json) => {
+        // If the response contains a `slug` for a permalink, we want to redirect
+        // to the corresponding path using `history.push`.
+        const { slug } = json;
+        const newPath = slug ? '/wikitables-parser/' + slug : '/wikitables-parser';
+
+        // We'll pass the request and response data along as part of the location object
+        // so that the `Demo` component can use them to re-render.
+        const location = {
+          pathname: newPath,
+          state: { requestData: payload, responseData: json }
+        }
+        this.props.history.push(location);
+      }).catch((error) => {
+        this.setState({outputState: "error"});
+        console.error(error);
+      });
+    }
+
+    render() {
+      const { requestData, responseData } = this.props;
+
+      const table = requestData && requestData.table;
+      const question = requestData && requestData.question;
+      const answer = responseData && responseData.answer;
+      const logicalForm = responseData && responseData.logical_form;
+      const actions = responseData && responseData.predicted_actions;
+      const linking_scores = responseData && responseData.linking_scores;
+      const feature_scores = responseData && responseData.feature_scores;
+      const similarity_scores = responseData && responseData.similarity_scores;
+      const entities = responseData && responseData.entities;
+      const question_tokens = responseData && responseData.question_tokens;
+
+      return (
+        <div className="pane model">
+          <PaneLeft>
+            <WikiTablesInput runParser={this.runParser}
+                             outputState={this.state.outputState}
+                             table={table}
+                             question={question}/>
+          </PaneLeft>
+          <PaneRight outputState={this.state.outputState}>
+            <WikiTablesOutput answer={answer}
+                              logicalForm={logicalForm}
+                              actions={actions}
+                              linking_scores={linking_scores}
+                              feature_scores={feature_scores}
+                              similarity_scores={similarity_scores}
+                              entities={entities}
+                              question_tokens={question_tokens}
+            />
+          </PaneRight>
+        </div>
+      );
+
+    }
+}
+
+const WikiTablesComponent = withRouter(_WikiTablesComponent);
+
+export default WikiTablesComponent;

--- a/server/models.py
+++ b/server/models.py
@@ -49,5 +49,9 @@ MODELS = {
         'dependency-parsing': DemoModel(
             'https://s3-us-west-2.amazonaws.com/allennlp/models/biaffine-dependency-parser-2018.08.01.tar.gz',  # pylint: disable=line-too-long
                 'biaffine-dependency-parser'
-        )
+        ),
+        'wikitables-parser': DemoModel(
+            'https://s3-us-west-2.amazonaws.com/allennlp/models/wikitables-model-2018.08.22.tar.gz',  # pylint: disable=line-too-long
+                'wikitables-parser'
+        ),
 }


### PR DESCRIPTION
This adds a demo for the wikitables parser.  It's currently hidden, as it could be made to look nicer, and we're still wanting to improve the model a bit.  I'm doing this now so that @kl2806 has an example to look at for building a demo for his in-progress ATIS model.