### PR TITLE
add quarel demo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This Dockerfile is used to serve the AllenNLP demo.
 
-FROM allennlp/allennlp:v0.7.2
+FROM allennlp/allennlp:v0.8.0
 LABEL maintainer="allennlp-contact@allenai.org"
 
 WORKDIR /stage/allennlp
@@ -19,7 +19,6 @@ RUN pip install psycopg2-binary
 # Download spacy model
 RUN spacy download en_core_web_sm
 
-# Cache models early, they're huge
 COPY scripts/ scripts/
 COPY server/models.py server/models.py
 

--- a/app.py
+++ b/app.py
@@ -236,6 +236,10 @@ def make_app(build_dir: str = None, demo_db: Optional[DemoDatabase] = None) -> F
         elif model_name == "wikitables-parser":
              log_blob['outputs']['logical_form'] = prediction['logical_form']
              log_blob['outputs']['answer'] = prediction['answer']
+        elif model_name == "quarel-parser-zero":
+             log_blob['outputs']['logical_form'] = prediction['logical_form']
+             log_blob['outputs']['answer'] = prediction['answer']
+             log_blob['outputs']['score'] = prediction['score']
         elif model_name == "atis-parser":
             log_blob['outputs']['predicted_sql_query'] = prediction['predicted_sql_query']
         # TODO(brendanr): Add event2mind log_blob here?
@@ -272,6 +276,7 @@ def make_app(build_dir: str = None, demo_db: Optional[DemoDatabase] = None) -> F
     @app.route('/named-entity-recognition')
     @app.route('/fine-grained-named-entity-recognition')
     @app.route('/wikitables-parser')
+    @app.route('/quarel-parser-zero')
     @app.route('/event2mind')
     @app.route('/open-information-extraction/<permalink>')
     @app.route('/atis-parser')
@@ -284,6 +289,7 @@ def make_app(build_dir: str = None, demo_db: Optional[DemoDatabase] = None) -> F
     @app.route('/named-entity-recognition/<permalink>')
     @app.route('/event2mind/<permalink>')
     @app.route('/wikitables-parser/<permalink>')
+    @app.route('/quarel-parser-zero/<permalink>')
     @app.route('/atis-parser/<permalink>')
     def return_page(permalink: str = None) -> Response:  # pylint: disable=unused-argument, unused-variable
         """return the page"""

--- a/demo/src/components/demos/QuarelZero.js
+++ b/demo/src/components/demos/QuarelZero.js
@@ -111,6 +111,18 @@ const qrspecDefault = "[friction, -speed, -smoothness, -distance, +heat]\n[speed
 
 const entitycuesDefault = "friction: resistance, traction\nspeed: velocity, pace, fast, slow, faster, slower, slowly, quickly, rapidly\ndistance: length, way, far, near, further, longer, shorter, long, short, farther, furthest\nheat: temperature, warmth, smoke, hot, hotter, cold, colder\nsmoothness: slickness, roughness, rough, smooth, rougher, smoother, bumpy, slicker\nacceleration: \namountSweat: sweat, sweaty\napparentSize: size, large, small, larger, smaller\nbreakability: brittleness, brittle, break, solid\nbrightness: bright, shiny, faint\nexerciseIntensity: excercise, run, walk\nflexibility: flexible, stiff, rigid\ngravity: \nloudness: loud, faint, louder, fainter\nmass: weight, heavy, light, heavier, lighter, massive\nstrength: power, strong, weak, stronger, weaker\nthickness: thick, thin, thicker, thinner, skinny\ntime: long, short\nweight: mass, heavy, light, heavier, lighter"
 
+const appendDefault = (example, fieldName, defaults) => {
+    if (example[fieldName] && example[fieldName].slice(-1) == '*') {
+        // Ends with *, so don't append anything and get rid of the '*'
+        example[fieldName] = example[fieldName].slice(0, -1)
+    } else if (example[fieldName]) {
+        example[fieldName] += "\n" + defaults
+    } else {
+        example[fieldName] = defaults
+    }
+}
+
+
 const examples = [
     {
       question: "Bill eats way more sweets than Sue. Based on this, who has more diabetes risk? (A) Sue (B) Bill",
@@ -161,14 +173,12 @@ const examples = [
     {
       question: "Jose pushed his burrito cart on the bumpy sidewalk and went slow, while much faster on the street because it had (A) more resistance (B) less resistance"
     }
-].map(example => {
-    if (!example.qrspec) {
-        example.qrspec = qrspecDefault
-    }
-    if (!example.entitycues) {
-        example.entitycues = entitycuesDefault
-    }
-    return example
+]
+
+// Add default
+examples.forEach(example => {
+    appendDefault(example, 'qrspec', qrspecDefault)
+    appendDefault(example, 'entitycues', entitycuesDefault)
 })
 
 const apiUrl = () => `${API_ROOT}/predict/quarel-parser-zero`

--- a/demo/src/components/demos/QuarelZero.js
+++ b/demo/src/components/demos/QuarelZero.js
@@ -1,0 +1,179 @@
+import React from 'react';
+import HeatMap from '../HeatMap'
+import Collapsible from 'react-collapsible'
+import { withRouter } from 'react-router-dom';
+import Model from '../Model'
+import OutputField from '../OutputField'
+import { API_ROOT } from '../../api-config';
+
+const title = "Qualitative Relations Story Question Answering"
+
+const description = (
+<span>
+  Answer story questions about qualitative relations (QuaRel dataset) while adding new relations
+  without retraining. This uses the QuaSP+Zero semantic parser described in <i>QuaRel: A Dataset and Models for
+  Answering Questions about Qualitative Relationships</i> (in submission). The first few examples use
+  new relations, the rest are from the validation set.
+  </span>
+)
+
+const fields = [
+    {name: "question", label: "Question", type: "TEXT_AREA",
+     placeholder: `E.g. "A hockey puck slides a lot longer on a frozen lake then on a slushy lake. This means the surface of the _____ is smoother (A) frozen lake (B) slushy lake"`},
+     {name: "qrspec", label: "Qualitative Relations", type: "TEXT_AREA", optional: true,
+     placeholder: `[friction, -speed, +heat]\n[weight, acceleration]`},
+     {name: "entitycues", label: "Attribute Cues", type: "TEXT_AREA", optional: true,
+     placeholder: `friction: resistance\nspeed: velocity, fast, slow`}
+]
+
+const ActionInfo = ({ action, question_tokens }) => {
+    const question_attention = action['question_attention'].map(x => [x])
+    const considered_actions = action['considered_actions']
+    const action_probs = action['action_probabilities'].map(x => [x])
+
+    const probability_heatmap = (
+        <div className="heatmap">
+           <HeatMap colLabels={['Prob']} rowLabels={considered_actions} data={action_probs} xLabelWidth={250} />
+        </div>
+    )
+
+    const question_attention_heatmap = question_attention.length > 0 ? (
+        <div className="heatmap">
+          <HeatMap colLabels={['Prob']} rowLabels={question_tokens} data={question_attention} xLabelWidth={70} />
+          </div>
+      ) : null
+
+      return (
+        <div>
+            {probability_heatmap}
+            {question_attention_heatmap}
+        </div>
+      )
+}
+
+const Explanation = ({entry}) => {
+    const listItems = entry.content.map((c) => (<li className="model__explanation__ul">{c}</li>))
+
+    return (
+        <div>
+            <div className="model__explanation__header">
+                {entry.header}:
+            </div>
+            <ul className="model__explanation__ul">
+                {listItems}
+            </ul>
+        </div>
+    )
+}
+
+const Output = ({ responseData }) => {
+    const { answer, logical_form, score, predicted_actions, question_tokens, world_extractions, explanation } = responseData
+
+    const explanations = explanation.map(entry => <Explanation entry={entry}/>)
+
+    return (
+        <div className="model__content">
+            <OutputField label="Answer">
+                {answer}
+            </OutputField>
+
+            <OutputField label="Explanation">
+                {explanations}
+            </OutputField>
+
+            <OutputField>
+                <Collapsible trigger="Model internals">
+                    <OutputField label="Logical Form">
+                    {logical_form}
+                    </OutputField>
+                    <OutputField label="Score">
+                    {score}
+                    </OutputField>
+                    <OutputField label="Extracted world entities">
+                        world1: {world_extractions.world1} world2: {world_extractions.world2}
+                    </OutputField>
+
+                    <Collapsible trigger="Predicted actions">
+                        {predicted_actions.map((action, action_index) => (
+                            <Collapsible key={"action_" + action_index} trigger={action['predicted_action']}>
+                                <ActionInfo action={action} question_tokens={question_tokens}/>
+                            </Collapsible>
+                        ))}
+                    </Collapsible>
+                </Collapsible>
+            </OutputField>
+        </div>
+    )
+}
+
+
+const qrspecDefault = "[friction, -speed, -smoothness, -distance, +heat]\n[speed, -time]\n[speed, +distance]\n[time, +distance]\n[weight, -acceleration]\n[strength, +distance]\n[strength, +thickness]\n[mass, +gravity]\n[flexibility, -breakability]\n[distance, -loudness, -brightness, -apparentSize]\n[exerciseIntensity, +amountSweat]"
+
+const entitycuesDefault = "friction: resistance, traction\nspeed: velocity, pace, fast, slow, faster, slower, slowly, quickly, rapidly\ndistance: length, way, far, near, further, longer, shorter, long, short, farther, furthest\nheat: temperature, warmth, smoke, hot, hotter, cold, colder\nsmoothness: slickness, roughness, rough, smooth, rougher, smoother, bumpy, slicker\nacceleration: \namountSweat: sweat, sweaty\napparentSize: size, large, small, larger, smaller\nbreakability: brittleness, brittle, break, solid\nbrightness: bright, shiny, faint\nexerciseIntensity: excercise, run, walk\nflexibility: flexible, stiff, rigid\ngravity: \nloudness: loud, faint, louder, fainter\nmass: weight, heavy, light, heavier, lighter, massive\nstrength: power, strong, weak, stronger, weaker\nthickness: thick, thin, thicker, thinner, skinny\ntime: long, short\nweight: mass, heavy, light, heavier, lighter"
+
+const examples = [
+    {
+      question: "Bill eats way more sweets than Sue. Based on this, who has more diabetes risk? (A) Sue (B) Bill",
+      qrspec: "[sugar, +diabetes]",
+      entitycues: "sugar: sweets"
+    },
+    {
+      question: "In his research, Joe is finding there is a lot more diabetes in the city than out in the countryside. He hypothesizes this is because people in _____ consume less sugar. (A) city (B) countryside",
+      qrspec: "[sugar, +diabetes]"
+    },
+    {
+      question: "There are way fewer trucks driving through Bob's city than Sue's city. Where would one expect air quality to be higher? (A) Bob's city (B) Sue's city",
+      qrspec: "[pollution, +vehicles, -air quality]",
+      entitycues: "vehicles: cars, trucks"
+    },
+    {
+      question: "There are way fewer trucks driving through Bob's city than Sue's city. Where would one expect air quality to be higher? (A) Bob's city (B) Sue's city",
+      qrspec: "[pollution, +vehicles, -air quality]*",
+      entitycues: "vehicles: cars, trucks*"
+    },
+    {
+      question: "Mary has always been weaker then Jimbo. Which person is able to throw a ball farther? (A) Jimbo (B) Mary"
+    },
+    {
+      question: "An empty pot generates less heat when Mary slides it the wood counter than it does when she slides it across a dish towel. This is because the _____ has less resistance. (A) towel (B) wood counter"
+    },
+    {
+      question: "A hockey puck slides a lot longer on a frozen lake then on a slushy lake. This means the surface of the _____ is smoother (A) frozen lake (B) slushy lake"
+    },
+    {
+      question: "The sun has much more mass than the earth so it has (A) weaker gravity (B) stronger gravity"
+    },
+    {
+      question: "Annabel and Lydia are riding their tricycles. Lydia is not as fast as Annabel is. Which one goes a shorter distance? (A) Annabel (B) Lydia"
+    },
+    {
+      question: "The fastest land animal on earth, a cheetah was having a 100m race against a rabbit. Which one one the race? (A) the cheetah (B) the rabbit"
+    },
+    {
+      question: "Jim was playing with his new ball. He rolled it on the carpet in his living room and it didn't go very far. He decided to go outside and play. Jim rolled his ball on the concrete driveway and it went a much longer distance. He realized there was more resistance to the ball on (A) the carpet (B) the concrete."
+    },
+    {
+      question: "If Mona is doing pushups and Milo is reading a book, which person is sweating less? (A) Mona (B) Milo"
+    },
+    {
+      question: "James has rigorous fencing lessons in the morning, and in the evening goes to see a film at the cinema with his girlfriend. Where is he less likely to be sweaty? (A) While fencing (B) While watching a movie"
+    },
+    {
+      question: "Jose pushed his burrito cart on the bumpy sidewalk and went slow, while much faster on the street because it had (A) more resistance (B) less resistance"
+    }
+].map(example => {
+    if (!example.qrspec) {
+        example.qrspec = qrspecDefault
+    }
+    if (!example.entitycues) {
+        example.entitycues = entitycuesDefault
+    }
+    return example
+})
+
+const apiUrl = () => `${API_ROOT}/predict/quarel-parser-zero`
+
+const modelProps = {apiUrl, title, description, fields, examples, Output}
+
+export default withRouter(props => <Model {...props} {...modelProps}/>)
+

--- a/demo/src/components/demos/QuarelZero.js
+++ b/demo/src/components/demos/QuarelZero.js
@@ -10,9 +10,15 @@ const title = "Qualitative Relations Story Question Answering"
 
 const description = (
 <span>
-  Answer story questions about qualitative relations (QuaRel dataset) while adding new relations
-  without retraining. This uses the QuaSP+Zero semantic parser described in <i>QuaRel: A Dataset and Models for
-  Answering Questions about Qualitative Relationships</i> (in submission). The first few examples use
+  Answer story questions about qualitative relations
+  (<a href = "http://data.allenai.org/quarel/" target="_blank" rel="noopener noreferrer">QuaRel dataset</a>)
+  while adding new relations
+  without retraining. This uses the QuaSP+Zero semantic parser described in
+  {' '}
+  <i>QuaRel: A Dataset and Models for
+  Answering Questions about Qualitative Relationships</i>{' '}
+  (<a href = "https://arxiv.org/abs/1811.08048" target="_blank" rel="noopener noreferrer">AAAI 2019</a>).
+  The first few examples use
   new relations, the rest are from the validation set.
   </span>
 )
@@ -112,7 +118,7 @@ const qrspecDefault = "[friction, -speed, -smoothness, -distance, +heat]\n[speed
 const entitycuesDefault = "friction: resistance, traction\nspeed: velocity, pace, fast, slow, faster, slower, slowly, quickly, rapidly\ndistance: length, way, far, near, further, longer, shorter, long, short, farther, furthest\nheat: temperature, warmth, smoke, hot, hotter, cold, colder\nsmoothness: slickness, roughness, rough, smooth, rougher, smoother, bumpy, slicker\nacceleration: \namountSweat: sweat, sweaty\napparentSize: size, large, small, larger, smaller\nbreakability: brittleness, brittle, break, solid\nbrightness: bright, shiny, faint\nexerciseIntensity: excercise, run, walk\nflexibility: flexible, stiff, rigid\ngravity: \nloudness: loud, faint, louder, fainter\nmass: weight, heavy, light, heavier, lighter, massive\nstrength: power, strong, weak, stronger, weaker\nthickness: thick, thin, thicker, thinner, skinny\ntime: long, short\nweight: mass, heavy, light, heavier, lighter"
 
 const appendDefault = (example, fieldName, defaults) => {
-    if (example[fieldName] && example[fieldName].slice(-1) == '*') {
+    if (example[fieldName] && example[fieldName].slice(-1) === '*') {
         // Ends with *, so don't append anything and get rid of the '*'
         example[fieldName] = example[fieldName].slice(0, -1)
     } else if (example[fieldName]) {
@@ -175,7 +181,7 @@ const examples = [
     }
 ]
 
-// Add default
+// Add defaults
 examples.forEach(example => {
     appendDefault(example, 'qrspec', qrspecDefault)
     appendDefault(example, 'entitycues', entitycuesDefault)

--- a/demo/src/css/model.css
+++ b/demo/src/css/model.css
@@ -45,6 +45,17 @@
   background: #f6f8fa;
 }
 
+.model__explanation__header {
+    font-size: 1em;
+    font-weight: bold;
+    margin-top: 0.5em;
+}
+
+.model__explanation__ul {
+    font-size: 1em;
+    margin: 0;
+}
+
 @media screen and (min-height:800px) {
   .model__content {
     padding-top: 4.6vh;

--- a/demo/src/models.js
+++ b/demo/src/models.js
@@ -9,6 +9,7 @@ import ConstituencyParser from './components/demos/ConstituencyParser';
 import DependencyParser from './components/demos/DependencyParser';
 import WikiTables from './components/demos/WikiTables';
 import Atis from './components/demos/Atis';
+import QuarelZero from './components/demos/QuarelZero'
 
 // This is the order in which they will appear in the menu
 const models = [
@@ -23,6 +24,7 @@ const models = [
     {model: "wikitables-parser", name: "WikiTableQuestions Semantic Parser", component: WikiTables},
     {model: "event2mind", name: "Event2Mind", component: Event2Mind},
     {model: "atis-parser", name: "Text to SQL (ATIS)", component: Atis},
+    {model: "quarel-parser-zero", name: "QuaRel Zero", component: QuarelZero},
     {model: "user-models", name: "Your model here!"}
 ]
 

--- a/server/models.py
+++ b/server/models.py
@@ -46,10 +46,10 @@ MODELS = {
                 'https://s3-us-west-2.amazonaws.com/allennlp/models/ner-model-2018.12.18.tar.gz',  # pylint: disable=line-too-long
                 'sentence-tagger'
         ),
-        #'fine-grained-named-entity-recognition': DemoModel(
-        #    'https://s3-us-west-2.amazonaws.com/allennlp/models/fine-grained-ner-model-elmo-2018.08.31.tar.gz',  # pylint: disable=line-too-long
-        #        'sentence-tagger'
-        #),
+        'fine-grained-named-entity-recognition': DemoModel(
+           'https://s3-us-west-2.amazonaws.com/allennlp/models/fine-grained-ner-model-elmo-2018.12.21.tar.gz',  # pylint: disable=line-too-long
+               'sentence-tagger'
+        ),
         'constituency-parsing': DemoModel(
                 'https://s3-us-west-2.amazonaws.com/allennlp/models/elmo-constituency-parser-2018.03.14.tar.gz',  # pylint: disable=line-too-long
                 'constituency-parser'

--- a/server/models.py
+++ b/server/models.py
@@ -43,13 +43,13 @@ MODELS = {
                 'coreference-resolution'
         ),
         'named-entity-recognition': DemoModel(
-                'https://s3-us-west-2.amazonaws.com/allennlp/models/ner-model-2018.04.30.tar.gz',  # pylint: disable=line-too-long
+                'https://s3-us-west-2.amazonaws.com/allennlp/models/ner-model-2018.12.18.tar.gz',  # pylint: disable=line-too-long
                 'sentence-tagger'
         ),
-        'fine-grained-named-entity-recognition': DemoModel(
-            'https://s3-us-west-2.amazonaws.com/allennlp/models/fine-grained-ner-model-elmo-2018.08.31.tar.gz',  # pylint: disable=line-too-long
-                'sentence-tagger'
-        ),
+        #'fine-grained-named-entity-recognition': DemoModel(
+        #    'https://s3-us-west-2.amazonaws.com/allennlp/models/fine-grained-ner-model-elmo-2018.08.31.tar.gz',  # pylint: disable=line-too-long
+        #        'sentence-tagger'
+        #),
         'constituency-parsing': DemoModel(
                 'https://s3-us-west-2.amazonaws.com/allennlp/models/elmo-constituency-parser-2018.03.14.tar.gz',  # pylint: disable=line-too-long
                 'constituency-parser'
@@ -70,4 +70,9 @@ MODELS = {
             'https://s3-us-west-2.amazonaws.com/allennlp/models/atis-parser-2018.11.10.tar.gz',  # pylint: disable=line-too-long
                  'atis-parser'
         ),
+        'quarel-parser-zero': DemoModel(
+            'https://s3-us-west-2.amazonaws.com/allennlp/models/quarel-parser-zero-2018.12.20.tar.gz',  # pylint: disable=line-too-long
+                 'quarel-parser'
+
+        )
 }


### PR DESCRIPTION
for the most part this is a straight port of Oyvind's existing demo into the new refactored world.

there was an `appendDefault` piece in the original that I didn't entirely understand, but I think it was trying to be more general and that the correponding behavior here is correct.

also, the trained quarel model referenced a trained tagger model that used a deprecated parameter, so I had to update the tagger mode and then the quarel model. this code reflects that too.

-- 

there is a section at the end where the fine-grained NER model is commented out, it needs to be similarly updated, but downloading and uploading these models is a pain on home network, so I'll fix that tomorrow, and I won't merge until that's done. in the meantime, that has nothing to do with the quarel demo itself, so that can still be reviewed.