### PR TITLE
Don't cache models in demo Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This Dockerfile is used to serve the AllenNLP demo.
 
-FROM allennlp/commit:2a8bd63829ed6e84ecd011e9dd8d134db41d93dd
+FROM allennlp/commit:v0.7.2
 LABEL maintainer="allennlp-contact@allenai.org"
 
 WORKDIR /stage/allennlp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This Dockerfile is used to serve the AllenNLP demo.
 
-FROM allennlp/commit:v0.7.2
+FROM allennlp/allennlp:v0.7.2
 LABEL maintainer="allennlp-contact@allenai.org"
 
 WORKDIR /stage/allennlp
@@ -22,7 +22,6 @@ RUN spacy download en_core_web_sm
 # Cache models early, they're huge
 COPY scripts/ scripts/
 COPY server/models.py server/models.py
-RUN ./scripts/cache_models.py
 
 # Now install and build the demo
 COPY demo/ demo/


### PR DESCRIPTION
Our images are getting huge (6 GB).  This removes most of the data in our images and allows users to use their local cache (by mounting in the appropriate directory) when running the demo locally.