### PR TITLE
Fixing input blank-out bug on Constituency and Dependency Parsing demos

### DIFF
--- a/demo/src/components/ConstituencyParserComponent.js
+++ b/demo/src/components/ConstituencyParserComponent.js
@@ -39,7 +39,7 @@ class ConstituencyParserInput extends React.Component {
     const { sentence } = props;
 
     this.state = {
-      sentenceValue: sentence || "",
+      constituencyParserSentenceValue: sentence || "",
     };
     this.handleListChange = this.handleListChange.bind(this);
     this.handleSentenceChange = this.handleSentenceChange.bind(this);
@@ -157,6 +157,8 @@ class _ConstituencyParserComponent extends React.Component {
       this.setState({ outputState: "error" });
       console.error(error);
     });
+
+    console.log(payload);
   }
 
   render() {

--- a/demo/src/components/DependencyParserComponent.js
+++ b/demo/src/components/DependencyParserComponent.js
@@ -39,7 +39,7 @@ class DependencyParserInput extends React.Component {
     const { sentence } = props;
 
     this.state = {
-      sentenceValue: sentence || "",
+      dependencyParserSentenceValue: sentence || "",
     };
     this.handleListChange = this.handleListChange.bind(this);
     this.handleSentenceChange = this.handleSentenceChange.bind(this);


### PR DESCRIPTION
Fixes [When you run an example, the demo blanks out the input text. (#18)](https://github.com/allenai/allennlp-demo/issues/18).

The hard part was tracking down the culprit since it was valid JS and didn't throw any errors. One I traced it back to the source, the fix was actually pretty simple. In both demos, the component's state objects were using the wrong keys for setting initial state of the inputs. It looks like they were using a key name from a different demo. This detail likely fell through the cracks when these demos were being instanced from another one. 

---

![blank-out](https://user-images.githubusercontent.com/8367927/44746312-d9d62b80-aabe-11e8-8a9d-9dff5d8769ec.gif)
