### PR TITLE
Switch commit reference from requirements.txt to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This Dockerfile is used to serve the AllenNLP demo.
 
-FROM allennlp/allennlp:v0.8.0
+FROM allennlp/commit:31af01e0db7ac401b6c4923d5badd7de2691d6a2
 LABEL maintainer="allennlp-contact@allenai.org"
 
 WORKDIR /stage/allennlp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-git+git://github.com/allenai/allennlp.git@c54fcc62936392cff23a7174a0309165c749df90
+allennlp
 psycopg2-binary
 sentry-sdk==0.7.1


### PR DESCRIPTION
This updates the allennlp version that the demo uses.  I originally thought that modifying `requirements.txt` was the right thing to do, but after digging into things I realized that I needed to modify the Dockerfile instead.  So this fixes that.  I see this as a temporary change to point to an un-released commit, so that I can go live with the demo tomorrow, and we can switch back to a regular release version after the next release.