### PR TITLE
Use the JRE instead of JDK.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="allennlp-contact@allenai.org"
 WORKDIR /stage/allennlp
 
 # Install Java.
-RUN apt-get update --fix-missing && apt-get install -y openjdk-8-jdk
+RUN apt-get update --fix-missing && apt-get install -y openjdk-8-jre
 
 # Install npm early so layer is cached when mucking with the demo
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && apt-get install -y nodejs


### PR DESCRIPTION
This cuts out around 300 MB from the Docker image.