### PR TITLE
Remove sentry.

### DIFF
--- a/app.py
+++ b/app.py
@@ -36,11 +36,6 @@ logging.getLogger("allennlp").setLevel(logging.WARN)
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 logger.setLevel(logging.INFO)
 
-if "SENTRY_PYTHON_AUTH" in os.environ:
-    logger.info("Enabling Sentry since SENTRY_PYTHON_AUTH is defined.")
-    import sentry_sdk
-    sentry_sdk.init(os.environ.get("SENTRY_PYTHON_AUTH"))
-
 handler = logging.StreamHandler(sys.stdout)
 handler.setFormatter(StackdriverJsonFormatter())
 handler.setLevel(logging.INFO)

--- a/demo/public/index.html
+++ b/demo/public/index.html
@@ -18,10 +18,6 @@
         ga('send', 'pageview');
       }
     </script>
-    <script src="https://browser.sentry-cdn.com/4.5.3/bundle.min.js" crossorigin="anonymous"></script>
-    <script>
-        Sentry.init({ dsn: 'https://e9dabc6e122e439e9d5166f48545409c@sentry.io/1389480' });
-    </script>
   </head>
   <body>
     <noscript>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 psycopg2-binary
-sentry-sdk==0.7.1
 python-json-logger
 pytorch-pretrained-bert


### PR DESCRIPTION
We don't use the data and it's causing some errors.  This is easier than troubleshooting.