### PR TITLE
Better organize logs in Stackdriver

### DIFF
--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -332,7 +332,7 @@ local model_deployment(model_name) = {
             spec: {
                 containers: [
                     {
-                        name: "model",
+                        name: model_name,
                         image: image,
                         args: [ '--model', model_name ],
                         readinessProbe: readinessProbe,


### PR DESCRIPTION
Set the container name to something more descriptive so logs are better organized in Stackdriver.  Currently everything just shows up under "model".

Fixes https://github.com/allenai/allennlp-demo/issues/243