### PR TITLE
Log the request earlier so exceptions can be troubleshooted

### DIFF
--- a/app.py
+++ b/app.py
@@ -177,6 +177,7 @@ def make_app(build_dir: str = None, demo_db: Optional[DemoDatabase] = None) -> F
             raise ServerError("unknown model: {}".format(model_name), status_code=400)
 
         data = request.get_json()
+        logger.info("request: %s", json.dumps({"model": model_name, "inputs": data}))
 
         log_blob = {"model": model_name, "inputs": data, "cached": False, "outputs": {}}
 

--- a/server/db.py
+++ b/server/db.py
@@ -177,7 +177,7 @@ class PostgresDemoDatabase(DemoDatabase):
         try:
             self._health_check()
             with self.conn.cursor() as curs:
-                logger.info("updating the database")
+                logger.info("updating the database for perma_id %s", perma_id)
 
                 curs.execute(UPDATE_SQL,
                              {'id'           : perma_id,


### PR DESCRIPTION
Presently if there's an exception when running the demo it's not possible to see the request information unless the demo is set to log to a database.  But even in that case, it requires connecting to the database and running SQL queries to determine what the input was.

I noticed this when looking at errors in Sentry.  It wasn't easy to find the input that caused the failure.  Similarly it wouldn't be possible to find out what input caused exceptions from the logs alone.

We now log some of the requestor information twice.  We could strip it out from the second log command, but it seems better for now to have all the data together in the final log statement.