### PR TITLE
add basic sentiment analysis

### DIFF
--- a/app.py
+++ b/app.py
@@ -254,6 +254,8 @@ def make_app(build_dir: str,
             log_blob["outputs"]["document"] = prediction["document"]
         elif model_name == "textual-entailment":
             log_blob["outputs"]["label_probs"] = prediction["label_probs"]
+        elif model_name == "sentiment-analysis":
+            log_blob["outputs"]["probs"] = prediction["probs"]
         elif model_name == "named-entity-recognition":
             log_blob["outputs"]["tags"] = prediction["tags"]
         elif model_name == "semantic-role-labeling":

--- a/demo/src/components/demos/SentimentAnalysis.js
+++ b/demo/src/components/demos/SentimentAnalysis.js
@@ -2,25 +2,13 @@ import React from 'react';
 import { API_ROOT } from '../../api-config';
 import { withRouter } from 'react-router-dom';
 import Model from '../Model'
-import { Accordion } from 'react-accessible-accordion';
 import OutputField from '../OutputField'
-import SaliencyComponent from '../Saliency'
-import InputReductionComponent from '../InputReduction'
-import HotflipComponent from '../Hotflip'
 
 // APIs. These link to the functions in app.py
 const apiUrl = () => `${API_ROOT}/predict/sentiment-analysis`
-const hotflipUrl = () => `${API_ROOT}/hotflip/sentiment-analysis`
-const inputReductionUrl = () => `${API_ROOT}/input-reduction/sentiment-analysis`
-const apiUrlInterpret = ({interpreter}) => `${API_ROOT}/interpret/sentiment-analysis/${interpreter}`
 
 // title of the page
 const title = "Sentiment Analysis"
-
-// The interpreters
-const GRAD_INTERPRETER = 'simple_gradients_interpreter'
-const IG_INTERPRETER = 'integrated_gradients_interpreter'
-const SG_INTERPRETER = 'smooth_gradient_interpreter'
 
 // Text shown in the UI
 const description = (
@@ -37,30 +25,16 @@ const fields = [
 ]
 
 // What is rendered as Output when the user hits buttons on the demo.
-const Output = ({ responseData, requestData, interpretData, interpretModel, inputReductionData, hotflipData, reduceInput, hotflipInput}) => {
+const Output = ({ responseData, requestData}) => {
   const [positiveClassProbability, negativeClassProbability] = responseData['probs']
   const prediction = negativeClassProbability < positiveClassProbability ? "Positive" : "Negative"
-
-  var t = requestData;
-  var tokens = t['sentence'].split(' '); // this model expects space-separated inputs
-  var task = "sentiment";
-
-  // The "Answer" output field has the models predictions. The other output fields are the reusable HTML/JavaScript for the interpretation methods.
+  
+  // The "Answer" output field has the models predictions.
   return (
     <div className="model__content answer">
       <OutputField label="Answer">
       {prediction}
-      </OutputField>
-
-    <OutputField>
-    <Accordion accordion={false}>
-        <SaliencyComponent interpretData={interpretData} input1_tokens={tokens}  interpretModel = {interpretModel} requestData = {requestData} interpreter={GRAD_INTERPRETER}/>
-        <SaliencyComponent interpretData={interpretData} input1_tokens={tokens}  interpretModel = {interpretModel} requestData = {requestData} interpreter={IG_INTERPRETER}/>
-        <SaliencyComponent interpretData={interpretData} input1_tokens={tokens} interpretModel = {interpretModel} requestData = {requestData} interpreter={SG_INTERPRETER}/>
-        <InputReductionComponent inputReductionData={inputReductionData} reduceInput={reduceInput} requestDataObject={requestData}/>
-        <HotflipComponent hotflipData={hotflipData} hotflipInput={hotflipInput} requestDataObject={requestData} task={task} />
-    </Accordion>
-    </OutputField>
+      </OutputField>  
   </div>
   );
 }
@@ -74,5 +48,5 @@ const examples = [
 ]
 
 // A call to a pre-existing model component that handles all of the inputs and outputs. We just need to pass it the things we've already defined as props:
-const modelProps = {apiUrl, apiUrlInterpret, inputReductionUrl, hotflipUrl,title, description, descriptionEllipsed, fields, examples, Output}
+const modelProps = {apiUrl, title, description, descriptionEllipsed, fields, examples, Output}
 export default withRouter(props => <Model {...props} {...modelProps}/>)

--- a/demo/src/components/demos/SentimentAnalysis.js
+++ b/demo/src/components/demos/SentimentAnalysis.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import { API_ROOT } from '../../api-config';
+import { withRouter } from 'react-router-dom';
+import Model from '../Model'
+import { Accordion } from 'react-accessible-accordion';
+import OutputField from '../OutputField'
+
+// APIs. These link to the functions in app.py
+const apiUrl = () => `${API_ROOT}/predict/sentiment-analysis`
+
+// title of the page
+const title = "Sentiment Analysis"
+
+// Text shown in the UI
+const description = (
+  <span> Sentiment Analysis predicts whether an input is positive or negative. The model is a simple LSTM using GloVe embeddings that is trained on the binary classification setting of the <a href="https://nlp.stanford.edu/sentiment/treebank.html">Stanford Sentiment Treebank</a>. It achieves about 87% accuracy on the test set.</span>
+);
+const descriptionEllipsed = (  
+  <span> Sentiment Analysis predicts whether an input is positive or negative… </span>
+);
+
+// Input fields to the model.
+const fields = [
+  {name: "sentence", label: "Input", type: "TEXT_INPUT",
+   placeholder: 'E.g. "amazing movie"'}
+]
+  
+// What is rendered as Output when the user hits buttons on the demo.
+const Output = ({ responseData,requestData}) => {
+    var prediction = "";            
+    if (responseData['probs'][1] < responseData['probs'][0]){  // if probability(negative_class) < probability(positive_class)  
+        prediction = "Positive";
+    }
+    else{
+      prediction = "Negative";
+    }
+  
+  // The "Answer" output field has the models predictions. The other output fields are the reusable HTML/JavaScript for the interpretation methods.
+  return (
+    <div className="model__content answer">        
+      <OutputField label="Answer"> {prediction} </OutputField>
+    </div>
+  );
+}
+
+// Examples the user can choose from in the demo
+const examples = [
+  { sentence: "a very well-made, funny and entertaining picture." },
+  { sentence: "so unremittingly awful that labeling it a dog probably constitutes cruelty to canines" },  
+  { sentence: "all the amped up tony hawk style stunts and thrashing rap-metal can't disguise the fact that, really, we've been here, done that."},  
+  { sentence: "visually imaginative, thematically instructive and thoroughly delightful, it takes us on a roller-coaster ride from innocence to experience without even a hint of that typical kiddie-flick sentimentality."}
+]
+
+// A call to a pre-existing model component that handles all of the inputs and outputs. We just need to pass it the things we've already defined as props:
+const modelProps = {apiUrl, title, description, descriptionEllipsed, fields, examples, Output}
+export default withRouter(props => <Model {...props} {...modelProps}/>)

--- a/demo/src/components/demos/SentimentAnalysis.js
+++ b/demo/src/components/demos/SentimentAnalysis.js
@@ -4,18 +4,29 @@ import { withRouter } from 'react-router-dom';
 import Model from '../Model'
 import { Accordion } from 'react-accessible-accordion';
 import OutputField from '../OutputField'
+import SaliencyComponent from '../Saliency'
+import InputReductionComponent from '../InputReduction'
+import HotflipComponent from '../Hotflip'
 
 // APIs. These link to the functions in app.py
 const apiUrl = () => `${API_ROOT}/predict/sentiment-analysis`
+const hotflipUrl = () => `${API_ROOT}/hotflip/sentiment-analysis`
+const inputReductionUrl = () => `${API_ROOT}/input-reduction/sentiment-analysis`
+const apiUrlInterpret = ({interpreter}) => `${API_ROOT}/interpret/sentiment-analysis/${interpreter}`
 
 // title of the page
 const title = "Sentiment Analysis"
+
+// The interpreters
+const GRAD_INTERPRETER = 'simple_gradients_interpreter'
+const IG_INTERPRETER = 'integrated_gradients_interpreter'
+const SG_INTERPRETER = 'smooth_gradient_interpreter'
 
 // Text shown in the UI
 const description = (
   <span> Sentiment Analysis predicts whether an input is positive or negative. The model is a simple LSTM using GloVe embeddings that is trained on the binary classification setting of the <a href="https://nlp.stanford.edu/sentiment/treebank.html">Stanford Sentiment Treebank</a>. It achieves about 87% accuracy on the test set.</span>
 );
-const descriptionEllipsed = (  
+const descriptionEllipsed = (
   <span> Sentiment Analysis predicts whether an input is positive or negative… </span>
 );
 
@@ -24,33 +35,44 @@ const fields = [
   {name: "sentence", label: "Input", type: "TEXT_INPUT",
    placeholder: 'E.g. "amazing movie"'}
 ]
-  
+
 // What is rendered as Output when the user hits buttons on the demo.
-const Output = ({ responseData,requestData}) => {
-    var prediction = "";            
-    if (responseData['probs'][1] < responseData['probs'][0]){  // if probability(negative_class) < probability(positive_class)  
-        prediction = "Positive";
-    }
-    else{
-      prediction = "Negative";
-    }
-  
+const Output = ({ responseData, requestData, interpretData, interpretModel, inputReductionData, hotflipData, reduceInput, hotflipInput}) => {
+  const [positiveClassProbability, negativeClassProbability] = responseData['probs']
+  const prediction = negativeClassProbability < positiveClassProbability ? "Positive" : "Negative"
+
+  var t = requestData;
+  var tokens = t['sentence'].split(' '); // this model expects space-separated inputs
+  var task = "sentiment";
+
   // The "Answer" output field has the models predictions. The other output fields are the reusable HTML/JavaScript for the interpretation methods.
   return (
-    <div className="model__content answer">        
-      <OutputField label="Answer"> {prediction} </OutputField>
-    </div>
+    <div className="model__content answer">
+      <OutputField label="Answer">
+      {prediction}
+      </OutputField>
+
+    <OutputField>
+    <Accordion accordion={false}>
+        <SaliencyComponent interpretData={interpretData} input1_tokens={tokens}  interpretModel = {interpretModel} requestData = {requestData} interpreter={GRAD_INTERPRETER}/>
+        <SaliencyComponent interpretData={interpretData} input1_tokens={tokens}  interpretModel = {interpretModel} requestData = {requestData} interpreter={IG_INTERPRETER}/>
+        <SaliencyComponent interpretData={interpretData} input1_tokens={tokens} interpretModel = {interpretModel} requestData = {requestData} interpreter={SG_INTERPRETER}/>
+        <InputReductionComponent inputReductionData={inputReductionData} reduceInput={reduceInput} requestDataObject={requestData}/>
+        <HotflipComponent hotflipData={hotflipData} hotflipInput={hotflipInput} requestDataObject={requestData} task={task} />
+    </Accordion>
+    </OutputField>
+  </div>
   );
 }
 
 // Examples the user can choose from in the demo
 const examples = [
   { sentence: "a very well-made, funny and entertaining picture." },
-  { sentence: "so unremittingly awful that labeling it a dog probably constitutes cruelty to canines" },  
-  { sentence: "all the amped up tony hawk style stunts and thrashing rap-metal can't disguise the fact that, really, we've been here, done that."},  
+  { sentence: "so unremittingly awful that labeling it a dog probably constitutes cruelty to canines" },
+  { sentence: "all the amped up tony hawk style stunts and thrashing rap-metal can't disguise the fact that, really, we've been here, done that."},
   { sentence: "visually imaginative, thematically instructive and thoroughly delightful, it takes us on a roller-coaster ride from innocence to experience without even a hint of that typical kiddie-flick sentimentality."}
 ]
 
 // A call to a pre-existing model component that handles all of the inputs and outputs. We just need to pass it the things we've already defined as props:
-const modelProps = {apiUrl, title, description, descriptionEllipsed, fields, examples, Output}
+const modelProps = {apiUrl, apiUrlInterpret, inputReductionUrl, hotflipUrl,title, description, descriptionEllipsed, fields, examples, Output}
 export default withRouter(props => <Model {...props} {...modelProps}/>)

--- a/demo/src/models.js
+++ b/demo/src/models.js
@@ -23,7 +23,8 @@ const modelGroups = [
             {model: "named-entity-recognition", name: "Named Entity Recognition", component: NamedEntityRecognition},
             {model: "constituency-parsing", name: "Constituency Parsing", component: ConstituencyParser},
             {model: "dependency-parsing", name: "Dependency Parsing", component: DependencyParser},
-            {model: "open-information-extraction", name: "Open Information Extraction", component: OpenIe}
+            {model: "open-information-extraction", name: "Open Information Extraction", component: OpenIe},
+            {model: "sentiment-analysis", name: "Sentiment Analysis", component: SentimentAnalysis}
         ]
     },
     {
@@ -50,8 +51,7 @@ const modelGroups = [
     {
         label: "Other",
         models: [
-            {model: "textual-entailment", name: "Textual Entailment", component: TextualEntailment},
-            {model: "sentiment-analysis", name: "Sentiment Analysis", component: SentimentAnalysis},
+            {model: "textual-entailment", name: "Textual Entailment", component: TextualEntailment},           
             {model: "event2mind", name: "Event2Mind", component: Event2Mind},
             {model: "gpt2", name: "Language Modeling", component: Gpt2},
             {model: "user-models", name: "Your model here!"}

--- a/demo/src/models.js
+++ b/demo/src/models.js
@@ -2,6 +2,7 @@ import SemanticRoleLabeling from './components/demos/SemanticRoleLabeling';
 import OpenIe from './components/demos/OpenIe';
 import Event2Mind from './components/demos/Event2Mind';
 import TextualEntailment from './components/demos/TextualEntailment';
+import SentimentAnalysis from './components/demos/SentimentAnalysis';
 import ReadingComprehension from './components/demos/ReadingComprehension';
 import Coref from './components/demos/Coref';
 import NamedEntityRecognition from './components/demos/NamedEntityRecognition';
@@ -50,6 +51,7 @@ const modelGroups = [
         label: "Other",
         models: [
             {model: "textual-entailment", name: "Textual Entailment", component: TextualEntailment},
+            {model: "sentiment-analysis", name: "Sentiment Analysis", component: SentimentAnalysis},
             {model: "event2mind", name: "Event2Mind", component: Event2Mind},
             {model: "gpt2", name: "Language Modeling", component: Gpt2},
             {model: "user-models", name: "Your model here!"}

--- a/demo/src/models.js
+++ b/demo/src/models.js
@@ -51,7 +51,7 @@ const modelGroups = [
     {
         label: "Other",
         models: [
-            {model: "textual-entailment", name: "Textual Entailment", component: TextualEntailment},           
+            {model: "textual-entailment", name: "Textual Entailment", component: TextualEntailment},
             {model: "event2mind", name: "Event2Mind", component: Event2Mind},
             {model: "gpt2", name: "Language Modeling", component: Gpt2},
             {model: "user-models", name: "Your model here!"}

--- a/models.json
+++ b/models.json
@@ -81,5 +81,10 @@
         "predictor_name": "",
         "max_request_length": 10000,
         "memory": "4Gi"
+    },
+    "sentiment-analysis": {
+        "archive_file": "https://s3-us-west-2.amazonaws.com/allennlp/models/sst-2-basic-classifier-glove-2019.06.27.tar.gz",
+        "predictor_name": "text_classifier",
+        "max_request_length": 1000
     }
 }


### PR DESCRIPTION
This adds a sentiment analysis to the demo with a simple GloVe LSTM model. We use this in the AllenNLP interpret demo. 

The UI for the answer is just the word "Positive" or "Negative". I don't know if this is fine, or if a front-end person wants to add something prettier. 

I also didn't modify the .skiff/webapp.json file, which I am guessing is auto-generated?