### PR TITLE
Configure sentry behind an environment variable.

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,9 +28,6 @@ from server.permalinks import int_to_slug, slug_to_int
 from server.db import DemoDatabase, PostgresDemoDatabase
 from server.models import MODELS, DemoModel
 
-import sentry_sdk
-sentry_sdk.init("https://05ec91fa0b22430e8bad2cb2a978b622@sentry.io/1389489")
-
 # Can override cache size with an environment variable. If it's 0 then disable caching altogether.
 CACHE_SIZE = os.environ.get("FLASK_CACHE_SIZE") or 128
 PORT = os.environ.get("ALLENNLP_DEMO_PORT") or 8000
@@ -39,6 +36,11 @@ DEMO_DIR = os.environ.get("ALLENNLP_DEMO_DIRECTORY") or 'demo/'
 logging.basicConfig(level=logging.INFO)
 logging.getLogger("allennlp").setLevel(logging.WARN)
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+if "SENTRY_PYTHON_AUTH" in os.environ:
+    logger.info("Enabling Sentry since SENTRY_PYTHON_AUTH is defined.")
+    import sentry_sdk
+    sentry_sdk.init(os.environ.get("SENTRY_PYTHON_AUTH"))
 
 class ServerError(Exception):
     status_code = 400


### PR DESCRIPTION
Our Javascript key needs to be public but our Python key does not.  I thought we could filter by domain for messages from Python--but it turns out that setting only works for the Javascript error capturing.  This change allows us to specify the key in production, but not in our other environments.