### PR TITLE
Switch from BiDAF character-level to BiDAF ELMo

### DIFF
--- a/models.json
+++ b/models.json
@@ -1,6 +1,7 @@
 {
     "reading-comprehension": {
-        "archive_file": "https://s3-us-west-2.amazonaws.com/allennlp/models/bidaf-model-2017.09.15-charpad.tar.gz",
+        "archive_file": "https://s3.us-west-2.amazonaws.com/allennlp/models/bidaf-elmo-model-2018.11.30-charpad.tar.gz",
+        "memory": "2Gi",
         "predictor_name": "machine-comprehension",
         "max_request_length": 311108
     },


### PR DESCRIPTION
We want to have the ELMo version in the demo instead because its higher accuracy. Also the demo better aligns with a paper submission if we ELMo.