### PR TITLE
Update NLVR model to one with a compatible vocabulary

### DIFF
--- a/server/models.py
+++ b/server/models.py
@@ -88,7 +88,7 @@ MODELS = {
                 8177
         ),
         'nlvr-parser': DemoModel(
-                'https://s3-us-west-2.amazonaws.com/allennlp/models/nlvr-erm-model-2018-12-18.tar.gz',
+                'https://s3-us-west-2.amazonaws.com/allennlp/models/nlvr-erm-model-2018-12-18-rule-vocabulary-updated.tar.gz',
                 'nlvr-parser',
                 1136
         ),

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -87,7 +87,6 @@ class TestFlask(AllenNlpTestCase):
                                 content_type="application/json",
                                 data=json.dumps(data))
 
-
     def tearDown(self):
         super().tearDown()
         try:


### PR DESCRIPTION
This error was (somewhat surprisingly) unrelated to the QuaRel demo problem (though they were both introduced in the big semantic parser refactoring that I did a while ago).  I just needed to update the saved model to something that's compatible with new code.  There is, unfortunately, not a good place to add a test for this.  A sniff test is the right thing here, but there aren't any of those in this repo, and if we're splitting things out into separate services, anyway, this wouldn't have ever been a problem (because the cause of the demo breaking was that the code changed from underneath what the demo model was expecting).