### PR TITLE
Adding crosshairs and tooltip to HeatMap

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -13877,6 +13877,16 @@
         "refractor": "^2.4.1"
       }
     },
+    "react-tooltip": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-3.8.4.tgz",
+      "integrity": "sha512-i9rP5eihRNXFqYtyw58fhy+oT7OAEox/WC7XJOSED57s31nLU+uOJai5TgADbwNzJ7xamPkijYF36IfrUGJgcQ==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "prop-types": "^15.6.0",
+        "sanitize-html-react": "^1.13.0"
+      }
+    },
     "read-all-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
@@ -14056,6 +14066,11 @@
       "requires": {
         "is-equal-shallow": "^0.1.3"
       }
+    },
+    "regexp-quote": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/regexp-quote/-/regexp-quote-0.0.0.tgz",
+      "integrity": "sha1-Hg9GUMhi3L/tVP1CsUjpuxch/PI="
     },
     "regexpu-core": {
       "version": "2.0.0",
@@ -14342,6 +14357,39 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
+    "sanitize-html-react": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html-react/-/sanitize-html-react-1.13.0.tgz",
+      "integrity": "sha1-51e5rbryyKdi89Lf9wE4g44FQgo=",
+      "requires": {
+        "htmlparser2": "^3.9.0",
+        "regexp-quote": "0.0.0",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+          "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "htmlparser2": {
+          "version": "3.9.2",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+          "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+          "requires": {
+            "domelementtype": "^1.3.0",
+            "domhandler": "^2.3.0",
+            "domutils": "^1.5.1",
+            "entities": "^1.1.1",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.2"
+          }
         }
       }
     },

--- a/demo/package.json
+++ b/demo/package.json
@@ -10,7 +10,8 @@
     "react-dom": "^15.6.1",
     "react-router-dom": "^4.2.2",
     "react-scripts": "1.0.13",
-    "react-syntax-highlighter": "^8.0.1"
+    "react-syntax-highlighter": "^8.0.1",
+    "react-tooltip": "^3.8.4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/demo/src/components/AtisComponent.js
+++ b/demo/src/components/AtisComponent.js
@@ -156,15 +156,11 @@ class ActionInfo extends React.Component {
     const action_probs = action['action_probabilities'].map(x => [x]);
 
     const probability_heatmap = (
-      <div className="heatmap">
-         <HeatMap colLabels={['Prob']} rowLabels={considered_actions} data={action_probs} />
-      </div>
+      <HeatMap colLabels={['Prob']} rowLabels={considered_actions} data={action_probs} />
     );
 
     const utterance_attention_heatmap = utterance_attention.length > 0 ? (
-      <div className="heatmap">
-         <HeatMap colLabels={['Prob']} rowLabels={tokenized_utterance} data={utterance_attention} />
-      </div>
+      <HeatMap colLabels={['Prob']} rowLabels={tokenized_utterance} data={utterance_attention} />
     ) : (
       ""
     )

--- a/demo/src/components/HeatMap.js
+++ b/demo/src/components/HeatMap.js
@@ -21,11 +21,39 @@ import '../css/HeatMap.css';
 *******************************************************************************/
 
 export default class HeatMap extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      activeRow: null,
+      activeCol: null
+    };
+    this.handleMouseOver = this.handleMouseOver.bind(this);
+    this.handleMouseOut = this.handleMouseOut.bind(this);
+  }
+
+  handleMouseOver(rowIndex, colIndex) {
+    this.setState({
+      activeRow: rowIndex,
+      activeCol: colIndex
+    });
+  }
+
+  handleMouseOut() {
+    this.setState({
+      activeRow: null,
+      activeCol: null
+    });
+  }
+
   render() {
     const { data,
             colLabels,
             rowLabels,
             normalization = "none" } = this.props;
+
+    const { activeRow,
+            activeCol } = this.state;
 
     let opacity;
 
@@ -72,7 +100,12 @@ export default class HeatMap extends React.Component {
                     <tbody>
                       <tr data-row="header">
                         {colLabels.map((colLabel, colIndex) => (
-                          <th className="heatmap__label" key={`${colLabel}_${colIndex}`} data-col={colIndex} data-row="header">
+                          <th className={`heatmap__label${colIndex === activeCol ? " heatmap__col-label-cursor" : ""}`}
+                            key={`${colLabel}_${colIndex}`}
+                            data-col={colIndex}
+                            data-row="header"
+                            onMouseOver={() => {this.handleMouseOver(null, colIndex)}}
+                            onMouseOut={() => {this.handleMouseOut()}}>
                             <div className="heatmap__label__outer">
                               <div className="heatmap__label__inner">
                                 <span>{colLabel}</span>
@@ -92,7 +125,12 @@ export default class HeatMap extends React.Component {
                     <tbody>
                       {rowLabels.map((rowLabel, rowIndex) => (
                         <tr className="heatmap__row" key={`${rowLabel}_${rowIndex}`} data-row={rowIndex}>
-                          <th className="heatmap__label" data-col="header" data-row={rowIndex}>
+                          <th
+                            className={`heatmap__label${rowIndex === activeRow ? " heatmap__row-label-cursor" : ""}`}
+                            data-col="header"
+                            data-row={rowIndex}
+                            onMouseOver={() => {this.handleMouseOver(rowIndex, null)}}
+                            onMouseOut={() => {this.handleMouseOut()}}>
                             <span>{rowLabel}</span>
                           </th>
                         </tr>
@@ -108,14 +146,18 @@ export default class HeatMap extends React.Component {
                         <tr className="heatmap__row" key={`${rowLabel}_${rowIndex}`} data-row={rowIndex}>
                           {colLabels.map((colLabel, colIndex) => (
                             <td key={`${colLabel}_${colIndex}_${rowLabel}_${rowIndex}`}
-                              data-col={colIndex}
-                              data-row={rowIndex}
                               className="heatmap__cell"
-                              title={`${data[rowIndex][colIndex]}`}>
-                              <div className="heatmap__cursor"></div>
-                              <div className="heatmap__col-cursor"></div>
-                              <div className="heatmap__row-cursor"></div>
+                              data-col={colIndex}
+                              data-row={rowIndex}>
+                              <div className={`heatmap__cursor${rowIndex === activeRow && colIndex === activeCol ? " heatmap__data--active" : ""}`}></div>
+                              <div className={`heatmap__col-cursor${((rowIndex === activeRow && colIndex === activeCol) || (colIndex === activeCol && rowIndex === 0 && activeRow === null)) ? " heatmap__data--active" : ""}`}></div>
+                              <div className={`heatmap__row-cursor${((rowIndex === activeRow && colIndex === activeCol) || (rowIndex === activeRow && colIndex === 0 && activeCol === null)) ? " heatmap__data--active" : ""}`}></div>
                               <div className="heatmap__color-box" style={{opacity: opacity[rowIndex][colIndex]}}></div>
+                              <div
+                                className="heatmap__trigger"
+                                onMouseOver={() => {this.handleMouseOver(rowIndex, colIndex)}}
+                                onMouseOut={() => {this.handleMouseOut()}}></div>
+                              <div className="heatmap__tooltip">{`${data[rowIndex][colIndex]}`}</div>
                             </td>
                           ))}
                         </tr>

--- a/demo/src/components/HeatMap.js
+++ b/demo/src/components/HeatMap.js
@@ -149,9 +149,6 @@ export default class HeatMap extends React.Component {
                               className="heatmap__cell"
                               data-col={colIndex}
                               data-row={rowIndex}>
-                              {rowIndex === activeRow && colIndex === activeCol ? (
-                                <div className="heatmap__cursor"></div>
-                              ) : null}
                               {((rowIndex === activeRow && colIndex === activeCol) || (colIndex === activeCol && rowIndex === 0 && activeRow === null)) ? (
                                 <div className="heatmap__col-cursor"></div>
                               ) : null}
@@ -159,12 +156,15 @@ export default class HeatMap extends React.Component {
                                 <div className="heatmap__row-cursor"></div>
                               ) : null}
                               <div className="heatmap__color-box" style={{opacity: opacity[rowIndex][colIndex]}}></div>
-                              <div
-                                className="heatmap__trigger"
+                              <div className={`heatmap__trigger${rowIndex === activeRow && colIndex === activeCol ? " heatmap__cursor" : ""}`}
                                 onMouseOver={() => {this.handleMouseOver(rowIndex, colIndex)}}
                                 onMouseOut={() => {this.handleMouseOut()}}></div>
                               {rowIndex === activeRow && colIndex === activeCol ? (
-                                <div className="heatmap__tooltip">{`${data[rowIndex][colIndex]}`}</div>
+                                <div className="heatmap__tooltip">
+                                  {`${data[rowIndex][colIndex]}`}
+                                  <span className="heatmap__tooltip__meta"><strong>Row:</strong> {rowLabels[rowIndex]}</span>
+                                  <span className="heatmap__tooltip__meta"><strong>Column:</strong> {colLabels[colIndex]}</span>
+                                </div>
                               ) : null}
                             </td>
                           ))}

--- a/demo/src/components/HeatMap.js
+++ b/demo/src/components/HeatMap.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactTooltip from 'react-tooltip';
 import '../css/HeatMap.css';
 
 /*******************************************************************************
@@ -147,6 +148,8 @@ export default class HeatMap extends React.Component {
                           {colLabels.map((colLabel, colIndex) => (
                             <td key={`${colLabel}_${colIndex}_${rowLabel}_${rowIndex}`}
                               className="heatmap__cell"
+                              data-tip=""
+                              data-for="heatmap-tooltip"
                               data-col={colIndex}
                               data-row={rowIndex}>
                               {((rowIndex === activeRow && colIndex === activeCol) || (colIndex === activeCol && rowIndex === 0 && activeRow === null)) ? (
@@ -158,14 +161,8 @@ export default class HeatMap extends React.Component {
                               <div className="heatmap__color-box" style={{opacity: opacity[rowIndex][colIndex]}}></div>
                               <div className={`heatmap__trigger${rowIndex === activeRow && colIndex === activeCol ? " heatmap__cursor" : ""}`}
                                 onMouseOver={() => {this.handleMouseOver(rowIndex, colIndex)}}
-                                onMouseOut={() => {this.handleMouseOut()}}></div>
-                              {rowIndex === activeRow && colIndex === activeCol ? (
-                                <div className="heatmap__tooltip">
-                                  {`${data[rowIndex][colIndex]}`}
-                                  <span className="heatmap__tooltip__meta"><strong>Row:</strong> {rowLabels[rowIndex]}</span>
-                                  <span className="heatmap__tooltip__meta"><strong>Column:</strong> {colLabels[colIndex]}</span>
-                                </div>
-                              ) : null}
+                                onMouseOut={() => {this.handleMouseOut()}}>
+                              </div>
                             </td>
                           ))}
                         </tr>
@@ -178,6 +175,13 @@ export default class HeatMap extends React.Component {
           </div>{/* END .heatmap */}
         </div>{/* END .heatmap-scroll */}
         {/* END .heatmap-container */}
+        {activeRow !== null && activeCol !== null ? (
+          <ReactTooltip id="heatmap-tooltip" place="right">
+            {`${data[activeRow][activeCol]}`}
+            <span className="heatmap__tooltip__meta"><strong>Row:</strong> {rowLabels[activeRow]}</span>
+            <span className="heatmap__tooltip__meta"><strong>Column:</strong> {colLabels[activeCol]}</span>
+          </ReactTooltip>
+        ) : null}
       </div>
     );
   }

--- a/demo/src/components/HeatMap.js
+++ b/demo/src/components/HeatMap.js
@@ -102,7 +102,7 @@ export default class HeatMap extends React.Component {
                 </div>{/* END .heatmap__td */}
                 <div className="heatmap__td heatmap__datagrid-container">
                   {/* BEGIN Data Grid */}
-                  <table className="heatmap__datagrid">
+                  <table>
                     <tbody>
                       {rowLabels.map((rowLabel, rowIndex) => (
                         <tr className="heatmap__row" key={`${rowLabel}_${rowIndex}`} data-row={rowIndex}>
@@ -112,6 +112,9 @@ export default class HeatMap extends React.Component {
                               data-row={rowIndex}
                               className="heatmap__cell"
                               title={`${data[rowIndex][colIndex]}`}>
+                              <div className="heatmap__cursor"></div>
+                              <div className="heatmap__col-cursor"></div>
+                              <div className="heatmap__row-cursor"></div>
                               <div className="heatmap__color-box" style={{opacity: opacity[rowIndex][colIndex]}}></div>
                             </td>
                           ))}

--- a/demo/src/components/HeatMap.js
+++ b/demo/src/components/HeatMap.js
@@ -149,15 +149,23 @@ export default class HeatMap extends React.Component {
                               className="heatmap__cell"
                               data-col={colIndex}
                               data-row={rowIndex}>
-                              <div className={`heatmap__cursor${rowIndex === activeRow && colIndex === activeCol ? " heatmap__data--active" : ""}`}></div>
-                              <div className={`heatmap__col-cursor${((rowIndex === activeRow && colIndex === activeCol) || (colIndex === activeCol && rowIndex === 0 && activeRow === null)) ? " heatmap__data--active" : ""}`}></div>
-                              <div className={`heatmap__row-cursor${((rowIndex === activeRow && colIndex === activeCol) || (rowIndex === activeRow && colIndex === 0 && activeCol === null)) ? " heatmap__data--active" : ""}`}></div>
+                              {rowIndex === activeRow && colIndex === activeCol ? (
+                                <div className="heatmap__cursor"></div>
+                              ) : null}
+                              {((rowIndex === activeRow && colIndex === activeCol) || (colIndex === activeCol && rowIndex === 0 && activeRow === null)) ? (
+                                <div className="heatmap__col-cursor"></div>
+                              ) : null}
+                              {((rowIndex === activeRow && colIndex === activeCol) || (rowIndex === activeRow && colIndex === 0 && activeCol === null)) ? (
+                                <div className="heatmap__row-cursor"></div>
+                              ) : null}
                               <div className="heatmap__color-box" style={{opacity: opacity[rowIndex][colIndex]}}></div>
                               <div
                                 className="heatmap__trigger"
                                 onMouseOver={() => {this.handleMouseOver(rowIndex, colIndex)}}
                                 onMouseOut={() => {this.handleMouseOut()}}></div>
-                              <div className="heatmap__tooltip">{`${data[rowIndex][colIndex]}`}</div>
+                              {rowIndex === activeRow && colIndex === activeCol ? (
+                                <div className="heatmap__tooltip">{`${data[rowIndex][colIndex]}`}</div>
+                              ) : null}
                             </td>
                           ))}
                         </tr>

--- a/demo/src/css/HeatMap.css
+++ b/demo/src/css/HeatMap.css
@@ -118,11 +118,11 @@ table.heatmap__row-labels {
 table.heatmap__col-labels tr th.heatmap__label {
   padding: 8px 0 0 0;
   background: #fff;
-  border-right: 1px solid #e9e9e9;
+  outline: 1px solid #e9e9e9;
   vertical-align: bottom;
   text-align: left;
-  width: 35px;
-  max-width: 35px;
+  width: 34px;
+  max-width: 34px;
   position: relative;
 }
 
@@ -139,7 +139,7 @@ table.heatmap__col-labels tr th.heatmap__label {
 }
 
 table.heatmap__col-labels tr th.heatmap__label span {
-  transform-origin: 7px -2px;
+  transform-origin: 7px -1px;
   transform: rotate(-90deg) translate(-100%);
   margin-top: -50%;
   white-space: nowrap;
@@ -151,9 +151,9 @@ table.heatmap__col-labels tr th.heatmap__label span {
 tr.heatmap__row th.heatmap__label {
   text-align: right;
   padding: 0 8px 0 10px;
-  border-bottom: 1px solid #e9e9e9;
+  outline: 1px solid #e9e9e9;
   background: #fff;
-  height: 35px;
+  height: 34px;
   position: relative;
 }
 
@@ -167,32 +167,23 @@ td.heatmap__cell {
   background: #fff;
 }
 
-tr.heatmap__row:last-child th.heatmap__label {
-  border-bottom-color: #fff;
-}
-
-table.heatmap__col-labels tr th.heatmap__label:last-child {
-  border-right-color: #fff;
-}
-
 .heatmap__color-box {
   /* width: 41px; TODO(aarons): change cell width when UI is moved to drawer */
-  width: 36px;
-  height: 36px;
+  width: 34px;
+  height: 34px;
   background: #329fff;
 }
 
 .heatmap__trigger {
   position: absolute;
-  width: 36px;
-  height: 36px;
-  margin-top: -36px;
+  width: 34px;
+  height: 34px;
+  margin-top: -34px;
   z-index: 999;
 }
 
 .heatmap__trigger.heatmap__cursor {
   box-shadow: 0 0 43px 2px rgba(44,93,136,0.2);
-  outline: 1px solid rgba(0,0,0,0.1);
 }
 
 /* Crosshairs */
@@ -205,13 +196,13 @@ table.heatmap__col-labels tr th.heatmap__label:last-child {
 }
 
 .heatmap__col-cursor {
-  width: 36px;
+  width: 34px;
   height: 100%;
   top: 0;
 }
 
 .heatmap__row-cursor {
-  height: 36px;
+  height: 34px;
   width: 100%;
   left: 0;
 }
@@ -223,13 +214,11 @@ table.heatmap__row-labels tr th.heatmap__label.heatmap__row-label-cursor {
 }
 
 table.heatmap__col-labels tr th.heatmap__label.heatmap__col-label-cursor {
-  box-shadow: 0.5px 0 0 0.5px #eee,
-              0 0 13px 4px rgba(0,0,0,0.08);
+  box-shadow: 0 0 13px 4px rgba(0,0,0,0.08);
 }
 
 table.heatmap__row-labels tr th.heatmap__label.heatmap__row-label-cursor {
-  box-shadow: 0 0.5px 0 0.5px #eee,
-              0 0 13px 4px rgba(0,0,0,0.08);
+  box-shadow: 0 0 13px 4px rgba(0,0,0,0.08);
 }
 
 .heatmap table th.heatmap__col-label-cursor span,

--- a/demo/src/css/HeatMap.css
+++ b/demo/src/css/HeatMap.css
@@ -197,18 +197,15 @@ table.heatmap__col-labels tr th.heatmap__label:last-child {
   width: 36px;
   height: 36px;
   margin-top: -36px;
-  z-index: 9999;
+  z-index: 999;
 }
 
-/* Crosshairs and tooltips */
-.heatmap__cursor {
-  width: 35px;
-  height: 35px;
-  position: absolute;
-  box-shadow: 0 0 43px 2px rgba(44,93,136,0.2);
-  z-index: 999;
-  outline: 1px solid rgba(255,255,255,.7);
+.heatmap__trigger.heatmap__cursor {
+  box-shadow: -0.5px 0.5px 0 0.5px #fff,
+              0 0 43px 2px rgba(44,93,136,0.2);
 }
+
+/* Crosshairs */
 
 .heatmap__col-cursor,
 .heatmap__row-cursor {
@@ -255,5 +252,59 @@ table.heatmap__row-labels tr th.heatmap__label.heatmap__row-label-cursor {
 
 /* Tooltip */
 .heatmap__tooltip {
-  display: none;
+  margin-top: -30px;
+  margin-left: 46px;
+  z-index: 9;
+  position: absolute;
+  box-shadow: 0 0 30px rgba(0,0,0,.2);
+  border-radius: 6px;
+  background: rgba(70,70,70,.9);
+  padding: 4px 12px 5px 12px;
+  font-size: 14px;
+  color: #fff;
+  font-weight: bold;
+  white-space: nowrap;
+  user-select: none;
+  cursor: default;
+}
+
+.heatmap__tooltip:before {
+  display: block;
+  position: absolute;
+  left: 0;
+  top: 0;
+  margin-top: 12px;
+  margin-left: -6px;
+  content: "";
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 6px 6px 6px 0;
+  border-color: transparent rgba(70,70,70,.9) transparent transparent;
+}
+
+.heatmap__tooltip__meta {
+  font-size: 12px;
+  display: block;
+  font-weight: normal;
+  color: rgba(255,255,255,0.4);
+  padding: 0;
+  margin: 0;
+  line-height: 16px;
+  -webkit-font-smoothing: subpixel-antialiased;
+  -moz-osx-font-smoothing: auto;
+}
+
+.heatmap__tooltip__meta strong {
+  color: rgba(255,255,255,0.66);
+  padding: 0;
+  margin: 0;
+  display: inline-block;
+  min-width: 50px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.heatmap__tooltip__meta + .heatmap__tooltip__meta {
+  padding-bottom: 5px;
 }

--- a/demo/src/css/HeatMap.css
+++ b/demo/src/css/HeatMap.css
@@ -196,14 +196,12 @@ table.heatmap__col-labels tr th.heatmap__label:last-child {
   position: absolute;
   width: 36px;
   height: 36px;
-  /* background: blue; */
   margin-top: -36px;
   z-index: 9999;
 }
 
 /* Crosshairs and tooltips */
 .heatmap__cursor {
-  opacity: 0;
   width: 35px;
   height: 35px;
   position: absolute;
@@ -215,7 +213,6 @@ table.heatmap__col-labels tr th.heatmap__label:last-child {
 .heatmap__col-cursor,
 .heatmap__row-cursor {
   position: absolute;
-  opacity: 0;
   box-shadow: 0 0 13px 2px rgba(44,93,136,0.14);
 }
 
@@ -232,22 +229,6 @@ table.heatmap__col-labels tr th.heatmap__label:last-child {
   left: 0;
   margin-top: -1px;
 }
-
-.heatmap__cursor.heatmap__data--active,
-.heatmap__col-cursor.heatmap__data--active,
-.heatmap__row-cursor.heatmap__data--active {
-  opacity: 1;
-}
-
-/* .heatmap__cursor,
-.heatmap__col-cursor,
-.heatmap__row-cursor {
-  display: none;
-} */
-
-/* td {
-  background: black !important;
-} */
 
 table.heatmap__col-labels tr th.heatmap__label.heatmap__col-label-cursor,
 table.heatmap__row-labels tr th.heatmap__label.heatmap__row-label-cursor {

--- a/demo/src/css/HeatMap.css
+++ b/demo/src/css/HeatMap.css
@@ -77,6 +77,8 @@ Data Grid
 .heatmap__datagrid-container table td {
   width: 34px;
   height: 34px;
+  min-width: 34px;
+  min-height: 34px;
 }
 
 .heatmap__datagrid-container table:before,

--- a/demo/src/css/HeatMap.css
+++ b/demo/src/css/HeatMap.css
@@ -63,6 +63,7 @@ span + .heatmap-container {
 
 .heatmap__datagrid-container table {
   position: relative;
+  height: 100%;
 }
 
 .heatmap__datagrid-container table:after,
@@ -180,4 +181,53 @@ tr.heatmap__row td.heatmap__cell:last-child {
   width: 35px;
   height: 35px;
   background: #329fff;
+}
+
+/* Crosshairs and tooltips */
+.heatmap__cursor {
+  opacity: 0;
+  width: 35px;
+  height: 35px;
+  position: absolute;
+  box-shadow: 0 0 43px 4px rgba(44,93,136,0.19);
+  z-index: 999;
+  outline: 1px solid #fff;
+}
+
+.heatmap__col-cursor,
+.heatmap__row-cursor {
+  position: absolute;
+  opacity: 0;
+  box-shadow: 0 0 13px 4px rgba(44,93,136,0.15);
+}
+
+.heatmap__col-cursor {
+  width: 37px;
+  height: 100%;
+  top: 0;
+  margin-left: -1px;
+}
+
+.heatmap__row-cursor {
+  height: 37px;
+  width: 100%;
+  left: 0;
+  margin-top: -1px;
+}
+
+td.heatmap__cell:hover .heatmap__cursor,
+td.heatmap__cell:hover .heatmap__col-cursor,
+td.heatmap__cell:hover .heatmap__row-cursor {
+  opacity: 1;
+}
+
+.heatmap__col-label-cursor,
+.heatmap__row-label-cursor {
+  opacity: 0.34;
+  box-shadow: 0 0 13px 4px rgba(0,0,0,0.42);
+}
+
+.heatmap table th.heatmap__col-label-cursor span,
+.heatmap table th.heatmap__row-label-cursor span {
+  color: #000;
 }

--- a/demo/src/css/HeatMap.css
+++ b/demo/src/css/HeatMap.css
@@ -1,3 +1,7 @@
+/********************************************
+HeatMap
+********************************************/
+
 .heatmap-container {
   position: relative;
   overflow: hidden;
@@ -39,7 +43,7 @@ span + .heatmap-container {
 
 .heatmap {
   display: inline-block;
-  filter: drop-shadow(0 0 40px rgba(0,0,0,.1));
+  filter: drop-shadow(0 0 40px rgba(0,0,0,0.1)) drop-shadow(0 0 1px rgba(0,0,0,0.1));
   cursor: default;
 }
 
@@ -56,7 +60,9 @@ span + .heatmap-container {
   display: table-cell;
 }
 
-/* Datagrid */
+/********************************************
+Data Grid
+********************************************/
 
 .heatmap__datagrid-container {
   overflow: hidden;
@@ -65,17 +71,22 @@ span + .heatmap-container {
 .heatmap__datagrid-container table {
   position: relative;
   height: 100%;
+  background: #fff;
 }
 
-.heatmap__datagrid-container table:after,
-.heatmap__datagrid-container table:before {
+.heatmap__datagrid-container table td {
+  width: 34px;
+  height: 34px;
+}
+
+.heatmap__datagrid-container table:before,
+.heatmap__datagrid-container table:after {
   display: block;
   content: "";
   top: -30px;
   left: 0;
   width: 100%;
   height: 30px;
-  box-shadow: 0 0 9px rgba(35,64,90,.21);
   z-index: 99;
   position: absolute;
 }
@@ -167,31 +178,21 @@ td.heatmap__cell {
   background: #fff;
 }
 
-.heatmap__color-box {
-  /* width: 41px; TODO(aarons): change cell width when UI is moved to drawer */
-  width: 34px;
-  height: 34px;
-  background: #329fff;
-}
-
 .heatmap__trigger {
   position: absolute;
   width: 34px;
   height: 34px;
-  margin-top: -34px;
+  margin-top: -17px;
   z-index: 999;
 }
 
-.heatmap__trigger.heatmap__cursor {
-  box-shadow: 0 0 43px 2px rgba(44,93,136,0.2);
-}
-
-/* Crosshairs */
+/********************************************
+Crosshairs
+********************************************/
 
 .heatmap__col-cursor,
 .heatmap__row-cursor {
   position: absolute;
-  box-shadow: 0 0 13px 2px rgba(44,93,136,0.14);
   outline: 1px solid rgba(0,0,0,0.033);
 }
 
@@ -205,6 +206,7 @@ td.heatmap__cell {
   height: 34px;
   width: 100%;
   left: 0;
+  margin-top: -17px;
 }
 
 table.heatmap__col-labels tr th.heatmap__label.heatmap__col-label-cursor,
@@ -228,41 +230,56 @@ table.heatmap__row-labels tr th.heatmap__label.heatmap__row-label-cursor {
   -moz-osx-font-smoothing: auto;
 }
 
-/* Tooltip */
-.heatmap__tooltip {
-  margin-top: -30px;
-  margin-left: 46px;
-  z-index: 9;
-  position: absolute;
-  box-shadow: 0 0 30px rgba(0,0,0,.2);
-  border-radius: 6px;
-  background: rgba(70,70,70,.9);
-  padding: 4px 12px 5px 12px;
-  font-size: 14px;
+/********************************************
+Tooltip
+********************************************/
+
+.heatmap-tooltip,
+.heatmap-tooltip * {
+  transition: none !important;
+}
+
+.heatmap-tooltip {
+  box-shadow: 0 0 30px rgba(0,0,0,.2) !important;
+  border-radius: 6px !important;
+  background: rgba(70,70,70,.9) !important;
+  padding: 8px 12px 5px 12px !important;
+  font-size: 14px !important;
+  opacity: 1 !important;
   color: #fff;
   font-weight: bold;
   white-space: nowrap;
   user-select: none;
   cursor: default;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
-.heatmap__tooltip:before {
-  display: block;
-  position: absolute;
-  left: 0;
-  top: 0;
-  margin-top: 12px;
-  margin-left: -6px;
-  content: "";
-  width: 0;
-  height: 0;
-  border-style: solid;
-  border-width: 6px 6px 6px 0;
-  border-color: transparent rgba(70,70,70,.9) transparent transparent;
+.heatmap-tooltip.__react_component_tooltip.type-dark.place-top:after {
+  border-top-color: rgba(70,70,70,.9);
 }
 
-.heatmap__tooltip__meta {
-  font-size: 12px;
+.heatmap-tooltip.__react_component_tooltip.type-dark.place-bottom:after {
+  border-bottom-color: rgba(70,70,70,.9);
+}
+
+.heatmap-tooltip.__react_component_tooltip.type-dark.place-left:after {
+  border-left-color: rgba(70,70,70,.9);
+}
+
+.heatmap-tooltip.__react_component_tooltip.type-dark.place-right {
+  margin-top: 25px;
+  margin-left: 12px;
+}
+
+.heatmap-tooltip.__react_component_tooltip.type-dark.place-right:after {
+  border-right-color: rgba(70,70,70,.9);
+  top: 12px;
+  margin-top: 0;
+}
+
+.heatmap-tooltip__meta {
+  font-size: 12px !important;
   display: block;
   font-weight: normal;
   color: rgba(255,255,255,0.4);
@@ -273,7 +290,11 @@ table.heatmap__row-labels tr th.heatmap__label.heatmap__row-label-cursor {
   -moz-osx-font-smoothing: auto;
 }
 
-.heatmap__tooltip__meta strong {
+.heatmap-tooltip__meta:first-child {
+  margin-top: 5px;
+}
+
+.heatmap-tooltip__meta strong {
   color: rgba(255,255,255,0.66);
   padding: 0;
   margin: 0;
@@ -283,6 +304,58 @@ table.heatmap__row-labels tr th.heatmap__label.heatmap__row-label-cursor {
   -moz-osx-font-smoothing: grayscale;
 }
 
-.heatmap__tooltip__meta + .heatmap__tooltip__meta {
+.heatmap-tooltip__meta + .heatmap-tooltip__meta {
   padding-bottom: 5px;
+}
+
+/********************************************
+Colors
+********************************************/
+
+/* Red */
+
+.heatmap__datagrid-container.heatmap__datagrid-container--red table:before,
+.heatmap__datagrid-container.heatmap__datagrid-container--red table:after {
+  box-shadow: 0 0 9px rgba(150,20,20,.21);
+}
+
+.heatmap__datagrid-container.heatmap__datagrid-container--red .heatmap__trigger.heatmap__cursor {
+  box-shadow: 0 0 43px 2px rgba(180,42,42,0.2);
+}
+
+.heatmap__datagrid-container.heatmap__datagrid-container--red .heatmap__col-cursor,
+.heatmap__datagrid-container.heatmap__datagrid-container--red .heatmap__row-cursor {
+  box-shadow: 0 0 13px 2px rgba(180,42,42,0.14);
+}
+
+/* Green */
+
+.heatmap__datagrid-container.heatmap__datagrid-container--green table:before,
+.heatmap__datagrid-container.heatmap__datagrid-container--green table:after {
+  box-shadow: 0 0 9px rgba(37,76,20,.21);
+}
+
+.heatmap__datagrid-container.heatmap__datagrid-container--green .heatmap__trigger.heatmap__cursor {
+  box-shadow: 0 0 43px 2px rgba(53,108,28,0.2);
+}
+
+.heatmap__datagrid-container.heatmap__datagrid-container--green .heatmap__col-cursor,
+.heatmap__datagrid-container.heatmap__datagrid-container--green .heatmap__row-cursor {
+  box-shadow: 0 0 13px 2px rgba(53,108,28,0.14);
+}
+
+/* Blue */
+
+.heatmap__datagrid-container.heatmap__datagrid-container--blue table:before,
+.heatmap__datagrid-container.heatmap__datagrid-container--blue table:after {
+  box-shadow: 0 0 9px rgba(35,64,90,.21);
+}
+
+.heatmap__datagrid-container.heatmap__datagrid-container--blue .heatmap__trigger.heatmap__cursor {
+  box-shadow: 0 0 43px 2px rgba(44,93,136,0.2);
+}
+
+.heatmap__datagrid-container.heatmap__datagrid-container--blue .heatmap__col-cursor,
+.heatmap__datagrid-container.heatmap__datagrid-container--blue .heatmap__row-cursor {
+  box-shadow: 0 0 13px 2px rgba(44,93,136,0.14);
 }

--- a/demo/src/css/HeatMap.css
+++ b/demo/src/css/HeatMap.css
@@ -157,38 +157,28 @@ tr.heatmap__row th.heatmap__label {
   position: relative;
 }
 
-
-
 tr.heatmap__row th.heatmap__label span {
   margin-bottom: 1px;
   padding: 4px 0;
 }
 
 td.heatmap__cell {
-  padding: 0 1px 1px 0;
+  padding: 0;
   background: #fff;
 }
 
-tr.heatmap__row:last-child td.heatmap__cell {
-  padding-bottom: 0;
-}
-
 tr.heatmap__row:last-child th.heatmap__label {
-  border-bottom-width: 0;
-}
-
-tr.heatmap__row td.heatmap__cell:last-child {
-  padding-right: 0;
+  border-bottom-color: #fff;
 }
 
 table.heatmap__col-labels tr th.heatmap__label:last-child {
-  border-right-width: 0;
+  border-right-color: #fff;
 }
 
 .heatmap__color-box {
   /* width: 41px; TODO(aarons): change cell width when UI is moved to drawer */
-  width: 35px;
-  height: 35px;
+  width: 36px;
+  height: 36px;
   background: #329fff;
 }
 
@@ -201,8 +191,8 @@ table.heatmap__col-labels tr th.heatmap__label:last-child {
 }
 
 .heatmap__trigger.heatmap__cursor {
-  box-shadow: -0.5px 0.5px 0 0.5px #fff,
-              0 0 43px 2px rgba(44,93,136,0.2);
+  box-shadow: 0 0 43px 2px rgba(44,93,136,0.2);
+  outline: 1px solid rgba(0,0,0,0.1);
 }
 
 /* Crosshairs */
@@ -211,20 +201,19 @@ table.heatmap__col-labels tr th.heatmap__label:last-child {
 .heatmap__row-cursor {
   position: absolute;
   box-shadow: 0 0 13px 2px rgba(44,93,136,0.14);
+  outline: 1px solid rgba(0,0,0,0.033);
 }
 
 .heatmap__col-cursor {
-  width: 37px;
+  width: 36px;
   height: 100%;
   top: 0;
-  margin-left: -1px;
 }
 
 .heatmap__row-cursor {
-  height: 37px;
+  height: 36px;
   width: 100%;
   left: 0;
-  margin-top: -1px;
 }
 
 table.heatmap__col-labels tr th.heatmap__label.heatmap__col-label-cursor,
@@ -234,12 +223,12 @@ table.heatmap__row-labels tr th.heatmap__label.heatmap__row-label-cursor {
 }
 
 table.heatmap__col-labels tr th.heatmap__label.heatmap__col-label-cursor {
-  box-shadow: 0.5px 0 0 0.5px #fff,
+  box-shadow: 0.5px 0 0 0.5px #eee,
               0 0 13px 4px rgba(0,0,0,0.08);
 }
 
 table.heatmap__row-labels tr th.heatmap__label.heatmap__row-label-cursor {
-  box-shadow: 0 0.5px 0 0.5px #fff,
+  box-shadow: 0 0.5px 0 0.5px #eee,
               0 0 13px 4px rgba(0,0,0,0.08);
 }
 

--- a/demo/src/css/HeatMap.css
+++ b/demo/src/css/HeatMap.css
@@ -40,6 +40,7 @@ span + .heatmap-container {
 .heatmap {
   display: inline-block;
   filter: drop-shadow(0 0 40px rgba(0,0,0,.1));
+  cursor: default;
 }
 
 .heatmap__ft {
@@ -104,13 +105,14 @@ span + .heatmap-container {
 .heatmap table th span {
   font-size: 16px;
   line-height: 20px;
-  color: #606060;
+  color: #777;
   white-space: nowrap;
   display: block;
 }
 
-table.heatmap__col-labels tr {
-
+table.heatmap__col-labels,
+table.heatmap__row-labels {
+  overflow: hidden;
 }
 
 table.heatmap__col-labels tr th.heatmap__label {
@@ -121,6 +123,7 @@ table.heatmap__col-labels tr th.heatmap__label {
   text-align: left;
   width: 35px;
   max-width: 35px;
+  position: relative;
 }
 
 .heatmap__label__outer {
@@ -151,7 +154,10 @@ tr.heatmap__row th.heatmap__label {
   border-bottom: 1px solid #e9e9e9;
   background: #fff;
   height: 35px;
+  position: relative;
 }
+
+
 
 tr.heatmap__row th.heatmap__label span {
   margin-bottom: 1px;
@@ -159,20 +165,23 @@ tr.heatmap__row th.heatmap__label span {
 }
 
 td.heatmap__cell {
-  padding: 0;
-  border: 1px solid #fff;
-  border-left-width: 0;
-  border-top-width: 0;
+  padding: 0 1px 1px 0;
   background: #fff;
 }
 
-tr.heatmap__row:last-child th.heatmap__label,
 tr.heatmap__row:last-child td.heatmap__cell {
+  padding-bottom: 0;
+}
+
+tr.heatmap__row:last-child th.heatmap__label {
   border-bottom-width: 0;
 }
 
-table.heatmap__col-labels tr th.heatmap__label:last-child,
 tr.heatmap__row td.heatmap__cell:last-child {
+  padding-right: 0;
+}
+
+table.heatmap__col-labels tr th.heatmap__label:last-child {
   border-right-width: 0;
 }
 
@@ -183,22 +192,31 @@ tr.heatmap__row td.heatmap__cell:last-child {
   background: #329fff;
 }
 
+.heatmap__trigger {
+  position: absolute;
+  width: 36px;
+  height: 36px;
+  /* background: blue; */
+  margin-top: -36px;
+  z-index: 9999;
+}
+
 /* Crosshairs and tooltips */
 .heatmap__cursor {
   opacity: 0;
   width: 35px;
   height: 35px;
   position: absolute;
-  box-shadow: 0 0 43px 4px rgba(44,93,136,0.19);
+  box-shadow: 0 0 43px 2px rgba(44,93,136,0.2);
   z-index: 999;
-  outline: 1px solid #fff;
+  outline: 1px solid rgba(255,255,255,.7);
 }
 
 .heatmap__col-cursor,
 .heatmap__row-cursor {
   position: absolute;
   opacity: 0;
-  box-shadow: 0 0 13px 4px rgba(44,93,136,0.15);
+  box-shadow: 0 0 13px 2px rgba(44,93,136,0.14);
 }
 
 .heatmap__col-cursor {
@@ -215,19 +233,46 @@ tr.heatmap__row td.heatmap__cell:last-child {
   margin-top: -1px;
 }
 
-td.heatmap__cell:hover .heatmap__cursor,
-td.heatmap__cell:hover .heatmap__col-cursor,
-td.heatmap__cell:hover .heatmap__row-cursor {
+.heatmap__cursor.heatmap__data--active,
+.heatmap__col-cursor.heatmap__data--active,
+.heatmap__row-cursor.heatmap__data--active {
   opacity: 1;
 }
 
-.heatmap__col-label-cursor,
-.heatmap__row-label-cursor {
-  opacity: 0.34;
-  box-shadow: 0 0 13px 4px rgba(0,0,0,0.42);
+/* .heatmap__cursor,
+.heatmap__col-cursor,
+.heatmap__row-cursor {
+  display: none;
+} */
+
+/* td {
+  background: black !important;
+} */
+
+table.heatmap__col-labels tr th.heatmap__label.heatmap__col-label-cursor,
+table.heatmap__row-labels tr th.heatmap__label.heatmap__row-label-cursor {
+  z-index: 999;
+  border-color: #fff;
+}
+
+table.heatmap__col-labels tr th.heatmap__label.heatmap__col-label-cursor {
+  box-shadow: 0.5px 0 0 0.5px #fff,
+              0 0 13px 4px rgba(0,0,0,0.08);
+}
+
+table.heatmap__row-labels tr th.heatmap__label.heatmap__row-label-cursor {
+  box-shadow: 0 0.5px 0 0.5px #fff,
+              0 0 13px 4px rgba(0,0,0,0.08);
 }
 
 .heatmap table th.heatmap__col-label-cursor span,
 .heatmap table th.heatmap__row-label-cursor span {
   color: #000;
+  -webkit-font-smoothing: subpixel-antialiased;
+  -moz-osx-font-smoothing: auto;
+}
+
+/* Tooltip */
+.heatmap__tooltip {
+  display: none;
 }


### PR DESCRIPTION
![heatmap](https://user-images.githubusercontent.com/8367927/46718993-c7a0ee80-cc21-11e8-8969-1c98a8d3a1e3.gif)

---

**This PR:**
- Fixes [Show crosshairs when hovering HeatMap (#96)](https://github.com/allenai/allennlp-demo/issues/96)
- Fixes [Add custom tooltip for displaying HeatMap cell values (#97)](https://github.com/allenai/allennlp-demo/issues/97)
- Introduces a new 3rd-party component, [`react-tooltip`](https://www.npmjs.com/package/react-tooltip) (was necessary to solve container overflow and window edge masking issues)
- Adds row and column metadata to cell value tooltip
- Removes grid lines
- Changes how opacity is applied (now as an alpha on an RGB background color value)
- Compacts data grid padding by a couple of pixels
- Adds rudimentary support for additional heatmap colors