### PR TITLE
Fix #235; Display something nice if there's no output.

### DIFF
--- a/demo/src/components/demos/SemanticRoleLabeling.js
+++ b/demo/src/components/demos/SemanticRoleLabeling.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ExternalLink } from  '@allenai/varnish/components';
 import { withRouter } from 'react-router-dom';
+import styled from 'styled-components';
 
 import { API_ROOT } from '../../api-config';
 import Model from '../Model'
@@ -178,9 +179,13 @@ function toHierplaneTrees(response) {
 
 const VisualizationType = {
   TREE: 'Tree',
-  TEXT: 'Text'
+  TEXT: 'Text',
 };
 Object.freeze(VisualizationType);
+
+const NoOutputMessage = styled.div`
+  padding: 2rem;
+`;
 
 // Stateful output component
 class Output extends React.Component {
@@ -196,14 +201,26 @@ class Output extends React.Component {
         const { verbs } = responseData
 
         let viz = null;
-        switch(visualizationType) {
-          case VisualizationType.TEXT:
-            viz = <TextVisualization verbs={verbs} model="srl"/>;
-            break;
-          case VisualizationType.TREE:
-          default:
-            viz = <HierplaneVisualization trees={toHierplaneTrees(responseData)} />
-            break;
+
+        // If there's no verbs, there's no output to display.
+        if (Array.isArray(verbs) && verbs.length > 0) {
+          switch(visualizationType) {
+            case VisualizationType.TEXT:
+              viz = <TextVisualization verbs={verbs} model="srl" />;
+              break;
+            case VisualizationType.TREE:
+            default:
+              viz = <HierplaneVisualization trees={toHierplaneTrees(responseData)} />
+              break;
+          }
+        }
+
+        if (viz == null) {
+          return (
+            <NoOutputMessage>
+              No output. Please revise the sentence and try again.
+            </NoOutputMessage>
+          );
         }
 
         return (

--- a/demo/src/components/demos/SemanticRoleLabeling.js
+++ b/demo/src/components/demos/SemanticRoleLabeling.js
@@ -179,7 +179,7 @@ function toHierplaneTrees(response) {
 
 const VisualizationType = {
   TREE: 'Tree',
-  TEXT: 'Text',
+  TEXT: 'Text'
 };
 Object.freeze(VisualizationType);
 


### PR DESCRIPTION
Hierplane throws up a nasty stack trace when there's no output
returned from the backend. This handles that scenario cleanly by
rendering a message asking the user to alter their input.