### PR TITLE
Increase failure threshold.

### DIFF
--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -208,7 +208,7 @@ local ingress = {
 };
 
 local healthCheck = {
-    failureThreshold: 3,
+    failureThreshold: 9,
     periodSeconds: 10,
     initialDelaySeconds: 180,
     httpGet: {


### PR DESCRIPTION
Currently our pods are failing because the `/health` route is inaccessible when the server blocks to make a model predictions.  I think this is a fundamental problem in flask, which makes me wonder how useful the `livenessProbe` is for the AllenNLP demo.

@joelgrus saw that there is some way to make flask application asynchronous (see https://stackoverflow.com/questions/14551823/running-flask-gevent-requests-not-serving-concurrently and https://gist.github.com/viksit/b6733fe1afdf5bb84a40#file-async_flask-py-L12) but I'm concerned this might bring up more problems (will models run in parallel?  I remember we used to have problems when we used Sanic around parallel execution).

For now, this seems like the most straightforward change that will improve the user experience--even though it falls far short of where we would ideally be.