### PR TITLE
Give the slider an option to always show all columns, add it back in

### DIFF
--- a/demo/src/components/HeatMap.js
+++ b/demo/src/components/HeatMap.js
@@ -12,6 +12,7 @@ import '../css/HeatMap.css';
     colLabels: string[]     * List of table header labels describing each column
     rowLabels: string[]     * List of table header labels describing each row
     includeSlider: bool     * Whether to include a slider to filter out values below a threshold
+    showAllCols: bool       * Whether to always show all columns with the slider
     color: string           * Heatmap color (optional, default = "blue", see supportedColors below)
     normalization: string   * Sets normalization type (optional). Supported types:
 
@@ -162,7 +163,7 @@ export default class HeatMap extends React.Component {
                     <tbody>
                       <tr data-row="header">
                         {colLabels.map((colLabel, colIndex) => (
-                          this.state.showColAt[colIndex] &&
+                          (this.props.showAllCols || this.state.showColAt[colIndex]) &&
                           <th className={`heatmap__label${colIndex === activeCol ? " heatmap__col-label-cursor" : ""}`}
                             key={`${colLabel}_${colIndex}`}
                             onMouseOver={() => this.handleMouseOver(null, colIndex)}
@@ -206,7 +207,7 @@ export default class HeatMap extends React.Component {
                         this.state.showRowAt[rowIndex] &&
                         <tr className="heatmap__row" key={`${rowLabel}_${rowIndex}`} data-row={rowIndex}>
                           {colLabels.map((colLabel, colIndex) => (
-                            this.state.showColAt[colIndex] &&
+                            (this.props.showAllCols || this.state.showColAt[colIndex]) &&
                             <td key={`${colLabel}_${colIndex}_${rowLabel}_${rowIndex}`}
                               className="heatmap__cell"
                               style={{backgroundColor: `rgba(${supportedColors[color].join(",")},${opacity[rowIndex][colIndex]})`}}

--- a/demo/src/components/demos/ReadingComprehension.js
+++ b/demo/src/components/demos/ReadingComprehension.js
@@ -69,7 +69,7 @@ const Attention = ({passage_question_attention, question_tokens, passage_tokens}
                 </p>
                 <HeatMap
                   colLabels={question_tokens} rowLabels={passage_tokens}
-                  data={passage_question_attention} />
+                  data={passage_question_attention} includeSlider={true} showAllCols={true} />
               </AccordionItemBody>
             </AccordionItem>
           </Accordion>


### PR DESCRIPTION
I misunderstood the feedback on the UI; this adds back in the slider, but makes all question words always visible (because the question is typically short).