### PR TITLE
Allow minor / revision updates for Varnish.

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@allenai/varnish": "0.3.16",
+    "@allenai/varnish": "^0.3.16",
     "antd": "^3.20.0",
     "hierplane": "^0.1.0",
     "lodash": "^4.17.11",

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@allenai/varnish@0.3.16":
+"@allenai/varnish@^0.3.16":
   version "0.3.16"
   resolved "https://registry.yarnpkg.com/@allenai/varnish/-/varnish-0.3.16.tgz#6e6c77f2049b28aff4610c50f2e739b0e6378619"
   integrity sha512-ecjus+q7BBEeZ5UQoRPpekNwhTgKqUM3zYiG+e6qs43BGlbxrYBV/ADpxhPVlguA6bpu0exhvA5ZyApyinSIKQ==


### PR DESCRIPTION
This modifies the dependency fix I just made so that minor / revision
updates are automatically installed from Varnish if the appropriate
update / upgrade command is used (I can't remember the exact command,
and I think it's different between yarn and npm).

Sorry for the noise @joelgrus.