### PR TITLE
allow single-model operation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,4 @@ ENV ALLENNLP_DEMO_SOURCE_COMMIT $SOURCE_COMMIT
 
 EXPOSE 8000
 
-ENV ALLENNLP_DEMO_DIRECTORY /stage/allennlp/demo
-
-ENTRYPOINT ["./app.py"]
+ENTRYPOINT ["./app.py", "--demo-dir /stage/allennlp/demo"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,5 @@ ENV ALLENNLP_DEMO_SOURCE_COMMIT $SOURCE_COMMIT
 
 EXPOSE 8000
 
-ENTRYPOINT ["./app.py", "--demo-dir /stage/allennlp/demo"]
+ENTRYPOINT ["./app.py"]
+CMD ["--demo-dir", "/stage/allennlp/demo"]

--- a/app.py
+++ b/app.py
@@ -331,11 +331,11 @@ if __name__ == "__main__":
     parser.add_argument('--port', type=int, default=8000, help='port to serve the demo on')
     parser.add_argument('--demo-dir', type=str, default='demo/', help="directory where the demo HTML is located")
     parser.add_argument('--cache-size', type=int, default=128, help="how many results to keep in memory")
-    parser.add_argument('--model-name', type=str, action='append', default=[], help='if specified, only load these models')
+    parser.add_argument('--model', type=str, action='append', default=[], help='if specified, only load these models')
 
     args = parser.parse_args()
 
     main(demo_dir=args.demo_dir,
          port=args.port,
          cache_size=args.cache_size,
-         model_names=args.model_name)
+         model_names=args.model)

--- a/app.py
+++ b/app.py
@@ -4,7 +4,8 @@
 A `Flask <http://flask.pocoo.org/>`_ server that serves up our demo.
 """
 from datetime import datetime
-from typing import Dict, Optional
+from typing import Dict, Optional, List
+import argparse
 import json
 import logging
 import os
@@ -28,13 +29,7 @@ from server.permalinks import int_to_slug, slug_to_int
 from server.db import DemoDatabase, PostgresDemoDatabase
 from server.models import MODELS, DemoModel
 
-# Can override cache size with an environment variable. If it's 0 then disable caching altogether.
-CACHE_SIZE = os.environ.get("FLASK_CACHE_SIZE") or 128
-PORT = os.environ.get("ALLENNLP_DEMO_PORT") or 8000
-DEMO_DIR = os.environ.get("ALLENNLP_DEMO_DIRECTORY") or 'demo/'
 
-# If this environment variable is set, then we only load the one model with this name.
-MODEL_NAME = os.environ.get("ALLENNLP_MODEL_NAME")
 
 logging.basicConfig(level=logging.INFO)
 logging.getLogger("allennlp").setLevel(logging.WARN)
@@ -61,11 +56,14 @@ class ServerError(Exception):
         error_dict['message'] = self.message
         return error_dict
 
-def main():
+def main(demo_dir: str,
+         port: int,
+         cache_size: int,
+         model_names: List[str]) -> None:
     """Run the server programatically"""
-    logger.info("Starting a flask server on port %i.", PORT)
+    logger.info("Starting a flask server on port %i.", port)
 
-    if PORT != 8000:
+    if port != 8000:
         logger.warning("The demo requires the API to be run on port 8000.")
 
     # This will be ``None`` if all the relevant environment variables are not defined or if
@@ -75,25 +73,27 @@ def main():
         logger.warning("demo db credentials not provided, so not using demo db")
 
     # If environment variables said to load only one model, only load that model.
-    if MODEL_NAME is not None:
-        models = {MODEL_NAME: MODELS[MODEL_NAME]}
+    if model_names:
+        models = {
+            name: demo_model
+            for name, demo_model in MODELS.items()
+            if name in model_names
+        }
     else:
         models = MODELS
 
-    app = make_app(demo_db=demo_db, models=models)
+    app = make_app(build_dir=f"{demo_dir}/build", demo_db=demo_db, models=models)
     CORS(app)
 
-    http_server = WSGIServer(('0.0.0.0', PORT), app)
-    logger.info("Server started on port %i.  Please visit: http://localhost:%i", PORT, PORT)
+    http_server = WSGIServer(('0.0.0.0', port), app)
+    logger.info("Server started on port %i.  Please visit: http://localhost:%i", port, port)
     http_server.serve_forever()
 
 
 def make_app(build_dir: str = None,
              demo_db: Optional[DemoDatabase] = None,
-             models: Dict[str, DemoModel] = None) -> Flask:
-    if build_dir is None:
-        build_dir = os.path.join(DEMO_DIR, 'build')
-
+             models: Dict[str, DemoModel] = None,
+             cache_size: int = 128) -> Flask:
     if models is None:
         models = {}
 
@@ -114,12 +114,6 @@ def make_app(build_dir: str = None,
         predictor = demo_model.predictor()
         app.predictors[name] = predictor
         app.max_request_lengths[name] = demo_model.max_request_length
-
-    try:
-        cache_size = int(CACHE_SIZE)  # type: ignore
-    except ValueError:
-        logger.warning("unable to parse cache size %s as int, disabling cache", CACHE_SIZE)
-        cache_size = 0
 
     @app.errorhandler(ServerError)
     def handle_invalid_usage(error: ServerError) -> Response:  # pylint: disable=unused-variable
@@ -333,4 +327,15 @@ def make_app(build_dir: str = None,
     return app
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser("start the allennlp demo")
+    parser.add_argument('--port', type=int, default=8000, help='port to serve the demo on')
+    parser.add_argument('--demo-dir', type=str, default='demo/', help="directory where the demo HTML is located")
+    parser.add_argument('--cache-size', type=int, default=128, help="how many results to keep in memory")
+    parser.add_argument('--model-name', type=str, action='append', default=[], help='if specified, only load these models')
+
+    args = parser.parse_args()
+
+    main(demo_dir=args.demo_dir,
+         port=args.port,
+         cache_size=args.cache_size,
+         model_names=args.model_name)

--- a/server/models.py
+++ b/server/models.py
@@ -37,11 +37,11 @@ MODELS = {
                 'machine-comprehension',
                 311108
         ),
-        'naqanet-reading-comprehension': DemoModel(
-                'https://s3-us-west-2.amazonaws.com/allennlp/models/naqanet-2019.03.01.tar.gz',
-                'machine-comprehension',
-                25819
-        ),
+        # 'naqanet-reading-comprehension': DemoModel(
+        #         'https://s3-us-west-2.amazonaws.com/allennlp/models/naqanet-2019.03.01.tar.gz',
+        #         'machine-comprehension',
+        #         25819
+        # ),
         'semantic-role-labeling': DemoModel(
                 'https://s3-us-west-2.amazonaws.com/allennlp/models/srl-model-2018.05.25.tar.gz',
                 'semantic-role-labeling',

--- a/server/models.py
+++ b/server/models.py
@@ -37,11 +37,11 @@ MODELS = {
                 'machine-comprehension',
                 311108
         ),
-        # 'naqanet-reading-comprehension': DemoModel(
-        #         'https://s3-us-west-2.amazonaws.com/allennlp/models/naqanet-2019.03.01.tar.gz',
-        #         'machine-comprehension',
-        #         25819
-        # ),
+        'naqanet-reading-comprehension': DemoModel(
+                'https://s3-us-west-2.amazonaws.com/allennlp/models/naqanet-2019.03.01.tar.gz',
+                'machine-comprehension',
+                25819
+        ),
         'semantic-role-labeling': DemoModel(
                 'https://s3-us-west-2.amazonaws.com/allennlp/models/srl-model-2018.05.25.tar.gz',
                 'semantic-role-labeling',

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -199,10 +199,8 @@ class TestFlask(AllenNlpTestCase):
             assert len(predictor.calls) == 2
 
     def test_disable_caching(self):
-        app.CACHE_SIZE = 0
-
         predictor = CountingPredictor()
-        application = make_app(build_dir=self.TEST_DIR)
+        application = make_app(build_dir=self.TEST_DIR, cache_size=0)
         application.predictors = {"counting": predictor}
         application.max_request_lengths["counting"] = 100
         application.testing = True


### PR DESCRIPTION
this PR has two changes (and some refactoring to enable them)

1. if an environment variable `ALLENNLP_MODEL_NAME` is set (e.g. to `machine-comprehension`) then the app will load only that model. Otherwise, it will load all the models in the `MODELS` variable.

2. there was some really clunky behavior where we manually added a path for each model to serve index.html at /model_name and /model_name/<permalink>. I made that automatic based on the keys of the models passed into the constructor.