### PR TITLE
add language modeling to the allennlp demo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && apt-get install -y
 RUN pip install psycopg2-binary
 RUN pip install sentry-sdk==0.7.1
 RUN pip install python-json-logger
+RUN pip install pytorch-pretrained-bert
 
 # Download spacy model
 RUN spacy download en_core_web_sm

--- a/app.py
+++ b/app.py
@@ -28,7 +28,8 @@ from allennlp.predictors import Predictor
 from server.permalinks import int_to_slug, slug_to_int
 from server.db import DemoDatabase, PostgresDemoDatabase
 from server.logging import StackdriverJsonFormatter
-from server.models import DemoModel, load_demo_models
+from server.demo_model import DemoModel
+from server.models import load_demo_models
 
 
 logging.getLogger("allennlp").setLevel(logging.WARN)
@@ -188,6 +189,7 @@ def make_app(build_dir: str,
         max_request_length = app.max_request_lengths[lowered_model_name]
 
         data = request.get_json()
+        print(request.args)
 
         serialized_request = json.dumps(data)
         if len(serialized_request) > max_request_length:

--- a/app.py
+++ b/app.py
@@ -189,7 +189,6 @@ def make_app(build_dir: str,
         max_request_length = app.max_request_lengths[lowered_model_name]
 
         data = request.get_json()
-        print(request.args)
 
         serialized_request = json.dumps(data)
         if len(serialized_request) > max_request_length:

--- a/demo/package.json
+++ b/demo/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "hierplane": "0.0.11",
+    "lodash": "^4.17.11",
     "npm": "6.1.0",
     "react": "15.6.1",
     "react-accessible-accordion": "2.4.5",

--- a/demo/public/assets/loading-bars.svg
+++ b/demo/public/assets/loading-bars.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" fill="#8c9296">
+  <path transform="translate(2)" d="M0 12 V20 H4 V12z">
+    <animate attributeName="d" values="M0 12 V20 H4 V12z; M0 4 V28 H4 V4z; M0 12 V20 H4 V12z; M0 12 V20 H4 V12z" dur="1.2s" repeatCount="indefinite" begin="0" keytimes="0;.2;.5;1" keySplines="0.2 0.2 0.4 0.8;0.2 0.6 0.4 0.8;0.2 0.8 0.4 0.8" calcMode="spline"  />
+  </path>
+  <path transform="translate(8)" d="M0 12 V20 H4 V12z">
+    <animate attributeName="d" values="M0 12 V20 H4 V12z; M0 4 V28 H4 V4z; M0 12 V20 H4 V12z; M0 12 V20 H4 V12z" dur="1.2s" repeatCount="indefinite" begin="0.2" keytimes="0;.2;.5;1" keySplines="0.2 0.2 0.4 0.8;0.2 0.6 0.4 0.8;0.2 0.8 0.4 0.8" calcMode="spline"  />
+  </path>
+  <path transform="translate(14)" d="M0 12 V20 H4 V12z">
+    <animate attributeName="d" values="M0 12 V20 H4 V12z; M0 4 V28 H4 V4z; M0 12 V20 H4 V12z; M0 12 V20 H4 V12z" dur="1.2s" repeatCount="indefinite" begin="0.4" keytimes="0;.2;.5;1" keySplines="0.2 0.2 0.4 0.8;0.2 0.6 0.4 0.8;0.2 0.8 0.4 0.8" calcMode="spline" />
+  </path>
+  <path transform="translate(20)" d="M0 12 V20 H4 V12z">
+    <animate attributeName="d" values="M0 12 V20 H4 V12z; M0 4 V28 H4 V4z; M0 12 V20 H4 V12z; M0 12 V20 H4 V12z" dur="1.2s" repeatCount="indefinite" begin="0.6" keytimes="0;.2;.5;1" keySplines="0.2 0.2 0.4 0.8;0.2 0.6 0.4 0.8;0.2 0.8 0.4 0.8" calcMode="spline" />
+  </path>
+  <path transform="translate(26)" d="M0 12 V20 H4 V12z">
+    <animate attributeName="d" values="M0 12 V20 H4 V12z; M0 4 V28 H4 V4z; M0 12 V20 H4 V12z; M0 12 V20 H4 V12z" dur="1.2s" repeatCount="indefinite" begin="0.8" keytimes="0;.2;.5;1" keySplines="0.2 0.2 0.4 0.8;0.2 0.6 0.4 0.8;0.2 0.8 0.4 0.8" calcMode="spline" />
+  </path>
+</svg>

--- a/demo/src/components/demos/Gpt2.js
+++ b/demo/src/components/demos/Gpt2.js
@@ -6,75 +6,12 @@ import _ from 'lodash';
 
 const Wrapper = styled.div`
   color: #232323;
-  border-top: 4px solid #fcb431;
-  max-width: 940px;
   flex-grow: 1;
-  margin: 2rem;
-  background: #fff;
-  padding: 2rem;
   font-size: 1em;
-  box-shadow: 1px 1px 3px rgba(0,0,0,0.3);
-  font-size: 1em;
-  line-height: 1.4;
 
   @media(max-width: 500px) {
     margin: 0;
   }
-`
-
-const Title = styled.h1`
-  font-size: 1.5em;
-  margin: 0 0 1rem;
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-
-  @media(max-width: 500px) {
-    justify-content: center;
-  }
-`
-
-const AppName = styled.span`
-  background: #2085bc;
-  font-weight: 200;
-  color: #fff;
-  padding: 0.5rem 1rem;
-  line-height: 1;
-  border-radius: 2rem;
-  margin-left: auto;
-
-  @media(max-width: 500px) {
-    margin: 1rem 0 0;
-  }
-`
-
-const LinkHome = styled.a`
-  background-image: url('static/ai2-logo-header.png');
-  background-size: 360px 71px;
-  backround-repeat: no-repeat;
-  width: 360px;
-  height: 71px;
-  display: block;
-  margin: 0 1rem 0 0;
-
-  @media(max-width: 500px) {
-    background-image: url('static/ai2-logo-header-crop.png');
-    background-size: 89px 71px;
-    width: 89px;
-    height: 71px;
-  }
-`
-
-const Intro = styled.div`
-  margin: 2em 0;
-
-  @media(max-width: 500px) {
-    font-size: 0.8em;
-  }
-`
-
-const TextInputWrapper = styled.div`
-  position: relative;
 `
 
 const Loading = styled.div`
@@ -97,6 +34,7 @@ const LoadingText = styled.div`
 
 const InputOutput = styled.div`
   display: flex;
+  margin-top: 10px;
 
   @media(max-width: 500px) {
     display: block;
@@ -132,26 +70,11 @@ const TextInput = styled.textarea`
   font-size: 1.25em;
   min-height: 100px;
   border: 1px solid rgba(0, 0, 0, 0.2);
-  box-shadow: inset 1px 1px 4px rgba(0, 0, 0, 0.1);
   padding: 1rem;
-  border-radius: 0.25rem;
-`
-
-const Button = styled.button`
-  color: #fff!important;
-  background: #2085bc;
 `
 
 const ListItem = styled.li`
   margin: 0 0 0.5rem;
-`
-
-const InputHeader = styled.h2`
-  font-weight: 600;
-  font-size: 1.1em;
-  margin: 0 0 1rem;
-  padding: 0 0 0.5rem;
-  border-bottom: 1px solid #eee;
 `
 
 const ChoiceList = styled.ul`
@@ -189,28 +112,6 @@ const Token = styled.span`
   font-weight: 600;
 `
 
-const OutputSentence = styled.div`
-  margin: 20px;
-  font-family: monospace;
-  flex: 1;
-`
-
-const OutputToken = styled.span`
-  cursor: pointer;
-
-  :hover {
-      font-weight: bold;
-  }
-`
-
-const OutputSpace = styled.span``
-
-const ModelChoice = styled.span`
-  font-weight: ${props => props.selected ? 'bold' : 'normal'};
-  color: ${props => props.selected ? 'black' : 'lightgray'};
-  cursor: ${props => props.selected ? 'default' : 'pointer'};
-`
-
 const Footer = styled.div`
   margin: 2rem 0 0 0;
 `
@@ -227,7 +128,7 @@ function loadFromUrl() {
   const params =
       document.location.search.substr(1).split('&').map(p => p.split('='));
   const text = params.find(p => p[0] === 'text');
-  return Array.isArray(text) && text.length == 2 ?  decodeURIComponent(text.pop()) : null;
+  return Array.isArray(text) && text.length === 2 ?  decodeURIComponent(text.pop()) : null;
 }
 
 function trimRight(str) {
@@ -235,6 +136,17 @@ function trimRight(str) {
 }
 
 const DEFAULT_MODEL = "345M"
+
+const description = (
+  <span>
+This demonstration uses the public 345M
+parameter <a href="https://github.com/openai/gpt-2" target="_blank" rel="noopener noreferrer">OpenAI GPT-2</a> language model
+to generate sentences.<br /><br />
+Enter some initial text and the model will generate the most likely next words.
+You can click on one of those words to choose it and continue or just keep typing.
+Click the left arrow at the bottom to undo your last choice.
+  </span>
+)
 
 class App extends React.Component {
 
@@ -316,7 +228,7 @@ class App extends React.Component {
     }
 
     const currentReqId = this.createRequestId();
-    const endpoint = `${API_ROOT}/predict`
+    const endpoint = `${API_ROOT}/predict/gpt2`
 
     if ('history' in window && !doNotChangeUrl) {
       addToUrl(this.state.output, choice);
@@ -354,42 +266,33 @@ class App extends React.Component {
   }
 
   render() {
+
     return (
-      <Wrapper>
-        <Title>
-          <LinkHome href="https://allenai.org" target="_blank"></LinkHome>
-          <AppName>GPT-2 Explorer</AppName>
-        </Title>
-        <Intro>
-          This demonstration uses the public 345M
-          parameter <a href="https://github.com/openai/gpt-2" target="_blank">OpenAI GPT-2</a> language model
-          to generate sentences.<br /><br />
-          Enter some initial text and the model will generate the most likely next words.
-          You can click on one of those words to choose it and continue or just keep typing.
-          Click the left arrow at the bottom to undo your last choice.
-        </Intro>
+      <Wrapper className="model">
+        <div className="model__content answer">
+        <h2><span>Language Modeling</span></h2>
+        <p><span>{description}</span></p>
+
         <InputOutput>
-          <InputOutputColumn>
-            <InputHeader>Sentence:</InputHeader>
-            <TextInputWrapper>
+          <InputOutputColumn className="form__field">
+            <label>Sentence:</label>
               <TextInput type="text"
                         value={this.state.output}
                         onChange={this.setOutput}/>
               {this.state.loading ? (
                 <Loading>
-                  <img src="/static/loading-bars.svg" width="25" height="25" />
+                  <img src="/assets/loading-bars.svg" width="25" height="25" alt="loading" />
                   <LoadingText>Loading</LoadingText>
                 </Loading>
               ) : null}
               {this.state.error ? (
                 <Error>
-                  ⚠️ Something went wrong. Please try again.
+                  <span role="img" aria-label="warning">️⚠</span> Something went wrong. Please try again.
                 </Error>
               ) : null}
-            </TextInputWrapper>
           </InputOutputColumn>
-          <InputOutputColumn>
-            <InputHeader>Options:</InputHeader>
+          <InputOutputColumn className="form__field">
+            <label>Options:</label>
             <Choices output={this.state.output}
                      choose={this.choose}
                      logits={this.state.logits}
@@ -399,10 +302,11 @@ class App extends React.Component {
           </InputOutputColumn>
         </InputOutput>
         <Footer>
-          Built at the <a href="https://allenai.org" target="_blank">Allen Institute for Artificial Intelligence</a>
-          {' '}using Hugging Face’s <a href="https://github.com/huggingface/pytorch-pretrained-BERT" target="_blank">pytorch-pretrained-BERT</a>
-          {' '}library.  See the <a href="https://github.com/allenai/lm-explorer">source code on GitHub</a>.
+          Built at the <a href="https://allenai.org" target="_blank" rel="noopener noreferrer">Allen Institute for Artificial Intelligence</a>
+          {' '}using Hugging Face’s <a href="https://github.com/huggingface/pytorch-pretrained-BERT" target="_blank" rel="noopener noreferrer">pytorch-pretrained-BERT</a>
+          {' '}library.
         </Footer>
+      </div>
       </Wrapper>
     )
   }
@@ -418,7 +322,6 @@ const Choices = ({output, logits, words, choose, probabilities}) => {
   if (!words) { return null }
 
   const lis = words.map((word, idx) => {
-    const logit = logits[idx]
     const prob = formatProbability(probabilities[idx])
 
     // get rid of CRs
@@ -458,62 +361,6 @@ const Choices = ({output, logits, words, choose, probabilities}) => {
     </ChoiceList>
   )
 }
-
-/*
-
-class Gpt2Model extends React.Component {
-    constructor(props) {
-      super(props);
-
-      const { requestData, responseData } = props;
-
-      this.state = {
-        outputState: responseData ? "received" : "empty", // valid values: "working", "empty", "received", "error"
-        requestData: requestData,
-        responseData: responseData
-      };
-
-      this.runModel = this.runModel.bind(this)
-    }
-
-    runModel(inputs) {
-      const { selectedModel, apiUrl } = this.props
-
-      this.setState({outputState: "working"});
-
-      fetch(apiUrl(inputs), {
-        method: 'POST',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(inputs)
-      }).then((response) => {
-        return response.json();
-      }).then((json) => {
-        // If the response contains a `slug` for a permalink, we want to redirect
-        // to the corresponding path using `history.push`.
-        const { slug } = json;
-        const newPath = slug ? `/${selectedModel}/${slug}` : `/${selectedModel}`
-
-        // We'll pass the request and response data along as part of the location object
-        // so that the `Demo` component can use them to re-render.
-        const location = {
-          pathname: newPath,
-          state: { requestData: inputs, responseData: json }
-        }
-        this.props.history.push(location);
-      }).catch((error) => {
-        this.setState({outputState: "error"});
-        console.error(error);
-      });
-    }
-
-    render() {
-        return <App/>
-    }
-}
-*/
 
 const modelProps = {}
 

--- a/demo/src/components/demos/Gpt2.js
+++ b/demo/src/components/demos/Gpt2.js
@@ -1,0 +1,520 @@
+import React from 'react'
+import { API_ROOT } from '../../api-config';
+import { withRouter } from 'react-router-dom';
+import styled from 'styled-components';
+import _ from 'lodash';
+
+const Wrapper = styled.div`
+  color: #232323;
+  border-top: 4px solid #fcb431;
+  max-width: 940px;
+  flex-grow: 1;
+  margin: 2rem;
+  background: #fff;
+  padding: 2rem;
+  font-size: 1em;
+  box-shadow: 1px 1px 3px rgba(0,0,0,0.3);
+  font-size: 1em;
+  line-height: 1.4;
+
+  @media(max-width: 500px) {
+    margin: 0;
+  }
+`
+
+const Title = styled.h1`
+  font-size: 1.5em;
+  margin: 0 0 1rem;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+
+  @media(max-width: 500px) {
+    justify-content: center;
+  }
+`
+
+const AppName = styled.span`
+  background: #2085bc;
+  font-weight: 200;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  line-height: 1;
+  border-radius: 2rem;
+  margin-left: auto;
+
+  @media(max-width: 500px) {
+    margin: 1rem 0 0;
+  }
+`
+
+const LinkHome = styled.a`
+  background-image: url('static/ai2-logo-header.png');
+  background-size: 360px 71px;
+  backround-repeat: no-repeat;
+  width: 360px;
+  height: 71px;
+  display: block;
+  margin: 0 1rem 0 0;
+
+  @media(max-width: 500px) {
+    background-image: url('static/ai2-logo-header-crop.png');
+    background-size: 89px 71px;
+    width: 89px;
+    height: 71px;
+  }
+`
+
+const Intro = styled.div`
+  margin: 2em 0;
+
+  @media(max-width: 500px) {
+    font-size: 0.8em;
+  }
+`
+
+const TextInputWrapper = styled.div`
+  position: relative;
+`
+
+const Loading = styled.div`
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+  display: flex;
+  align-items: center;
+  font-size: 0.8em;
+  color: #8c9296;
+`
+
+const Error = styled(Loading)`
+  color: red;
+`
+
+const LoadingText = styled.div`
+  padding-left: 0.5rem;
+`
+
+const InputOutput = styled.div`
+  display: flex;
+
+  @media(max-width: 500px) {
+    display: block;
+  }
+`
+
+const InputOutputColumn = styled.div`
+  flex: 1 1 50%;
+
+  :first-child {
+    padding-right: 1rem;
+  }
+
+  :last-child {
+    padding-left: 1rem;
+  }
+
+  @media(max-width: 500px) {
+    :first-child,
+    :last-child {
+      padding: 0;
+    }
+
+    :first-child {
+      padding: 0 0 1rem;
+    }
+  }
+`
+
+const TextInput = styled.textarea`
+  display: block;
+  width: 100%;
+  font-size: 1.25em;
+  min-height: 100px;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  box-shadow: inset 1px 1px 4px rgba(0, 0, 0, 0.1);
+  padding: 1rem;
+  border-radius: 0.25rem;
+`
+
+const Button = styled.button`
+  color: #fff!important;
+  background: #2085bc;
+`
+
+const ListItem = styled.li`
+  margin: 0 0 0.5rem;
+`
+
+const InputHeader = styled.h2`
+  font-weight: 600;
+  font-size: 1.1em;
+  margin: 0 0 1rem;
+  padding: 0 0 0.5rem;
+  border-bottom: 1px solid #eee;
+`
+
+const ChoiceList = styled.ul`
+  padding: 0;
+  margin: 0;
+  flex-wrap: wrap;
+  list-style-type: none;
+`
+
+const ChoiceItem = styled.button`
+  color: #2085bc;
+  cursor: pointer;
+  background: transparent;
+  display: inline-flex;
+  align-items: center;
+  line-height: 1;
+  font-size: 1.15em;
+  border: none;
+  border-bottom: 2px solid transparent;
+`
+
+const UndoButton = styled(ChoiceItem)`
+  color: #8c9296;
+`
+
+const Probability = styled.span`
+  color: #8c9296;
+  margin-right: 0.5rem;
+  font-size: 0.8em;
+  min-width: 4em;
+  text-align: right;
+`
+
+const Token = styled.span`
+  font-weight: 600;
+`
+
+const OutputSentence = styled.div`
+  margin: 20px;
+  font-family: monospace;
+  flex: 1;
+`
+
+const OutputToken = styled.span`
+  cursor: pointer;
+
+  :hover {
+      font-weight: bold;
+  }
+`
+
+const OutputSpace = styled.span``
+
+const ModelChoice = styled.span`
+  font-weight: ${props => props.selected ? 'bold' : 'normal'};
+  color: ${props => props.selected ? 'black' : 'lightgray'};
+  cursor: ${props => props.selected ? 'default' : 'pointer'};
+`
+
+const Footer = styled.div`
+  margin: 2rem 0 0 0;
+`
+
+const DEFAULT = "Joel is";
+
+function addToUrl(output, choice) {
+  if ('history' in window) {
+    window.history.pushState(null, null, '?text=' + encodeURIComponent(output + (choice || '')))
+  }
+}
+
+function loadFromUrl() {
+  const params =
+      document.location.search.substr(1).split('&').map(p => p.split('='));
+  const text = params.find(p => p[0] === 'text');
+  return Array.isArray(text) && text.length == 2 ?  decodeURIComponent(text.pop()) : null;
+}
+
+function trimRight(str) {
+  return str.replace(/ +$/, '');
+}
+
+const DEFAULT_MODEL = "345M"
+
+class App extends React.Component {
+
+  constructor(props) {
+    super(props)
+
+    this.currentRequestId = 0;
+
+    this.state = {
+      output: loadFromUrl() || DEFAULT,
+      words: null,
+      logits: null,
+      probabilities: null,
+      loading: false,
+      error: false,
+      model: DEFAULT_MODEL
+    }
+
+    this.choose = this.choose.bind(this)
+    this.debouncedChoose = _.debounce(this.choose, 1000)
+    this.setOutput = this.setOutput.bind(this)
+    this.runOnEnter = this.runOnEnter.bind(this)
+  }
+
+  setOutput(evt) {
+    const value = evt.target.value
+    const trimmed = trimRight(value);
+
+    this.setState({
+        output: value,
+        words: null,
+        logits: null,
+        probabilities: null,
+        loading: trimmed.length > 0
+    })
+    this.debouncedChoose()
+  }
+
+  createRequestId() {
+    const nextReqId = this.currentRequestId + 1;
+    this.currentRequestId = nextReqId;
+    return nextReqId;
+  }
+
+  componentDidMount() {
+    this.choose()
+    if ('history' in window) {
+      window.addEventListener('popstate', () => {
+        const fullText = loadFromUrl();
+        const doNotChangeUrl = fullText ? true : false;
+        const output = fullText || DEFAULT;
+        this.setState({
+          output,
+          loading: true,
+          words: null,
+          logits: null,
+          probabilities: null,
+          model: this.state.model
+        }, () => this.choose(undefined, doNotChangeUrl));
+      })
+    }
+  }
+
+  choose(choice = undefined, doNotChangeUrl) {
+    this.setState({ loading: true, error: false })
+
+    // strip trailing spaces
+    const trimmedOutput = trimRight(this.state.output);
+    if (trimmedOutput.length === 0) {
+      this.setState({ loading: false });
+      return;
+    }
+
+    const payload = {
+      previous: trimmedOutput,
+      next: choice,
+      numsteps: 5,
+      model_name: this.state.model
+    }
+
+    const currentReqId = this.createRequestId();
+    const endpoint = `${API_ROOT}/predict`
+
+    if ('history' in window && !doNotChangeUrl) {
+      addToUrl(this.state.output, choice);
+    }
+
+    fetch(endpoint, {
+      method: "POST",
+      headers: {
+          "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload)
+    })
+    .then(response => response.json())
+    .then(data => {
+      if (this.currentRequestId === currentReqId) {
+        // If the user entered text by typing don't overwrite it, as that feels
+        // weird. If they clicked it overwrite it
+        const output = choice === undefined ? this.state.output : data.output
+        this.setState({...data, output, loading: false})
+      }
+    })
+    .catch(err => {
+      console.error('Error trying to communicate with the API:', err);
+      this.setState({ error: true, loading: false });
+    });
+  }
+
+  // Temporarily (?) disabled
+  runOnEnter(e) {
+    if (e.key === 'Enter') {
+        e.preventDefault()
+        e.stopPropagation()
+        this.choose()
+    }
+  }
+
+  render() {
+    return (
+      <Wrapper>
+        <Title>
+          <LinkHome href="https://allenai.org" target="_blank"></LinkHome>
+          <AppName>GPT-2 Explorer</AppName>
+        </Title>
+        <Intro>
+          This demonstration uses the public 345M
+          parameter <a href="https://github.com/openai/gpt-2" target="_blank">OpenAI GPT-2</a> language model
+          to generate sentences.<br /><br />
+          Enter some initial text and the model will generate the most likely next words.
+          You can click on one of those words to choose it and continue or just keep typing.
+          Click the left arrow at the bottom to undo your last choice.
+        </Intro>
+        <InputOutput>
+          <InputOutputColumn>
+            <InputHeader>Sentence:</InputHeader>
+            <TextInputWrapper>
+              <TextInput type="text"
+                        value={this.state.output}
+                        onChange={this.setOutput}/>
+              {this.state.loading ? (
+                <Loading>
+                  <img src="/static/loading-bars.svg" width="25" height="25" />
+                  <LoadingText>Loading</LoadingText>
+                </Loading>
+              ) : null}
+              {this.state.error ? (
+                <Error>
+                  ⚠️ Something went wrong. Please try again.
+                </Error>
+              ) : null}
+            </TextInputWrapper>
+          </InputOutputColumn>
+          <InputOutputColumn>
+            <InputHeader>Options:</InputHeader>
+            <Choices output={this.state.output}
+                     choose={this.choose}
+                     logits={this.state.logits}
+                     words={this.state.words}
+                     probabilities={this.state.probabilities}
+                     hidden={this.state.loading}/>
+          </InputOutputColumn>
+        </InputOutput>
+        <Footer>
+          Built at the <a href="https://allenai.org" target="_blank">Allen Institute for Artificial Intelligence</a>
+          {' '}using Hugging Face’s <a href="https://github.com/huggingface/pytorch-pretrained-BERT" target="_blank">pytorch-pretrained-BERT</a>
+          {' '}library.  See the <a href="https://github.com/allenai/lm-explorer">source code on GitHub</a>.
+        </Footer>
+      </Wrapper>
+    )
+  }
+}
+
+
+const formatProbability = prob => {
+  prob = prob * 100
+  return `${prob.toFixed(1)}%`
+}
+
+const Choices = ({output, logits, words, choose, probabilities}) => {
+  if (!words) { return null }
+
+  const lis = words.map((word, idx) => {
+    const logit = logits[idx]
+    const prob = formatProbability(probabilities[idx])
+
+    // get rid of CRs
+    const cleanWord = word.replace(/\n/g, "↵")
+
+    return (
+      <ListItem key={`${idx}-${cleanWord}`}>
+        <ChoiceItem onClick={() => choose(word)}>
+          <Probability>{prob}</Probability>
+          {' '}
+          <Token>{cleanWord}</Token>
+        </ChoiceItem>
+      </ListItem>
+    )
+  })
+
+  const goBack = () => {
+    window.history.back();
+  }
+
+  const goBackItem = (
+    <ListItem key="go-back">
+      {'history' in window ? (
+        <UndoButton onClick={goBack}>
+          <Probability>←</Probability>
+          {' '}
+          <Token>Undo</Token>
+        </UndoButton>
+      ) : null}
+    </ListItem>
+  )
+
+  return (
+    <ChoiceList>
+      {lis}
+      {goBackItem}
+    </ChoiceList>
+  )
+}
+
+/*
+
+class Gpt2Model extends React.Component {
+    constructor(props) {
+      super(props);
+
+      const { requestData, responseData } = props;
+
+      this.state = {
+        outputState: responseData ? "received" : "empty", // valid values: "working", "empty", "received", "error"
+        requestData: requestData,
+        responseData: responseData
+      };
+
+      this.runModel = this.runModel.bind(this)
+    }
+
+    runModel(inputs) {
+      const { selectedModel, apiUrl } = this.props
+
+      this.setState({outputState: "working"});
+
+      fetch(apiUrl(inputs), {
+        method: 'POST',
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(inputs)
+      }).then((response) => {
+        return response.json();
+      }).then((json) => {
+        // If the response contains a `slug` for a permalink, we want to redirect
+        // to the corresponding path using `history.push`.
+        const { slug } = json;
+        const newPath = slug ? `/${selectedModel}/${slug}` : `/${selectedModel}`
+
+        // We'll pass the request and response data along as part of the location object
+        // so that the `Demo` component can use them to re-render.
+        const location = {
+          pathname: newPath,
+          state: { requestData: inputs, responseData: json }
+        }
+        this.props.history.push(location);
+      }).catch((error) => {
+        this.setState({outputState: "error"});
+        console.error(error);
+      });
+    }
+
+    render() {
+        return <App/>
+    }
+}
+*/
+
+const modelProps = {}
+
+export default withRouter(props => <App {...props} {...modelProps}/>)

--- a/demo/src/components/demos/Gpt2scratch.js
+++ b/demo/src/components/demos/Gpt2scratch.js
@@ -1,3 +1,0 @@
-
-
-ReactDOM.render(<App />, document.getElementById("app"))

--- a/demo/src/components/demos/Gpt2scratch.js
+++ b/demo/src/components/demos/Gpt2scratch.js
@@ -1,0 +1,3 @@
+
+
+ReactDOM.render(<App />, document.getElementById("app"))

--- a/demo/src/models.js
+++ b/demo/src/models.js
@@ -51,7 +51,7 @@ const modelGroups = [
         models: [
             {model: "textual-entailment", name: "Textual Entailment", component: TextualEntailment},
             {model: "event2mind", name: "Event2Mind", component: Event2Mind},
-            {model: "gpt2", name: "GPT-2", component: Gpt2},
+            {model: "gpt2", name: "Language Modeling", component: Gpt2},
             {model: "user-models", name: "Your model here!"}
         ]
     }

--- a/demo/src/models.js
+++ b/demo/src/models.js
@@ -10,7 +10,8 @@ import DependencyParser from './components/demos/DependencyParser';
 import WikiTables from './components/demos/WikiTables';
 import Nlvr from './components/demos/Nlvr';
 import Atis from './components/demos/Atis';
-import QuarelZero from './components/demos/QuarelZero'
+import QuarelZero from './components/demos/QuarelZero';
+import Gpt2 from './components/demos/Gpt2';
 
 // This is the order in which they will appear in the menu
 const modelGroups = [
@@ -50,6 +51,7 @@ const modelGroups = [
         models: [
             {model: "textual-entailment", name: "Textual Entailment", component: TextualEntailment},
             {model: "event2mind", name: "Event2Mind", component: Event2Mind},
+            {model: "gpt2", name: "GPT-2", component: Gpt2},
             {model: "user-models", name: "Your model here!"}
         ]
     }

--- a/models.json
+++ b/models.json
@@ -79,6 +79,7 @@
         "type": "gpt2",
         "archive_file": "https://storage.googleapis.com/allennlp/models/gpt2-345M-dump",
         "predictor_name": "",
-        "max_request_length": 10000
+        "max_request_length": 10000,
+        "memory": "3Gi"
     }
 }

--- a/models.json
+++ b/models.json
@@ -74,5 +74,11 @@
         "archive_file": "https://storage.googleapis.com/allennlp-public-models/quarel-parser-zero-2018.12.20.tar.gz",
         "predictor_name": "quarel-parser",
         "max_request_length": 6695
+    },
+    "gpt2": {
+        "type": "gpt2",
+        "archive_file": "https://storage.googleapis.com/allennlp/models/gpt2-345M-dump",
+        "predictor_name": "",
+        "max_request_length": 10000
     }
 }

--- a/models.json
+++ b/models.json
@@ -80,6 +80,6 @@
         "archive_file": "https://storage.googleapis.com/allennlp/models/gpt2-345M-dump",
         "predictor_name": "",
         "max_request_length": 10000,
-        "memory": "3Gi"
+        "memory": "4Gi"
     }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ allennlp
 psycopg2-binary
 sentry-sdk==0.7.1
 python-json-logger
+pytorch-pretrained-bert

--- a/server/demo_model.py
+++ b/server/demo_model.py
@@ -1,0 +1,26 @@
+from allennlp.predictors import Predictor
+from allennlp.models.archival import load_archive
+
+
+class DemoModel:
+    """
+    A demo model is determined by an archive file (representing the trained model), a
+    choice of predictor, and a limit on the maximum request length it can handle.
+
+    The initial max_request_length values were selected by querying the DB for:
+
+        with queries_with_len as (select *, char_length(request_data) as request_len from queries)
+            select model_name, max(request_len)/2 as max_lim from queries_with_len
+            where response_data is not null
+            group by model_name;
+
+    These limits affect less than 1% of queries for each model.
+    """
+    def __init__(self, archive_file: str, predictor_name: str, max_request_length: int) -> None:
+        self.archive_file = archive_file
+        self.predictor_name = predictor_name
+        self.max_request_length = max_request_length
+
+    def predictor(self) -> Predictor:
+        archive = load_archive(self.archive_file)
+        return Predictor.from_archive(archive, self.predictor_name)

--- a/server/gpt2.py
+++ b/server/gpt2.py
@@ -10,6 +10,11 @@ SMALL_MODEL = 'gpt2'
 MEDIUM_MODEL = 'https://storage.googleapis.com/allennlp/models/gpt2-345M-dump'
 
 class Gpt2Predictor(Predictor):
+    """
+    The HuggingFace implementation of GPT-2 is not an AllenNLP model;
+    however, our demo only expects an AllenNLP ``Predictor``. Accordingly,
+    we implement a ``Predictor`` that wraps the HuggingFace GPT-2 implementation.
+    """
     def __init__(self,
                  model_name: str = MEDIUM_MODEL,
                  cache_size: int = 0) -> None:
@@ -75,6 +80,7 @@ class Gpt2Predictor(Predictor):
 
     def __getitem__(self, index: int) -> str:
         return self.tokenizer.decode([index])
+
 
 class Gpt2DemoModel(DemoModel):
     def predictor(self) -> Predictor:

--- a/server/gpt2.py
+++ b/server/gpt2.py
@@ -1,0 +1,81 @@
+from allennlp.predictors import Predictor
+from pytorch_pretrained_bert.tokenization_gpt2 import GPT2Tokenizer
+from pytorch_pretrained_bert.modeling_gpt2 import GPT2LMHeadModel
+import torch
+
+from server.demo_model import DemoModel
+from server.lru_cache import LRUCache
+
+
+MEDIUM_MODEL = 'https://storage.googleapis.com/allennlp/models/gpt2-345M-dump'
+
+class Gpt2Predictor(Predictor):
+    def __init__(self,
+                 model_name: str = MEDIUM_MODEL,
+                 cache_size: int = 0) -> None:
+        """
+        Each cache element is about 8MB, so size accordingly.
+        """
+        # Cache stores tuples, so default value is a tuple
+        self._cache = LRUCache(cache_size, default_value=(None, None))
+        self.tokenizer = GPT2Tokenizer.from_pretrained('gpt2')
+        self.model = GPT2LMHeadModel.from_pretrained(MEDIUM_MODEL)
+
+        # The end of text marker.
+        self.END_OF_TEXT = self.tokenizer.encoder["<|endoftext|>"]
+
+
+    def predict_json(self, inputs: dict) -> dict:
+        previous_str = inputs["previous"]
+        next_str = inputs.get("next")
+        topk = inputs.get("topk", 10)
+
+        logits = self._predict(previous_str, next_str)
+        probabilities = torch.nn.functional.softmax(logits)
+
+        best_logits, best_indices = logits.topk(topk)
+        best_words = [self.tokenizer.decode([idx.item()])
+                      for idx in best_indices]
+        best_probabilities = probabilities[best_indices].tolist()
+
+        return {
+            "logits": best_logits.tolist(),
+            "probabilities": best_probabilities,
+            "words": best_words,
+            "output": previous_str + (next_str or "")
+        }
+
+    def _predict(self, previous: str, next: str = None) -> torch.Tensor:
+
+        past_logits, past = self._cache[previous]
+
+        # CASE 1: Previously seen input, no next
+        if next is None and past is not None:
+            return past_logits
+
+        # CASE 2: Previously seen input, yes next
+        elif past is not None:
+            token_ids = self.tokenizer.encode(next)
+        # CASE 3: Brand new input, no next
+        elif next is None:
+            token_ids = self.tokenizer.encode(previous)
+        # CASE 4: Brand new input, yes next
+        else:
+            token_ids = self.tokenizer.encode(previous) + self.tokenizer.encode(next)
+
+        inputs = torch.LongTensor([token_ids])
+
+        logits, present = self.model(inputs, past=past)
+        logits = logits[0, -1]
+
+        key = previous if next is None else previous + next
+        self._cache[key] = logits, present
+
+        return logits
+
+    def __getitem__(self, index: int) -> str:
+        return self.tokenizer.decode([index])
+
+class Gpt2DemoModel(DemoModel):
+    def predictor(self) -> Predictor:
+        return Gpt2Predictor(self.archive_file)

--- a/server/gpt2.py
+++ b/server/gpt2.py
@@ -6,12 +6,12 @@ import torch
 from server.demo_model import DemoModel
 from server.lru_cache import LRUCache
 
-
+SMALL_MODEL = 'gpt2'
 MEDIUM_MODEL = 'https://storage.googleapis.com/allennlp/models/gpt2-345M-dump'
 
 class Gpt2Predictor(Predictor):
     def __init__(self,
-                 model_name: str = MEDIUM_MODEL,
+                 model_name: str = SMALL_MODEL,
                  cache_size: int = 0) -> None:
         """
         Each cache element is about 8MB, so size accordingly.
@@ -19,7 +19,7 @@ class Gpt2Predictor(Predictor):
         # Cache stores tuples, so default value is a tuple
         self._cache = LRUCache(cache_size, default_value=(None, None))
         self.tokenizer = GPT2Tokenizer.from_pretrained('gpt2')
-        self.model = GPT2LMHeadModel.from_pretrained(MEDIUM_MODEL)
+        self.model = GPT2LMHeadModel.from_pretrained(model_name)
 
         # The end of text marker.
         self.END_OF_TEXT = self.tokenizer.encoder["<|endoftext|>"]

--- a/server/gpt2.py
+++ b/server/gpt2.py
@@ -11,7 +11,7 @@ MEDIUM_MODEL = 'https://storage.googleapis.com/allennlp/models/gpt2-345M-dump'
 
 class Gpt2Predictor(Predictor):
     def __init__(self,
-                 model_name: str = SMALL_MODEL,
+                 model_name: str = MEDIUM_MODEL,
                  cache_size: int = 0) -> None:
         """
         Each cache element is about 8MB, so size accordingly.

--- a/server/lru_cache.py
+++ b/server/lru_cache.py
@@ -1,0 +1,35 @@
+"""
+Based on https://www.kunxi.org/2014/05/lru-cache-in-python
+"""
+from typing import Dict, TypeVar, Generic, Optional
+from collections import OrderedDict
+
+K = TypeVar('K')
+V = TypeVar('V')
+
+class LRUCache(Generic[K, V]):
+    def __init__(self, capacity: int, default_value = None):
+        self._capacity = capacity
+        self._cache: Dict[K, V] = OrderedDict()
+        self._default_value = default_value
+
+    def __getitem__(self, key: K) -> Optional[V]:
+        if self._capacity == 0:
+            return self._default_value
+        try:
+            value = self._cache.pop(key)
+            self._cache[key] = value
+            return value
+        except KeyError:
+            return self._default_value
+
+    def __setitem__(self, key: K, value: V) -> None:
+        if self._capacity == 0:
+            return
+
+        try:
+            self._cache.pop(key)
+        except KeyError:
+            if len(self._cache) >= self._capacity:
+                self._cache.popitem(last=False)
+        self._cache[key] = value

--- a/server/models.py
+++ b/server/models.py
@@ -34,6 +34,8 @@ def load_demo_models(models_file: str,
         model = blob[task_name]
         model_type = model.get("type", "allennlp")
 
+        # If ever we introduce additional model types,
+        # we'll need to add corresponding logic here.
         if model_type == "allennlp":
             load = DemoModel
         elif model_type == "gpt2":


### PR DESCRIPTION
This is basically a port of the gpt2-explorer (345M model only) into the allennlp demo.

I did my best to change the visual language so that it "looks like" the rest of the allennlp demo.

This is the first model in the demo that's not actually an allennlp `Model`. However, the demo really just wants a `Predictor`, so I implemented a `Predictor` that just wraps the huggingface gpt-2 code. Then there's some if/then logic around whether to instantiate a predictor from a model archive (in the allennlp case), or some other way (in the gpt2 case).

I don't know that this is the best design for getting non-allennlp models into the demo, but it seems a reasonable first step.

The react code for this is less than ideal because it's a hybrid of the existing gpt2-explorer front-end code and the existing allennlp-demo front-end code. (And also because this demo is not input -> submit button -> results, like the other demos are.)

Anyway, if/when we put more non-allennlp models in the demo, we'll probably learn more about the best way to handle this case.