### PR TITLE
Improving Event2Mind demo UI

### DIFF
--- a/demo/src/components/Event2MindComponent.js
+++ b/demo/src/components/Event2MindComponent.js
@@ -130,6 +130,12 @@ class Event2MindInput extends React.Component {
 
 /*******************************************************************************
   <TokenCarousel /> Component
+
+  This component is an Event2Mind-specific container for a carousel of tokens
+  that are navigated via `HighlightButton`s. Both the token text and navigation
+  buttons are contained inside a `Highlight`. The container also includes
+  a `HighlightArrow` as part of its structure.
+
 *******************************************************************************/
 
 class TokenCarousel extends React.Component {

--- a/demo/src/components/Event2MindComponent.js
+++ b/demo/src/components/Event2MindComponent.js
@@ -3,6 +3,7 @@ import { API_ROOT } from '../api-config';
 import { withRouter } from 'react-router-dom';
 import { PaneLeft, PaneRight } from './Pane';
 import Button from './Button';
+import HighlightArrow from './highlight/HighlightArrow';
 import HighlightContainer from './highlight/HighlightContainer';
 import { Highlight } from './highlight/Highlight';
 import ModelIntro from './ModelIntro';
@@ -163,25 +164,16 @@ class Event2MindDiagram extends React.Component {
           </div>
           <div className="e2m-mind-container">
             <div className="e2m-mind-container__item">
-              <div className="highlight-arrow highlight-arrow--right highlight-arrow--blue">
-                <div className="highlight-arrow__stalk"></div>
-                <div className="highlight-arrow__triangle"></div>
-              </div>
-              <Highlight label="X's Intent" color="blue" labelPosition="top">none</Highlight>
+              <HighlightArrow color="blue" direction="right" />
+              <Highlight label="X's Intent" secondaryLabel="1 of 8" color="blue" labelPosition="top">none</Highlight>
             </div>
             <div className="e2m-mind-container__item">
-              <div className="highlight-arrow highlight-arrow--right highlight-arrow--orange">
-                <div className="highlight-arrow__stalk"></div>
-                <div className="highlight-arrow__triangle"></div>
-              </div>
-              <Highlight label="X's Reaction" color="orange" labelPosition="top">angry</Highlight>
+              <HighlightArrow color="orange" direction="right" />
+              <Highlight label="X's Reaction" secondaryLabel="1 of 8" color="orange" labelPosition="top">angry</Highlight>
             </div>
             <div className="e2m-mind-container__item">
-              <div className="highlight-arrow highlight-arrow--right highlight-arrow--orange">
-                <div className="highlight-arrow__stalk"></div>
-                <div className="highlight-arrow__triangle"></div>
-              </div>
-              <Highlight label="Other's Reaction" color="orange" labelPosition="top">none</Highlight>
+              <HighlightArrow color="tan" direction="bottom" />
+              <Highlight label="Other's Reaction" secondaryLabel="1 of 8" color="orange" labelPosition="top">none</Highlight>
             </div>
           </div>
         </HighlightContainer>

--- a/demo/src/components/Event2MindComponent.js
+++ b/demo/src/components/Event2MindComponent.js
@@ -23,6 +23,24 @@ const event2MindSentences = [
   "It starts snowing",
 ];
 
+const prettyTargetTypes = [
+  {
+    targetType: "xintent_top_k_predicted_tokens",
+    prettyLabel: "Person X's Intent",
+    color: "blue"
+  },
+  {
+    targetType: "xreact_top_k_predicted_tokens",
+    prettyLabel: "Person X's Reaction",
+    color: "orange"
+  },
+  {
+    targetType: "oreact_top_k_predicted_tokens",
+    prettyLabel: "Other's Reaction",
+    color: "orange"
+  }
+];
+
 const title = "Event2Mind";
 const description = (
   <span>
@@ -112,85 +130,91 @@ class Event2MindInput extends React.Component {
 
 
 /*******************************************************************************
-  <Event2MindOutput /> Component
+  <Event2MindTextOutput /> Component
 *******************************************************************************/
 
-class Event2MindOutput extends React.Component {
+class Event2MindTextOutput extends React.Component {
   render() {
     const { responseData } = this.props;
-    const target_types = {
-      "Person X's Intent": "xintent_top_k_predicted_tokens",
-      "Person X's Reaction": "xreact_top_k_predicted_tokens",
-      "Other's Reaction": "oreact_top_k_predicted_tokens"
-    }
-
     return (
       <div className="model__content model__content--event2Mind-output">
-          {Object.keys(target_types).map((target_desc, i) => {
-            return (
-              <div key={i}>
-                {i !== 0 ? (
-                  <div>
-                    <hr />
-                    <h3>{target_desc}</h3>
-                  </div>
-                ) : (
-                  <h3 className="no-top-margin">{target_desc}</h3>
-                )}
-                {responseData[target_types[target_desc]].map((target, j) => {
-                  return (
-                    <p key={j}>&nbsp;<strong>{j}:</strong> {target.join(" ")}</p>
-                  )
-                })}
-              </div>
-            )
-          })}
+        {prettyTargetTypes.map((item, i) => {
+          return (
+            <div key={i}>
+              {i !== 0 ? (
+                <div>
+                  <hr />
+                  <h3>{item.prettyLabel}</h3>
+                </div>
+              ) : (
+                <h3 className="no-top-margin">{item.prettyLabel}</h3>
+              )}
+              {responseData[item.targetType].map((target, j) => {
+                return (
+                  <p key={j}>&nbsp;<strong>{j}:</strong> {target.join(" ")}</p>
+                )
+              })}
+            </div>
+          )
+        })}
       </div>
     );
   }
 }
 
 /*******************************************************************************
-  <Event2MindDiagram /> Component
+  <Event2MindDiagramOutput /> Component
 *******************************************************************************/
 
-class Event2MindDiagram extends React.Component {
+class Event2MindDiagramOutput extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      tokenIndex: 0,
+    };
+
+    this.updateTokenIndex = this.updateTokenIndex.bind(this);
+  }
+
+  updateTokenIndex(direction) {
+    if (direction === "prev") {
+      this.setState({tokenIndex: this.state.tokenIndex - 1});
+    } else if (direction === "next") {
+      this.setState({tokenIndex: this.state.tokenIndex + 1});
+    }
+  }
+
   render() {
+
+    const responseData = {"oreact_top_k_predicted_tokens":[["none"],["angry"],["annoyed"],["scared"],["hurt"],["sad"],["upset"],["frustrated"],["worried"],["mad"]],"xintent_top_k_predicted_tokens":[["none"],["annoying"],["mean"],["angry"],["show","affection"],["express","anger"],["hurt","person"],["express","affection"],["get","attention"],["get","to","know","persony"]],"xreact_top_k_predicted_tokens":[["angry"],["mad"],["sad"],["scared"],["upset"],["nervous"],["happy"],["guilty"],["annoyed"],["powerful"]]};
+
+    const sentence = "PersonX starts to yell at PersonY";
+
+    // const { responseData, sentence } = this.props;
+    const { tokenIndex } = this.state;
 
     return (
       <div className="model__content">
         <HighlightContainer layout="diagram">
           <div className="e2m-event-container">
-            <Highlight label="Event" color="gray" labelPosition="top">PersonX starts to yell at PersonY</Highlight>
+            <Highlight label="Event" color="gray" labelPosition="top">{sentence}</Highlight>
           </div>
 
           <div className="e2m-mind-container">
-            <div className="e2m-mind-container__item">
-              <HighlightArrow color="blue" direction="right" />
-              <Highlight label="X's Intent" secondaryLabel="1 of 8" color="blue" labelPosition="top">
-                <HighlightButton direction="prev" color="blue" disabled={true} />
-                <span>none</span>
-                <HighlightButton direction="next" color="blue" disabled={false} />
-              </Highlight>
-            </div>
-
-            <div className="e2m-mind-container__item">
-              <HighlightArrow color="orange" direction="right" />
-              <Highlight label="X's Reaction" secondaryLabel="1 of 8" color="orange" labelPosition="top">
-                <HighlightButton direction="prev" color="orange" disabled={true} />
-                <span>angry</span>
-                <HighlightButton direction="next" color="orange" disabled={false} />
-              </Highlight>
-            </div>
-
-            <div className="e2m-mind-container__item">
-              <HighlightArrow color="orange" direction="right" />
-              <Highlight label="Other's Reaction" secondaryLabel="1 of 8" color="orange" labelPosition="top">
-                <HighlightButton direction="prev" color="orange" disabled={true} />
-                <span>none</span>
-                <HighlightButton direction="next" color="orange" disabled={false} />
-              </Highlight>
-            </div>
+            {prettyTargetTypes.map((item, i) => {
+              const tokens = responseData[item.targetType];
+              return (
+                <div className="e2m-mind-container__item" key={i}>
+                  <HighlightArrow color={item.color} direction="right" />
+                  <Highlight label={item.prettyLabel} secondaryLabel={`${tokenIndex + 1} of ${tokens.length}`} color={item.color} labelPosition="top">
+                    <HighlightButton direction="prev" color={item.color} disabled={tokenIndex === 0} onClick={this.updateTokenIndex} />
+                    <span>{tokens[tokenIndex].join(" ")}</span>
+                    <HighlightButton direction="next" color={item.color} disabled={tokenIndex === tokens.length - 1} onClick={this.updateTokenIndex} />
+                  </Highlight>
+                </div>
+              )
+            })}
           </div>
         </HighlightContainer>
       </div>
@@ -218,8 +242,8 @@ class _Event2MindComponent extends React.Component {
       requestData: requestData,
       responseData: responseData,
       // valid values: "working", "empty", "received", "error",
-      // outputState: responseData ? "received" : "empty",
       // TODO(aarons): un-hard-code outputstate
+      // outputState: responseData ? "received" : "empty",
       outputState: "received",
       visualizationType: VisualizationType.DIAGRAM
     };
@@ -269,10 +293,10 @@ class _Event2MindComponent extends React.Component {
     let viz = null;
     switch(visualizationType) {
       case VisualizationType.TEXT:
-        viz = <Event2MindOutput responseData={responseData} />;
+        viz = <Event2MindTextOutput responseData={responseData} />;
         break;
       default: // VisualizationType.DIAGRAM
-        viz = <Event2MindDiagram responseData={responseData} />;
+        viz = <Event2MindDiagramOutput responseData={responseData} sentence={sentence} />;
         break;
     }
 

--- a/demo/src/components/Event2MindComponent.js
+++ b/demo/src/components/Event2MindComponent.js
@@ -4,6 +4,7 @@ import { withRouter } from 'react-router-dom';
 import { PaneLeft, PaneRight } from './Pane';
 import Button from './Button';
 import HighlightArrow from './highlight/HighlightArrow';
+import HighlightButton from './highlight/HighlightButton';
 import HighlightContainer from './highlight/HighlightContainer';
 import { Highlight } from './highlight/Highlight';
 import ModelIntro from './ModelIntro';
@@ -162,18 +163,33 @@ class Event2MindDiagram extends React.Component {
           <div className="e2m-event-container">
             <Highlight label="Event" color="gray" labelPosition="top">PersonX starts to yell at PersonY</Highlight>
           </div>
+
           <div className="e2m-mind-container">
             <div className="e2m-mind-container__item">
               <HighlightArrow color="blue" direction="right" />
-              <Highlight label="X's Intent" secondaryLabel="1 of 8" color="blue" labelPosition="top">none</Highlight>
+              <Highlight label="X's Intent" secondaryLabel="1 of 8" color="blue" labelPosition="top">
+                <HighlightButton direction="prev" color="blue" disabled={true} />
+                <span>none</span>
+                <HighlightButton direction="next" color="blue" disabled={false} />
+              </Highlight>
             </div>
+
             <div className="e2m-mind-container__item">
               <HighlightArrow color="orange" direction="right" />
-              <Highlight label="X's Reaction" secondaryLabel="1 of 8" color="orange" labelPosition="top">angry</Highlight>
+              <Highlight label="X's Reaction" secondaryLabel="1 of 8" color="orange" labelPosition="top">
+                <HighlightButton direction="prev" color="orange" disabled={true} />
+                <span>angry</span>
+                <HighlightButton direction="next" color="orange" disabled={false} />
+              </Highlight>
             </div>
+
             <div className="e2m-mind-container__item">
-              <HighlightArrow color="tan" direction="bottom" />
-              <Highlight label="Other's Reaction" secondaryLabel="1 of 8" color="orange" labelPosition="top">none</Highlight>
+              <HighlightArrow color="orange" direction="right" />
+              <Highlight label="Other's Reaction" secondaryLabel="1 of 8" color="orange" labelPosition="top">
+                <HighlightButton direction="prev" color="orange" disabled={true} />
+                <span>none</span>
+                <HighlightButton direction="next" color="orange" disabled={false} />
+              </Highlight>
             </div>
           </div>
         </HighlightContainer>

--- a/demo/src/components/Event2MindComponent.js
+++ b/demo/src/components/Event2MindComponent.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import { API_ROOT } from '../api-config';
 import { withRouter } from 'react-router-dom';
-import { PaneLeft, PaneRight } from './Pane'
-import Button from './Button'
-import ModelIntro from './ModelIntro'
+import { PaneLeft, PaneRight } from './Pane';
+import Button from './Button';
+import ModelIntro from './ModelIntro';
+import '../css/Event2MindDiagram.css';
 
 /*******************************************************************************
   <Event2MindInput /> Component
@@ -121,22 +122,40 @@ class Event2MindOutput extends React.Component {
 
     return (
       <div className="model__content model__content--event2Mind-output">
-        <ul>
           {Object.keys(target_types).map((target_desc, i) => {
             return (
               <div key={i}>
-                <p>{target_desc}</p>
-                <li>
-                  {responseData[target_types[target_desc]].map((target, j) => {
-                      return (
-                          <p key={j}><b>{j}:</b> {target.join(" ")}</p>
-                      )
-                  })}
-                </li>
+                {i !== 0 ? (
+                  <div>
+                    <hr />
+                    <h3>{target_desc}</h3>
+                  </div>
+                ) : (
+                  <h3 className="no-top-margin">{target_desc}</h3>
+                )}
+                {responseData[target_types[target_desc]].map((target, j) => {
+                  return (
+                    <p key={j}>&nbsp;<strong>{j}:</strong> {target.join(" ")}</p>
+                  )
+                })}
               </div>
             )
           })}
-        </ul>
+      </div>
+    );
+  }
+}
+
+/*******************************************************************************
+  <Event2MindDiagram /> Component
+*******************************************************************************/
+
+class Event2MindDiagram extends React.Component {
+  render() {
+
+    return (
+      <div className="model__content">
+        Hello world.
       </div>
     );
   }
@@ -162,8 +181,10 @@ class _Event2MindComponent extends React.Component {
       requestData: requestData,
       responseData: responseData,
       // valid values: "working", "empty", "received", "error",
-      outputState: responseData ? "received" : "empty",
-      visualizationType: VisualizationType.TEXT
+      // outputState: responseData ? "received" : "empty",
+      // TODO(aarons): un-hard-code outputstate
+      outputState: "received",
+      visualizationType: VisualizationType.DIAGRAM
     };
 
     this.runEvent2MindModel = this.runEvent2MindModel.bind(this);
@@ -211,8 +232,10 @@ class _Event2MindComponent extends React.Component {
     let viz = null;
     switch(visualizationType) {
       case VisualizationType.TEXT:
-      default:
         viz = <Event2MindOutput responseData={responseData} />;
+        break;
+      default: // VisualizationType.DIAGRAM
+        viz = <Event2MindDiagram responseData={responseData} />;
         break;
     }
 
@@ -224,28 +247,23 @@ class _Event2MindComponent extends React.Component {
             sentence={sentence} />
         </PaneLeft>
         <PaneRight outputState={this.state.outputState}>
-          {/*
-            // TODO(aarons): Temporarily hiding this navigation UI behind a comment
-            // since we will need to add it back in the next iteration.
-
-            <ul className="visualization-types">
-              {Object.keys(VisualizationType).map(tpe => {
-                const vizType = VisualizationType[tpe];
-                const className = (
-                  visualizationType === vizType
-                    ? 'visualization-types__active-type'
-                    : null
-                );
-                return (
-                  <li key={vizType} className={className}>
-                    <a onClick={() => this.setState({ visualizationType: vizType })}>
-                      {vizType}
-                    </a>
-                  </li>
-                );
-              })}
-            </ul>
-          */}
+          <ul className="visualization-types">
+            {Object.keys(VisualizationType).map(tpe => {
+              const vizType = VisualizationType[tpe];
+              const className = (
+                visualizationType === vizType
+                  ? 'visualization-types__active-type'
+                  : null
+              );
+              return (
+                <li key={vizType} className={className}>
+                  <a onClick={() => this.setState({ visualizationType: vizType })}>
+                    {vizType}
+                  </a>
+                </li>
+              );
+            })}
+          </ul>
           {viz}
         </PaneRight>
       </div>

--- a/demo/src/components/Event2MindComponent.js
+++ b/demo/src/components/Event2MindComponent.js
@@ -45,12 +45,12 @@ const title = "Event2Mind";
 const description = (
   <span>
     <span>
-      The Event2Mind dataset proposes a commonsense inference task between events and mental states. In particular, it takes events as lightly preprocessed text and produces likely intents and reactions for individuals in the event.
+      The Event2Mind dataset proposes a commonsense inference task between events and mental states. In particular, it takes events as lightly preprocessed text and produces likely intents and reactions for participants of the event.
       This page demonstrates a reimplementation of
     </span>
     <a href="https://www.semanticscholar.org/paper/b89f8a9b2192a8f2018eead6b135ed30a1f2144d" target="_blank" rel="noopener noreferrer">{' '} the original Event2Mind system (Rashkin et al, 2018)</a>
     <span>
-      . An event with people entities should be typed as "PersonX" or "PersonY". Optionally, "___" can be used for uncommon objects.
+      . An event with people entities should be typed as "PersonX" or "PersonY". Optionally, "___" can be used as a placeholder for objects or phrases.
     </span>
   </span>
 );

--- a/demo/src/components/Event2MindComponent.js
+++ b/demo/src/components/Event2MindComponent.js
@@ -3,6 +3,8 @@ import { API_ROOT } from '../api-config';
 import { withRouter } from 'react-router-dom';
 import { PaneLeft, PaneRight } from './Pane';
 import Button from './Button';
+import HighlightContainer from './highlight/HighlightContainer';
+import { Highlight } from './highlight/Highlight';
 import ModelIntro from './ModelIntro';
 import '../css/Event2MindDiagram.css';
 
@@ -155,7 +157,34 @@ class Event2MindDiagram extends React.Component {
 
     return (
       <div className="model__content">
-        Hello world.
+        <HighlightContainer layout="diagram">
+          <div className="e2m-event-container">
+            <Highlight label="Event" color="gray" labelPosition="top">PersonX starts to yell at PersonY</Highlight>
+          </div>
+          <div className="e2m-mind-container">
+            <div className="e2m-mind-container__item">
+              <div className="highlight-arrow highlight-arrow--right highlight-arrow--blue">
+                <div className="highlight-arrow__stalk"></div>
+                <div className="highlight-arrow__triangle"></div>
+              </div>
+              <Highlight label="X's Intent" color="blue" labelPosition="top">none</Highlight>
+            </div>
+            <div className="e2m-mind-container__item">
+              <div className="highlight-arrow highlight-arrow--right highlight-arrow--orange">
+                <div className="highlight-arrow__stalk"></div>
+                <div className="highlight-arrow__triangle"></div>
+              </div>
+              <Highlight label="X's Reaction" color="orange" labelPosition="top">angry</Highlight>
+            </div>
+            <div className="e2m-mind-container__item">
+              <div className="highlight-arrow highlight-arrow--right highlight-arrow--orange">
+                <div className="highlight-arrow__stalk"></div>
+                <div className="highlight-arrow__triangle"></div>
+              </div>
+              <Highlight label="Other's Reaction" color="orange" labelPosition="top">none</Highlight>
+            </div>
+          </div>
+        </HighlightContainer>
       </div>
     );
   }

--- a/demo/src/components/Menu.js
+++ b/demo/src/components/Menu.js
@@ -43,10 +43,7 @@ class Menu extends React.Component {
                 {buildLink("constituency-parsing", "Constituency Parsing")}
                 {buildLink("dependency-parsing", "Dependency Parsing")}
                 {buildLink("open-information-extraction", "Open Information Extraction")}
-                {
-                  // TODO(brendanr): Re-enable this once we're ready to have it be visible in prod.
-                  //buildLink("event2mind", "Event2Mind")
-                }
+                {buildLink("event2mind", "Event2Mind")}
                 {buildLink("user-models", "Your model here!")}
               </ul>
             </nav>

--- a/demo/src/components/highlight/Highlight.js
+++ b/demo/src/components/highlight/Highlight.js
@@ -86,7 +86,7 @@ export class Highlight extends React.Component {
         {children ? (
           <span className="highlight__content">{children}</span>
         ) : null}
-        {(label || label !== null) && (labelPosition === "bottom" || labelPosition === "right") ? labelTemplate : null}
+        {(label || label !== null) && (labelPosition !== "left" && labelPosition !== "top") ? labelTemplate : null}
         {tooltip ? (
           <span className="highlight__tooltip">{tooltip}</span>
         ) : null}

--- a/demo/src/components/highlight/Highlight.js
+++ b/demo/src/components/highlight/Highlight.js
@@ -41,7 +41,7 @@ export class Highlight extends React.Component {
       isClickable,    // boolean
       isClicking,     // boolean
       label,          // string
-      labelPosition,  // string
+      labelPosition,  // string (supported values: "top", "left", "right", "bottom")
       onClick,        // function
       onMouseDown,    // function
       onMouseOver,    // function
@@ -72,13 +72,13 @@ export class Highlight extends React.Component {
         onMouseOver={onMouseOver ? () => { onMouseOver(id) } : null}
         onMouseOut={onMouseOut ? () => { onMouseOut(id) } : null}
         onMouseUp={onMouseUp ? () => { onMouseUp(id) } : null}>
-        {(label || label !== null) && labelPosition === "left" ? (
+        {(label || label !== null) && (labelPosition === "left" || labelPosition === "top") ? (
           <span className="highlight__label"><strong>{label}</strong></span>
         ) : null}
         {children ? (
           <span className="highlight__content">{children}</span>
         ) : null}
-        {(label || label !== null) && labelPosition !== "left" ? (
+        {(label || label !== null) && (labelPosition === "bottom" || labelPosition === "right") ? (
           <span className="highlight__label"><strong>{label}</strong></span>
         ) : null}
         {tooltip ? (

--- a/demo/src/components/highlight/Highlight.js
+++ b/demo/src/components/highlight/Highlight.js
@@ -82,7 +82,7 @@ export class Highlight extends React.Component {
         onMouseOver={onMouseOver ? () => { onMouseOver(id) } : null}
         onMouseOut={onMouseOut ? () => { onMouseOut(id) } : null}
         onMouseUp={onMouseUp ? () => { onMouseUp(id) } : null}>
-        {(label || label !== null) && (labelPosition === "left" || labelPosition === "top") ? labelTemplate : null}
+        {(labelPosition === "left" || labelPosition === "top") ? labelTemplate : null}
         {children ? (
           <span className="highlight__content">{children}</span>
         ) : null}

--- a/demo/src/components/highlight/Highlight.js
+++ b/demo/src/components/highlight/Highlight.js
@@ -48,6 +48,7 @@ export class Highlight extends React.Component {
       onMouseOut,     // function
       onMouseUp,      // function
       selectedId,     // string | number
+      secondaryLabel, // string
       tooltip         // string
     } = this.props;
 
@@ -61,6 +62,15 @@ export class Highlight extends React.Component {
       ${!isClicking && activeIds && activeIds.includes(id) ? "active" : ""}
       ${typeof(children) === "string" && children.length < 8 ? "short-text" : ""}`;
 
+    const labelTemplate = (
+      <span className="highlight__label">
+        <strong>{label}</strong>
+        {secondaryLabel ? (
+          <span className="highlight__label__secondary-label">{secondaryLabel}</span>
+        ) : null}
+      </span>
+    );
+
     return (
       <span
         className={conditionalClasses}
@@ -72,15 +82,11 @@ export class Highlight extends React.Component {
         onMouseOver={onMouseOver ? () => { onMouseOver(id) } : null}
         onMouseOut={onMouseOut ? () => { onMouseOut(id) } : null}
         onMouseUp={onMouseUp ? () => { onMouseUp(id) } : null}>
-        {(label || label !== null) && (labelPosition === "left" || labelPosition === "top") ? (
-          <span className="highlight__label"><strong>{label}</strong></span>
-        ) : null}
+        {(label || label !== null) && (labelPosition === "left" || labelPosition === "top") ? labelTemplate : null}
         {children ? (
           <span className="highlight__content">{children}</span>
         ) : null}
-        {(label || label !== null) && (labelPosition === "bottom" || labelPosition === "right") ? (
-          <span className="highlight__label"><strong>{label}</strong></span>
-        ) : null}
+        {(label || label !== null) && (labelPosition === "bottom" || labelPosition === "right") ? labelTemplate : null}
         {tooltip ? (
           <span className="highlight__tooltip">{tooltip}</span>
         ) : null}

--- a/demo/src/components/highlight/HighlightArrow.js
+++ b/demo/src/components/highlight/HighlightArrow.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import '../../css/HighlightArrow.css';
 
 /*******************************************************************************
   <HighlightArrow /> Component
 *******************************************************************************/
 
-export default class Highlight extends React.Component {
+export default class HighlightArrow extends React.Component {
   render() {
     const {         // All fields optional:
       color,        // string (see highlightColors for supported values)

--- a/demo/src/components/highlight/HighlightArrow.js
+++ b/demo/src/components/highlight/HighlightArrow.js
@@ -3,6 +3,10 @@ import '../../css/HighlightArrow.css';
 
 /*******************************************************************************
   <HighlightArrow /> Component
+
+  This component creates a directional arrow as a visual element of a diagram.
+  For example, see Event2Mind diagram visualization.
+
 *******************************************************************************/
 
 export default class HighlightArrow extends React.Component {

--- a/demo/src/components/highlight/HighlightArrow.js
+++ b/demo/src/components/highlight/HighlightArrow.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+/*******************************************************************************
+  <HighlightArrow /> Component
+*******************************************************************************/
+
+export default class Highlight extends React.Component {
+  render() {
+    const {         // All fields optional:
+      color,        // string (see highlightColors for supported values)
+      direction,    // string (supported values: "top", left", "right", "bottom")
+    } = this.props;
+
+    return (
+      <div className={`highlight-arrow highlight-arrow--${direction ? direction : "right"} highlight-arrow--${color ? color : "blue"}`}>
+        {direction === "left" || direction === "top" ? (
+          <div className="highlight-arrow__triangle"></div>
+        ) : null}
+        <div className="highlight-arrow__stalk"></div>
+        {direction === "right" || direction === "bottom" ? (
+          <div className="highlight-arrow__triangle"></div>
+        ) : null}
+      </div>
+    );
+  }
+}

--- a/demo/src/components/highlight/HighlightButton.js
+++ b/demo/src/components/highlight/HighlightButton.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import '../../css/HighlightButton.css';
+
+/*******************************************************************************
+  <HighlightButton /> Component
+*******************************************************************************/
+
+export default class HighlightButton extends React.Component {
+  render() {
+    const {         // All fields optional:
+      color,        // string (see highlightColors for supported values)
+      direction,    // string (supported values: "top", left", "right", "bottom")
+      disabled,     // boolean
+    } = this.props;
+
+    return (
+      <button className={`highlight__button ${direction === "prev" ? "highlight__button--prev" : "highlight__button--next"}`} disabled={disabled}
+        title={`${!disabled ? `Show ${direction === "prev" ? "previous" : "next"} item` : ""}`}>
+        <span className="highlight__button__body"></span>
+        <svg>
+          <use xlinkHref="#icon__disclosure"></use>
+        </svg>
+      </button>
+    );
+  }
+}

--- a/demo/src/components/highlight/HighlightButton.js
+++ b/demo/src/components/highlight/HighlightButton.js
@@ -8,7 +8,7 @@ import '../../css/HighlightButton.css';
 export default class HighlightButton extends React.Component {
   render() {
     const {         // All fields optional:
-      direction,    // string (supported values: "top", left", "right", "bottom")
+      direction,    // string (supported values: "prev", "next")
       disabled,     // boolean
       onClick,      // function
     } = this.props;

--- a/demo/src/components/highlight/HighlightButton.js
+++ b/demo/src/components/highlight/HighlightButton.js
@@ -8,13 +8,16 @@ import '../../css/HighlightButton.css';
 export default class HighlightButton extends React.Component {
   render() {
     const {         // All fields optional:
-      color,        // string (see highlightColors for supported values)
       direction,    // string (supported values: "top", left", "right", "bottom")
       disabled,     // boolean
+      onClick,      // function
     } = this.props;
 
     return (
-      <button className={`highlight__button ${direction === "prev" ? "highlight__button--prev" : "highlight__button--next"}`} disabled={disabled}
+      <button
+        className={`highlight__button ${direction === "prev" ? "highlight__button--prev" : "highlight__button--next"}`}
+        disabled={disabled}
+        onClick={onClick ? () => { onClick(direction) } : null}
         title={`${!disabled ? `Show ${direction === "prev" ? "previous" : "next"} item` : ""}`}>
         <span className="highlight__button__body"></span>
         <svg>

--- a/demo/src/components/highlight/HighlightButton.js
+++ b/demo/src/components/highlight/HighlightButton.js
@@ -3,6 +3,10 @@ import '../../css/HighlightButton.css';
 
 /*******************************************************************************
   <HighlightButton /> Component
+
+  This component adds a carousl navigation button to a highlight structure.
+  For example, see Event2Mind diagram visualization.
+
 *******************************************************************************/
 
 export default class HighlightButton extends React.Component {

--- a/demo/src/css/App.css
+++ b/demo/src/css/App.css
@@ -171,3 +171,17 @@ th {
   margin-top: 0;
   padding-top: 0;
 }
+
+.flex-container {
+  display: flex;
+}
+
+.flex-container--column {
+  flex-direction: column;
+}
+
+.flex-container--center {
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}

--- a/demo/src/css/App.css
+++ b/demo/src/css/App.css
@@ -166,3 +166,8 @@ th {
 .u-hidden {
   display: none;
 }
+
+.no-top-margin {
+  margin-top: 0;
+  padding-top: 0;
+}

--- a/demo/src/css/App.css
+++ b/demo/src/css/App.css
@@ -171,17 +171,3 @@ th {
   margin-top: 0;
   padding-top: 0;
 }
-
-.flex-container {
-  display: flex;
-}
-
-.flex-container--column {
-  flex-direction: column;
-}
-
-.flex-container--center {
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-}

--- a/demo/src/css/Event2MindDiagram.css
+++ b/demo/src/css/Event2MindDiagram.css
@@ -43,12 +43,12 @@
   padding: 10px 0;
 }
 
-.e2m-mind-container__item {
+.e2m-mind-container__target-type {
   padding: 10px 0;
   display: flex;
 }
 
-.e2m-mind-container__item .highlight-arrow {
+.e2m-mind-container__target-type .highlight-arrow {
   width: 36px;
   padding-top: 9px;
 }

--- a/demo/src/css/Event2MindDiagram.css
+++ b/demo/src/css/Event2MindDiagram.css
@@ -1,12 +1,9 @@
 .e2m-event-container {
-  /* flex-grow: 1; */
-  /* background: red; */
   flex: 1;
 }
 
 .e2m-mind-container {
   width: 55%;
-  /* background: blue; */
 }
 
 .e2m-event-container,

--- a/demo/src/css/Event2MindDiagram.css
+++ b/demo/src/css/Event2MindDiagram.css
@@ -1,10 +1,11 @@
 .e2m-event-container {
   /* flex-grow: 1; */
   /* background: red; */
+  flex: 1;
 }
 
 .e2m-mind-container {
-  width: 50%;
+  width: 55%;
   /* background: blue; */
 }
 
@@ -12,13 +13,16 @@
 .e2m-mind-container {
   align-items: stretch;
   justify-content: stretch;
-  flex: 1;
 }
 
 .e2m-event-container .highlight,
 .e2m-event-container .highlight .highlight__content {
   height: 100%;
   box-sizing: border-box;
+}
+
+.e2m-mind-container .highlight .highlight__content {
+  padding: 10px 40px;
 }
 
 .e2m-event-container .highlight,

--- a/demo/src/css/Event2MindDiagram.css
+++ b/demo/src/css/Event2MindDiagram.css
@@ -21,8 +21,20 @@
   box-sizing: border-box;
 }
 
+.e2m-event-container .highlight .highlight__content {
+  padding: 10px 20px 12px 20px;
+}
+
 .e2m-mind-container .highlight .highlight__content {
-  padding: 10px 40px;
+  padding: 0;
+  flex-wrap: nowrap;
+  flex: 1;
+}
+
+.e2m-mind-container .highlight .highlight__content > span {
+  padding: 10px;
+  display: flex;
+  flex-grow: 1;
 }
 
 .e2m-event-container .highlight,
@@ -49,19 +61,15 @@
 }
 
 .e2m-event-container .highlight .highlight__content,
-.e2m-mind-container .highlight .highlight__content {
+.e2m-mind-container .highlight .highlight__content,
+.e2m-mind-container .highlight .highlight__content > span {
   align-items: center;
   justify-content: center;
   text-align: center;
+  position: relative;
 }
 
 .e2m-event-container .highlight.top .highlight__label,
 .e2m-mind-container .highlight.top .highlight__label {
   min-height: 28px;
 }
-
-
-
-
-
-

--- a/demo/src/css/Event2MindDiagram.css
+++ b/demo/src/css/Event2MindDiagram.css
@@ -1,0 +1,63 @@
+.e2m-event-container {
+  /* flex-grow: 1; */
+  /* background: red; */
+}
+
+.e2m-mind-container {
+  width: 50%;
+  /* background: blue; */
+}
+
+.e2m-event-container,
+.e2m-mind-container {
+  align-items: stretch;
+  justify-content: stretch;
+  flex: 1;
+}
+
+.e2m-event-container .highlight,
+.e2m-event-container .highlight .highlight__content {
+  height: 100%;
+  box-sizing: border-box;
+}
+
+.e2m-event-container .highlight,
+.e2m-mind-container .highlight {
+  margin: 0;
+}
+
+.e2m-mind-container {
+  padding: 10px 0;
+}
+
+.e2m-mind-container__item {
+  padding: 10px 0;
+  display: flex;
+}
+
+.e2m-mind-container__item .highlight-arrow {
+  width: 36px;
+  padding-top: 9px;
+}
+
+.e2m-mind-container .highlight {
+  flex: 1;
+}
+
+.e2m-event-container .highlight .highlight__content,
+.e2m-mind-container .highlight .highlight__content {
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.e2m-event-container .highlight.top .highlight__label,
+.e2m-mind-container .highlight.top .highlight__label {
+  min-height: 28px;
+}
+
+
+
+
+
+

--- a/demo/src/css/Highlight.css
+++ b/demo/src/css/Highlight.css
@@ -76,6 +76,17 @@
   padding-top: 1px;
 }
 
+/* Top Label Layout */
+
+.highlight.top {
+  flex-direction: column;
+  white-space: normal;
+}
+
+.highlight.top .highlight__label {
+  min-height: 22px;
+}
+
 /* Interactions */
 
 .highlight.active,
@@ -114,11 +125,16 @@ Colors
 /* Gray (Default) */
 
 .highlight.gray {
-  border-color: #a0aab5;
   background: #f2f4f6;
 }
 
-.highlight.gray .highlight__label {
+.highlight.gray,
+.highlight-arrow--gray .highlight-arrow__triangle {
+  border-color: #a0aab5;
+}
+
+.highlight.gray .highlight__label,
+.highlight-arrow--gray .highlight-arrow__stalk {
   background-color: #a0aab5;
 }
 
@@ -135,11 +151,16 @@ Colors
 /* Blue */
 
 .highlight.blue {
-  border-color: #4db1f7;
   background: #edf4fa;
 }
 
-.highlight.blue > .highlight__label {
+.highlight.blue,
+.highlight-arrow--blue .highlight-arrow__triangle {
+  border-color: #4db1f7;
+}
+
+.highlight.blue > .highlight__label,
+.highlight-arrow--blue .highlight-arrow__stalk {
   background-color: #4db1f7;
 }
 
@@ -156,11 +177,16 @@ Colors
 /* Green */
 
 .highlight.green {
-  border-color: #90ac4e;
   background: #f1f4f1;
 }
 
-.highlight.green > .highlight__label {
+.highlight.green,
+.highlight-arrow--green .highlight-arrow__triangle {
+  border-color: #90ac4e;
+}
+
+.highlight.green > .highlight__label,
+.highlight-arrow--green .highlight-arrow__stalk {
   background-color: #90ac4e;
 }
 
@@ -177,11 +203,16 @@ Colors
 /* Pink */
 
 .highlight.pink {
-  border-color: #ce6587;
   background: #f4f1f4;
 }
 
-.highlight.pink > .highlight__label {
+.highlight.pink,
+.highlight-arrow--pink .highlight-arrow__triangle {
+  border-color: #ce6587;
+}
+
+.highlight.pink > .highlight__label,
+.highlight-arrow--pink .highlight-arrow__stalk {
   background-color: #ce6587;
 }
 
@@ -198,11 +229,16 @@ Colors
 /* Orange */
 
 .highlight.orange {
-  border-color: #dd9e3e;
   background: #f2f4f4;
 }
 
-.highlight.orange > .highlight__label {
+.highlight.orange,
+.highlight-arrow--orange .highlight-arrow__triangle {
+  border-color: #dd9e3e;
+}
+
+.highlight.orange > .highlight__label,
+.highlight-arrow--orange .highlight-arrow__stalk {
   background-color: #dd9e3e;
 }
 
@@ -219,11 +255,16 @@ Colors
 /* Purple */
 
 .highlight.purple {
-  border-color: #9a5eba;
   background: #f1f0f7;
 }
 
-.highlight.purple > .highlight__label {
+.highlight.purple,
+.highlight-arrow--purple .highlight-arrow__triangle {
+  border-color: #9a5eba;
+}
+
+.highlight.purple > .highlight__label,
+.highlight-arrow--purple .highlight-arrow__stalk {
   background-color: #9a5eba;
 }
 
@@ -240,11 +281,16 @@ Colors
 /* Teal */
 
 .highlight.teal {
-  border-color: #5bb1ad;
   background: #eef4f6;
 }
 
-.highlight.teal > .highlight__label {
+.highlight.teal,
+.highlight-arrow--teal .highlight-arrow__triangle {
+  border-color: #5bb1ad;
+}
+
+.highlight.teal > .highlight__label,
+.highlight-arrow--teal .highlight-arrow__stalk {
   background-color: #5bb1ad;
 }
 
@@ -261,11 +307,16 @@ Colors
 /* Tan */
 
 .highlight.tan {
-  border-color: #b0a481;
   background: #f2f4f4;
 }
 
-.highlight.tan > .highlight__label {
+.highlight.tan,
+.highlight-arrow--tan .highlight-arrow__triangle {
+  border-color: #b0a481;
+}
+
+.highlight.tan > .highlight__label,
+.highlight-arrow--tan .highlight-arrow__stalk {
   background-color: #b0a481;
 }
 
@@ -282,11 +333,16 @@ Colors
 /* Red */
 
 .highlight.red {
-  border-color: #df3838;
   background: #f5eef0;
 }
 
-.highlight.red > .highlight__label {
+.highlight.red,
+.highlight-arrow--red .highlight-arrow__triangle {
+  border-color: #df3838;
+}
+
+.highlight.red > .highlight__label,
+.highlight-arrow--red .highlight-arrow__stalk {
   background-color: #df3838;
 }
 
@@ -303,11 +359,16 @@ Colors
 /* Cobalt */
 
 .highlight.cobalt {
-  border-color: #5f5b97;
   background: #eef0f5;
 }
 
-.highlight.cobalt > .highlight__label {
+.highlight.cobalt,
+.highlight-arrow--cobalt .highlight-arrow__triangle {
+  border-color: #5f5b97;
+}
+
+.highlight.cobalt > .highlight__label,
+.highlight-arrow--cobalt .highlight-arrow__stalk {
   background-color: #5f5b97;
 }
 
@@ -324,11 +385,16 @@ Colors
 /* Brown */
 
 .highlight.brown {
-  border-color: #6a4e3d;
   background: #f2f4f6;
 }
 
-.highlight.brown > .highlight__label {
+.highlight.brown,
+.highlight-arrow--brown .highlight-arrow__triangle {
+  border-color: #6a4e3d;
+}
+
+.highlight.brown > .highlight__label,
+.highlight-arrow--brown .highlight-arrow__stalk {
   background-color: #6a4e3d;
 }
 
@@ -345,11 +411,16 @@ Colors
 /* Slate */
 
 .highlight.slate {
-  border-color: #3b4247;
   background: #eceff1;
 }
 
-.highlight.slate > .highlight__label {
+.highlight.slate,
+.highlight-arrow--slate .highlight-arrow__triangle {
+  border-color: #3b4247;
+}
+
+.highlight.slate > .highlight__label,
+.highlight-arrow--slate .highlight-arrow__stalk {
   background-color: #3b4247;
 }
 
@@ -366,11 +437,16 @@ Colors
 /* Fuchsia */
 
 .highlight.fuchsia {
-  border-color: #e875e8;
   background: #f5f1f9;
 }
 
-.highlight.fuchsia > .highlight__label {
+.highlight.fuchsia,
+.highlight-arrow--fuchsia .highlight-arrow__triangle {
+  border-color: #e875e8;
+}
+
+.highlight.fuchsia > .highlight__label,
+.highlight-arrow--fuchsia .highlight-arrow__stalk {
   background-color: #e875e8;
 }
 
@@ -434,4 +510,44 @@ Tooltip
 
 .highlight__tooltip:hover {
   z-index: -9 !important;
+}
+
+/********************************************
+Arrow
+********************************************/
+
+.highlight-arrow {
+  display: flex;
+  height: 12px;
+  align-items: center;
+}
+
+.highlight-arrow__stalk {
+  width: 100%;
+  height: 4px;
+  padding-right: 10.4px;
+  box-sizing: border-box;
+}
+
+.highlight-arrow__triangle {
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 6px 0 6px 10.4px;
+  border-color: transparent;
+  margin-right: -1px;
+}
+
+.highlight-arrow.highlight-arrow--right .highlight-arrow__triangle,
+.highlight-arrow.highlight-arrow--left .highlight-arrow__triangle {
+  border-top-color: transparent;
+  border-bottom-color: transparent;
+}
+
+.highlight-arrow.highlight-arrow--left .highlight-arrow__triangle {
+  border-left-color: transparent;
+}
+
+.highlight-arrow.highlight-arrow--right .highlight-arrow__triangle {
+  border-right-color: transparent;
 }

--- a/demo/src/css/Highlight.css
+++ b/demo/src/css/Highlight.css
@@ -143,7 +143,8 @@ Colors
 }
 
 .highlight.gray .highlight__label,
-.highlight-arrow--gray .highlight-arrow__stalk {
+.highlight-arrow--gray .highlight-arrow__stalk,
+.highlight.gray .highlight__button .highlight__button__body {
   background-color: #a0aab5;
 }
 
@@ -153,6 +154,10 @@ Colors
 
 .highlight.gray.active .highlight__label {
   background-color: #aab3bd;
+}
+
+.highlight.gray .highlight__button svg {
+  fill: #a0aab5;
 }
 
 /********************************************/
@@ -169,7 +174,8 @@ Colors
 }
 
 .highlight.blue > .highlight__label,
-.highlight-arrow--blue .highlight-arrow__stalk {
+.highlight-arrow--blue .highlight-arrow__stalk,
+.highlight.blue .highlight__button .highlight__button__body {
   background-color: #4db1f7;
 }
 
@@ -179,6 +185,10 @@ Colors
 
 .highlight.blue.active > .highlight__label {
   background-color: #5fb9f8;
+}
+
+.highlight.blue .highlight__button svg {
+  fill: #4db1f7;
 }
 
 /********************************************/
@@ -195,7 +205,8 @@ Colors
 }
 
 .highlight.green > .highlight__label,
-.highlight-arrow--green .highlight-arrow__stalk {
+.highlight-arrow--green .highlight-arrow__stalk,
+.highlight.green .highlight__button .highlight__button__body {
   background-color: #90ac4e;
 }
 
@@ -205,6 +216,10 @@ Colors
 
 .highlight.green.active > .highlight__label {
   background-color: #9bb460;
+}
+
+.highlight.green .highlight__button svg {
+  fill: #90ac4e;
 }
 
 /********************************************/
@@ -221,7 +236,8 @@ Colors
 }
 
 .highlight.pink > .highlight__label,
-.highlight-arrow--pink .highlight-arrow__stalk {
+.highlight-arrow--pink .highlight-arrow__stalk,
+.highlight.pink .highlight__button .highlight__button__body {
   background-color: #ce6587;
 }
 
@@ -231,6 +247,10 @@ Colors
 
 .highlight.pink.active > .highlight__label {
   background-color: #d37593;
+}
+
+.highlight.pink .highlight__button svg {
+  fill: #ce6587;
 }
 
 /********************************************/
@@ -247,7 +267,8 @@ Colors
 }
 
 .highlight.orange > .highlight__label,
-.highlight-arrow--orange .highlight-arrow__stalk {
+.highlight-arrow--orange .highlight-arrow__stalk,
+.highlight.orange .highlight__button .highlight__button__body {
   background-color: #dd9e3e;
 }
 
@@ -257,6 +278,10 @@ Colors
 
 .highlight.orange.active > .highlight__label {
   background-color: #e0a852;
+}
+
+.highlight.orange .highlight__button svg {
+  fill: #dd9e3e;
 }
 
 /********************************************/
@@ -273,7 +298,8 @@ Colors
 }
 
 .highlight.purple > .highlight__label,
-.highlight-arrow--purple .highlight-arrow__stalk {
+.highlight-arrow--purple .highlight-arrow__stalk,
+.highlight.purple .highlight__button .highlight__button__body {
   background-color: #9a5eba;
 }
 
@@ -283,6 +309,10 @@ Colors
 
 .highlight.purple.active > .highlight__label {
   background-color: #a46ec1;
+}
+
+.highlight.purple .highlight__button svg {
+  fill: #9a5eba;
 }
 
 /********************************************/
@@ -299,7 +329,8 @@ Colors
 }
 
 .highlight.teal > .highlight__label,
-.highlight-arrow--teal .highlight-arrow__stalk {
+.highlight-arrow--teal .highlight-arrow__stalk,
+.highlight.teal .highlight__button .highlight__button__body {
   background-color: #5bb1ad;
 }
 
@@ -309,6 +340,10 @@ Colors
 
 .highlight.teal.active > .highlight__label {
   background-color: #6cb9b5;
+}
+
+.highlight.teal .highlight__button svg {
+  fill: #5bb1ad;
 }
 
 /********************************************/
@@ -325,7 +360,8 @@ Colors
 }
 
 .highlight.tan > .highlight__label,
-.highlight-arrow--tan .highlight-arrow__stalk {
+.highlight-arrow--tan .highlight-arrow__stalk,
+.highlight.tan .highlight__button .highlight__button__body {
   background-color: #b0a481;
 }
 
@@ -335,6 +371,10 @@ Colors
 
 .highlight.tan.active > .highlight__label {
   background-color: #b8ad8e;
+}
+
+.highlight.tan .highlight__button svg {
+  fill: #b0a481;
 }
 
 /********************************************/
@@ -351,7 +391,8 @@ Colors
 }
 
 .highlight.red > .highlight__label,
-.highlight-arrow--red .highlight-arrow__stalk {
+.highlight-arrow--red .highlight-arrow__stalk,
+.highlight.red .highlight__button .highlight__button__body {
   background-color: #df3838;
 }
 
@@ -361,6 +402,10 @@ Colors
 
 .highlight.red.active > .highlight__label {
   background-color: #e24c4c;
+}
+
+.highlight.red .highlight__button svg {
+  fill: #df3838;
 }
 
 /********************************************/
@@ -377,7 +422,8 @@ Colors
 }
 
 .highlight.cobalt > .highlight__label,
-.highlight-arrow--cobalt .highlight-arrow__stalk {
+.highlight-arrow--cobalt .highlight-arrow__stalk,
+.highlight.cobalt .highlight__button .highlight__button__body {
   background-color: #5f5b97;
 }
 
@@ -387,6 +433,10 @@ Colors
 
 .highlight.cobalt.active > .highlight__label {
   background-color: #6f6ca2;
+}
+
+.highlight.cobalt .highlight__button svg {
+  fill: #5f5b97;
 }
 
 /********************************************/
@@ -403,7 +453,8 @@ Colors
 }
 
 .highlight.brown > .highlight__label,
-.highlight-arrow--brown .highlight-arrow__stalk {
+.highlight-arrow--brown .highlight-arrow__stalk,
+.highlight.brown .highlight__button .highlight__button__body {
   background-color: #6a4e3d;
 }
 
@@ -413,6 +464,10 @@ Colors
 
 .highlight.brown.active > .highlight__label {
   background-color: #796051;
+}
+
+.highlight.brown .highlight__button svg {
+  fill: #6a4e3d;
 }
 
 /********************************************/
@@ -429,7 +484,8 @@ Colors
 }
 
 .highlight.slate > .highlight__label,
-.highlight-arrow--slate .highlight-arrow__stalk {
+.highlight-arrow--slate .highlight-arrow__stalk,
+.highlight.slate .highlight__button .highlight__button__body {
   background-color: #3b4247;
 }
 
@@ -439,6 +495,10 @@ Colors
 
 .highlight.slate.active > .highlight__label {
   background-color: #4f555a;
+}
+
+.highlight.slate .highlight__button svg {
+  fill: #3b4247;
 }
 
 /********************************************/
@@ -455,7 +515,8 @@ Colors
 }
 
 .highlight.fuchsia > .highlight__label,
-.highlight-arrow--fuchsia .highlight-arrow__stalk {
+.highlight-arrow--fuchsia .highlight-arrow__stalk,
+.highlight.fuchsia .highlight__button .highlight__button__body {
   background-color: #e875e8;
 }
 
@@ -465,6 +526,10 @@ Colors
 
 .highlight.fuchsia.active > .highlight__label {
   background-color: #ea83ea;
+}
+
+.highlight.fuchsia .highlight__button svg {
+  fill: #e875e8;
 }
 
 /********************************************
@@ -519,94 +584,4 @@ Tooltip
 
 .highlight__tooltip:hover {
   z-index: -9 !important;
-}
-
-/********************************************
-Arrow
-********************************************/
-
-.highlight-arrow {
-  display: flex;
-  height: 12px;
-  align-items: center;
-}
-
-.highlight-arrow__stalk {
-  width: 100%;
-  box-sizing: border-box;
-}
-
-.highlight-arrow__triangle {
-  width: 0;
-  height: 0;
-  border-style: solid;
-}
-
-.highlight-arrow.highlight-arrow--right .highlight-arrow__triangle,
-.highlight-arrow.highlight-arrow--left .highlight-arrow__triangle {
-  border-top-color: transparent;
-  border-bottom-color: transparent;
-}
-
-.highlight-arrow.highlight-arrow--left .highlight-arrow__stalk {
-  height: 4px;
-  padding-left: 10.4px;
-}
-
-.highlight-arrow.highlight-arrow--right .highlight-arrow__stalk {
-  height: 4px;
-  padding-right: 10.4px;
-}
-
-.highlight-arrow.highlight-arrow--left .highlight-arrow__triangle {
-  border-left-color: transparent;
-  border-width: 6px 10.4px 6px 0;
-  margin-left: -1px;
-}
-
-.highlight-arrow.highlight-arrow--right .highlight-arrow__triangle {
-  border-right-color: transparent;
-  border-width: 6px 0 6px 10.4px;
-  margin-right: -1px;
-}
-
-/* Vertical Arrows */
-
-.highlight-arrow.highlight-arrow--top,
-.highlight-arrow.highlight-arrow--bottom {
-  flex-direction: column;
-  width: 12px;
-  /* align-items: center; */
-}
-
-.highlight-arrow__stalk {
-  height: 100%;
-}
-
-.highlight-arrow.highlight-arrow--top .highlight-arrow__stalk {
-  width: 4px;
-  padding-top: 10.4px;
-}
-
-.highlight-arrow.highlight-arrow--bottom .highlight-arrow__stalk {
-  width: 4px;
-  padding-bottom: 10.4px;
-}
-
-.highlight-arrow.highlight-arrow--top .highlight-arrow__triangle,
-.highlight-arrow.highlight-arrow--bottom .highlight-arrow__triangle {
-  border-left-color: transparent;
-  border-right-color: transparent;
-}
-
-.highlight-arrow.highlight-arrow--top .highlight-arrow__triangle {
-  border-top-color: transparent;
-  border-width: 0 6px 10.4px 6px;
-  margin-top: -1px;
-}
-
-.highlight-arrow.highlight-arrow--bottom .highlight-arrow__triangle {
-  border-bottom-color: transparent;
-  border-width: 10.4px 6px 0 6px;
-  margin-bottom: -1px;
 }

--- a/demo/src/css/Highlight.css
+++ b/demo/src/css/Highlight.css
@@ -39,13 +39,22 @@
   text-align: center;
 }
 
-.highlight__label strong {
+.highlight__label strong,
+.highlight__label span.highlight__label__secondary-label {
   display: block;
   font-size: 11px;
   color: #fff;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
   -webkit-font-smoothing: subpixel-antialiased;
+  letter-spacing: 0.1em;
+}
+
+.highlight__label strong {
+  text-transform: uppercase;
+}
+
+.highlight__label span.highlight__label__secondary-label {
+  opacity: .75;
+  padding-left: 6px;
 }
 
 .highlight__content {
@@ -524,8 +533,6 @@ Arrow
 
 .highlight-arrow__stalk {
   width: 100%;
-  height: 4px;
-  padding-right: 10.4px;
   box-sizing: border-box;
 }
 
@@ -533,9 +540,6 @@ Arrow
   width: 0;
   height: 0;
   border-style: solid;
-  border-width: 6px 0 6px 10.4px;
-  border-color: transparent;
-  margin-right: -1px;
 }
 
 .highlight-arrow.highlight-arrow--right .highlight-arrow__triangle,
@@ -544,10 +548,65 @@ Arrow
   border-bottom-color: transparent;
 }
 
+.highlight-arrow.highlight-arrow--left .highlight-arrow__stalk {
+  height: 4px;
+  padding-left: 10.4px;
+}
+
+.highlight-arrow.highlight-arrow--right .highlight-arrow__stalk {
+  height: 4px;
+  padding-right: 10.4px;
+}
+
 .highlight-arrow.highlight-arrow--left .highlight-arrow__triangle {
   border-left-color: transparent;
+  border-width: 6px 10.4px 6px 0;
+  margin-left: -1px;
 }
 
 .highlight-arrow.highlight-arrow--right .highlight-arrow__triangle {
   border-right-color: transparent;
+  border-width: 6px 0 6px 10.4px;
+  margin-right: -1px;
+}
+
+/* Vertical Arrows */
+
+.highlight-arrow.highlight-arrow--top,
+.highlight-arrow.highlight-arrow--bottom {
+  flex-direction: column;
+  width: 12px;
+  /* align-items: center; */
+}
+
+.highlight-arrow__stalk {
+  height: 100%;
+}
+
+.highlight-arrow.highlight-arrow--top .highlight-arrow__stalk {
+  width: 4px;
+  padding-top: 10.4px;
+}
+
+.highlight-arrow.highlight-arrow--bottom .highlight-arrow__stalk {
+  width: 4px;
+  padding-bottom: 10.4px;
+}
+
+.highlight-arrow.highlight-arrow--top .highlight-arrow__triangle,
+.highlight-arrow.highlight-arrow--bottom .highlight-arrow__triangle {
+  border-left-color: transparent;
+  border-right-color: transparent;
+}
+
+.highlight-arrow.highlight-arrow--top .highlight-arrow__triangle {
+  border-top-color: transparent;
+  border-width: 0 6px 10.4px 6px;
+  margin-top: -1px;
+}
+
+.highlight-arrow.highlight-arrow--bottom .highlight-arrow__triangle {
+  border-bottom-color: transparent;
+  border-width: 10.4px 6px 0 6px;
+  margin-bottom: -1px;
 }

--- a/demo/src/css/Highlight.css
+++ b/demo/src/css/Highlight.css
@@ -37,6 +37,7 @@
   display: flex;
   padding: 0 8px;
   text-align: center;
+  user-select: none;
 }
 
 .highlight__label strong,

--- a/demo/src/css/HighlightArrow.css
+++ b/demo/src/css/HighlightArrow.css
@@ -1,0 +1,88 @@
+/********************************************
+Highlight Arrow
+********************************************/
+
+.highlight-arrow {
+  display: flex;
+  height: 12px;
+  align-items: center;
+}
+
+.highlight-arrow__stalk {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.highlight-arrow__triangle {
+  width: 0;
+  height: 0;
+  border-style: solid;
+}
+
+.highlight-arrow.highlight-arrow--right .highlight-arrow__triangle,
+.highlight-arrow.highlight-arrow--left .highlight-arrow__triangle {
+  border-top-color: transparent;
+  border-bottom-color: transparent;
+}
+
+.highlight-arrow.highlight-arrow--left .highlight-arrow__stalk {
+  height: 4px;
+  padding-left: 10.4px;
+}
+
+.highlight-arrow.highlight-arrow--right .highlight-arrow__stalk {
+  height: 4px;
+  padding-right: 10.4px;
+}
+
+.highlight-arrow.highlight-arrow--left .highlight-arrow__triangle {
+  border-left-color: transparent;
+  border-width: 6px 10.4px 6px 0;
+  margin-left: -1px;
+}
+
+.highlight-arrow.highlight-arrow--right .highlight-arrow__triangle {
+  border-right-color: transparent;
+  border-width: 6px 0 6px 10.4px;
+  margin-right: -1px;
+}
+
+/* Vertical Arrows */
+
+.highlight-arrow.highlight-arrow--top,
+.highlight-arrow.highlight-arrow--bottom {
+  flex-direction: column;
+  width: 12px;
+}
+
+.highlight-arrow__stalk {
+  height: 100%;
+}
+
+.highlight-arrow.highlight-arrow--top .highlight-arrow__stalk {
+  width: 4px;
+  padding-top: 10.4px;
+}
+
+.highlight-arrow.highlight-arrow--bottom .highlight-arrow__stalk {
+  width: 4px;
+  padding-bottom: 10.4px;
+}
+
+.highlight-arrow.highlight-arrow--top .highlight-arrow__triangle,
+.highlight-arrow.highlight-arrow--bottom .highlight-arrow__triangle {
+  border-left-color: transparent;
+  border-right-color: transparent;
+}
+
+.highlight-arrow.highlight-arrow--top .highlight-arrow__triangle {
+  border-top-color: transparent;
+  border-width: 0 6px 10.4px 6px;
+  margin-top: -1px;
+}
+
+.highlight-arrow.highlight-arrow--bottom .highlight-arrow__triangle {
+  border-bottom-color: transparent;
+  border-width: 10.4px 6px 0 6px;
+  margin-bottom: -1px;
+}

--- a/demo/src/css/HighlightButton.css
+++ b/demo/src/css/HighlightButton.css
@@ -1,0 +1,72 @@
+/********************************************
+Highlight Button
+********************************************/
+
+.highlight__button {
+  border: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  width: 32px;
+  min-width: 32px;
+  height: 100%;
+  position: relative;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: transparent;
+  align-items: center;
+  justify-content: center;
+}
+
+.highlight__button:focus {
+  outline: none;
+}
+
+.highlight__button__body {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  transition: opacity .2s ease;
+  opacity: 0.08;
+}
+
+.highlight__button svg {
+  width: 7px;
+  height: 12px;
+}
+
+.highlight__button:not([disabled]) {
+  cursor: pointer;
+}
+
+/* Previous */
+
+.highlight__button.highlight__button--prev svg {
+  transform: rotate(180deg);
+}
+
+/* Hover */
+
+.highlight__button:not([disabled]):hover .highlight__button__body {
+  opacity: 0.25;
+}
+
+/* Active */
+
+.highlight__button:not([disabled]):active .highlight__button__body {
+  opacity: 0.1;
+  transition-duration: 0s;
+}
+
+/* Disabled */
+
+.highlight__button[disabled] .highlight__button__body {
+  opacity: 0.03;
+}
+
+.highlight__button[disabled] svg {
+  opacity: 0.25;
+}

--- a/demo/src/css/HighlightContainer.css
+++ b/demo/src/css/HighlightContainer.css
@@ -13,3 +13,15 @@
   padding: 10px 1.125em;
   align-items: flex-start;
 }
+
+/* Diagram Layout */
+
+.highlight-container.highlight-container--diagram {
+  align-items: flex-start;
+}
+
+.highlight-container.highlight-container--diagram.passage.model__content__summary {
+  background: transparent;
+  align-items: stretch;
+  padding: 0;
+}


### PR DESCRIPTION
![e2m](https://user-images.githubusercontent.com/8367927/45987119-aab2cb80-c024-11e8-95a0-36e8995115ea.gif)

---

**This PR:**

- Fixes [Create a better demo for Event2Mind (#63)](https://github.com/allenai/allennlp-demo/issues/63)
- Adds `Diagram` visualization tab based on "[Option A](https://files.slack.com/files-pri/T0A198UU9-FCYNYU550/event2mind_a.png)" design agreed upon by team via Slack
- Improves readability of `Text` tab output
- Adds `Event2Mind` link to model menu

