### PR TITLE
Fix the SHA in the info route.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This Dockerfile is used to serve the AllenNLP demo.
 
-FROM allennlp/commit:ae72f792ff9ecdd0e449281d049eb306219f76f2
+FROM allennlp/commit:0b44bceba0b604822b8dc576a8ed2a99e7bd83a9
 LABEL maintainer="allennlp-contact@allenai.org"
 
 WORKDIR /stage/allennlp

--- a/app.py
+++ b/app.py
@@ -255,7 +255,7 @@ def make_app(build_dir: str = None, demo_db: Optional[DemoDatabase] = None) -> F
                 "uptime": uptime,
                 "git_version": git_version,
                 "peak_memory_mb": peak_memory_mb(),
-                "githubUrl": "http://github.com/allenai/allennlp/commit/" + git_version})
+                "githubUrl": "http://github.com/allenai/allennlp-demo/commit/" + git_version})
 
     # As an SPA, we need to return index.html for /model-name and /model-name/permalink.
     @app.route('/open-information-extraction')


### PR DESCRIPTION
Previously we were bringing in SOURCE_COMMIT from the base image instead of the build argument, and so the SHA we present corresponds to allenai/allennlp instead of allenai/allennlp-demo.