### PR TITLE
Use URLs from GCS for the demo.

### DIFF
--- a/app.py
+++ b/app.py
@@ -103,7 +103,7 @@ def make_app(build_dir: str,
     start_time_str = start_time.strftime("%Y-%m-%d %H:%M:%S %Z")
 
     app.predictors = {}
-    app.max_request_lengths = {}
+    app.max_request_lengths = {} # requests longer than these will be rejected to prevent OOME
     app.wsgi_app = ProxyFix(app.wsgi_app) # sets the requester IP with the X-Forwarded-For header
 
     for name, demo_model in models.items():

--- a/models.json
+++ b/models.json
@@ -1,77 +1,77 @@
 {
     "reading-comprehension": {
-        "archive_file": "https://s3.us-west-2.amazonaws.com/allennlp/models/bidaf-elmo-model-2018.11.30-charpad.tar.gz",
+        "archive_file": "https://storage.googleapis.com/allennlp-public-models/bidaf-elmo-model-2018.11.30-charpad.tar.gz",
         "memory": "2Gi",
         "predictor_name": "machine-comprehension",
         "max_request_length": 311108
     },
     "naqanet-reading-comprehension": {
-        "archive_file": "https://s3-us-west-2.amazonaws.com/allennlp/models/naqanet-2019.03.01.tar.gz",
+        "archive_file": "https://storage.googleapis.com/allennlp-public-models/naqanet-2019.03.01.tar.gz",
         "predictor_name": "machine-comprehension",
         "max_request_length": 25819
     },
     "semantic-role-labeling": {
-        "archive_file": "https://s3-us-west-2.amazonaws.com/allennlp/models/srl-model-2018.05.25.tar.gz",
+        "archive_file": "https://storage.googleapis.com/allennlp-public-models/srl-model-2018.05.25.tar.gz",
         "predictor_name": "semantic-role-labeling",
         "max_request_length": 4590
     },
     "open-information-extraction": {
-        "archive_file": "https://s3-us-west-2.amazonaws.com/allennlp/models/openie-model.2018-08-20.tar.gz",
+        "archive_file": "https://storage.googleapis.com/allennlp-public-models/openie-model.2018-08-20.tar.gz",
         "predictor_name": "open-information-extraction",
         "max_request_length": 19681
     },
     "textual-entailment": {
-        "archive_file": "https://s3-us-west-2.amazonaws.com/allennlp/models/decomposable-attention-elmo-2018.02.19.tar.gz",
+        "archive_file": "https://storage.googleapis.com/allennlp-public-models/decomposable-attention-elmo-2018.02.19.tar.gz",
         "predictor_name": "textual-entailment",
         "max_request_length": 13129
     },
     "coreference-resolution": {
-        "archive_file": "https://s3-us-west-2.amazonaws.com/allennlp/models/coref-model-2018.02.05.tar.gz",
+        "archive_file": "https://storage.googleapis.com/allennlp-public-models/coref-model-2018.02.05.tar.gz",
         "predictor_name": "coreference-resolution",
         "max_request_length": 21097
     },
     "named-entity-recognition": {
-        "archive_file": "https://s3-us-west-2.amazonaws.com/allennlp/models/ner-model-2018.12.18.tar.gz",
+        "archive_file": "https://storage.googleapis.com/allennlp-public-models/ner-model-2018.12.18.tar.gz",
         "predictor_name": "sentence-tagger",
         "max_request_length": 94864
     },
     "fine-grained-named-entity-recognition": {
-        "archive_file": "https://s3-us-west-2.amazonaws.com/allennlp/models/fine-grained-ner-model-elmo-2018.12.21.tar.gz",
+        "archive_file": "https://storage.googleapis.com/allennlp-public-models/fine-grained-ner-model-elmo-2018.12.21.tar.gz",
         "predictor_name": "sentence-tagger",
         "max_request_length": 22878
     },
     "constituency-parsing": {
-        "archive_file": "https://s3-us-west-2.amazonaws.com/allennlp/models/elmo-constituency-parser-2018.03.14.tar.gz",
+        "archive_file": "https://storage.googleapis.com/allennlp-public-models/elmo-constituency-parser-2018.03.14.tar.gz",
         "predictor_name": "constituency-parser",
         "max_request_length": 2236
     },
     "dependency-parsing": {
-        "archive_file": "https://s3-us-west-2.amazonaws.com/allennlp/models/biaffine-dependency-parser-ptb-2018.08.23.tar.gz",
+        "archive_file": "https://storage.googleapis.com/allennlp-public-models/biaffine-dependency-parser-ptb-2018.08.23.tar.gz",
         "predictor_name": "biaffine-dependency-parser",
         "max_request_length": 5675
     },
     "wikitables-parser": {
-        "archive_file": "https://s3-us-west-2.amazonaws.com/allennlp/models/wikitables-model-2018.09.14.tar.gz",
+        "archive_file": "https://storage.googleapis.com/allennlp-public-models/wikitables-model-2018.09.14.tar.gz",
         "predictor_name": "wikitables-parser",
         "max_request_length": 8177
     },
     "nlvr-parser": {
-        "archive_file": "https://s3-us-west-2.amazonaws.com/allennlp/models/nlvr-erm-model-2018-12-18-rule-vocabulary-updated.tar.gz",
+        "archive_file": "https://storage.googleapis.com/allennlp-public-models/nlvr-erm-model-2018-12-18-rule-vocabulary-updated.tar.gz",
         "predictor_name": "nlvr-parser",
         "max_request_length": 1136
     },
     "event2mind": {
-        "archive_file": "https://s3-us-west-2.amazonaws.com/allennlp/models/event2mind-2018.10.26.tar.gz",
+        "archive_file": "https://storage.googleapis.com/allennlp-public-models/event2mind-2018.10.26.tar.gz",
         "predictor_name": "event2mind",
         "max_request_length": 11643
     },
     "atis-parser": {
-        "archive_file": "https://s3-us-west-2.amazonaws.com/allennlp/models/atis-parser-2018.11.10.tar.gz",
+        "archive_file": "https://storage.googleapis.com/allennlp-public-models/atis-parser-2018.11.10.tar.gz",
         "predictor_name": "atis-parser",
         "max_request_length": 2236
     },
     "quarel-parser-zero": {
-        "archive_file": "https://s3-us-west-2.amazonaws.com/allennlp/models/quarel-parser-zero-2018.12.20.tar.gz",
+        "archive_file": "https://storage.googleapis.com/allennlp-public-models/quarel-parser-zero-2018.12.20.tar.gz",
         "predictor_name": "quarel-parser",
         "max_request_length": 6695
     }


### PR DESCRIPTION
Our demo is hosted on GCP and downloads from GCS are 6x faster than downloads from S3.  In addition--they are free whereas downloads from S3 have some overhead (AWS charges us around $0.10 cents per gigabyte for egress).