### PR TITLE
UI Improvements Demo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This Dockerfile is used to serve the AllenNLP demo.
 
-FROM allennlp/commit:2a950223792ef816971e9e9aa35f38c32b9c0785
+FROM allennlp/commit:d09042e49226bd7fa04a4e37cd63aa46d7ccd2f1
 LABEL maintainer="allennlp-contact@allenai.org"
 
 WORKDIR /stage/allennlp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This Dockerfile is used to serve the AllenNLP demo.
 
-FROM allennlp/commit:76d248f814967541b8e69959ac68c6979a1d1a30
+FROM allennlp/commit:2a950223792ef816971e9e9aa35f38c32b9c0785
 LABEL maintainer="allennlp-contact@allenai.org"
 
 WORKDIR /stage/allennlp

--- a/app.py
+++ b/app.py
@@ -25,8 +25,8 @@ import pytz
 
 from allennlp.common.util import JsonDict, peak_memory_mb
 from allennlp.predictors import Predictor
-from allennlp.interpret.saliency_interpreters import SimpleGradient, IntegratedGradient, SmoothGradient
-from allennlp.interpret.attackers import InputReduction, Hotflip
+from allennlp.interpret.saliency_interpreters import SaliencyInterpreter, SimpleGradient, IntegratedGradient, SmoothGradient
+from allennlp.interpret.attackers import Attacker, InputReduction, Hotflip 
 
 from server.permalinks import int_to_slug, slug_to_int
 from server.db import DemoDatabase, PostgresDemoDatabase
@@ -75,6 +75,8 @@ class ServerError(Exception):
 def main(demo_dir: str,
          port: int,
          cache_size: int,
+         interpret_cache_size: int,
+         attack_cache_size: int,
          models: Dict[str, DemoModel]) -> None:
     """Run the server programatically"""
     logger.info("Starting a flask server on port %i.", port)
@@ -102,7 +104,9 @@ def main(demo_dir: str,
 def make_app(build_dir: str,
              models: Dict[str, DemoModel],
              demo_db: Optional[DemoDatabase] = None,
-             cache_size: int = 128) -> Flask:
+             cache_size: int = 128,
+             interpret_cache_size: int = 128,
+             attack_cache_size: int = 128) -> Flask:
     if not os.path.exists(build_dir):
         logger.error("app directory %s does not exist, aborting", build_dir)
         sys.exit(-1)
@@ -166,7 +170,32 @@ def make_app(build_dir: str,
         Just a wrapper around ``model.predict_json`` that allows us to use a cache decorator.
         """
         return model.predict_json(json.loads(data))
+    
+    
+        attack = attacker.attack_from_json(inputs=data,
+                                           input_field_to_attack=input_field_to_attack,
+                                           grad_input_field=grad_input_field,
+                                           target=target)
+        
+        
+    @lru_cache(maxsize=interpret_cache_size)
+    def _caching_interpret(interpreter: SaliencyInterpreter, data: str) -> JsonDict:
+        """
+        Just a wrapper around ``model.interpret_from_json`` that allows us to use a cache decorator.
+        """
+        return interpreter.saliency_interpret_from_json(json.loads(data))
 
+    @lru_cache(maxsize=attack_cache_size)
+    def _caching_attack(attacker: Attacker, data: str, input_field_to_attack: str, grad_input_field: str, target: str) -> JsonDict:
+        attacker, json.dumps(data), input_field_to_attack, grad_input_field, target
+        """
+        Just a wrapper around ``model.attack_from_json`` that allows us to use a cache decorator.
+        """
+        return attacker.attack_from_json(inputs=json.loads(data),
+                                         input_field_to_attack=input_field_to_attack,
+                                         grad_input_field=grad_input_field,
+                                         target=target)
+    
     @app.route('/')
     def index() -> Response: # pylint: disable=unused-variable
         return send_file(os.path.join(build_dir, 'index.html'))
@@ -334,6 +363,10 @@ def make_app(build_dir: str,
         """
         if request.method == "OPTIONS":
             return Response(response="", status=200)
+        
+        # Do use the cache if no argument is specified
+        use_cache = request.args.get("cache", "true").lower() != "false"
+
         lowered_model_name = model_name.lower()
 
         data = request.get_json()
@@ -354,11 +387,27 @@ def make_app(build_dir: str,
         if len(serialized_request) > max_request_length:
             raise ServerError(f"Max request length exceeded for model {model_name}! " +
                               f"Max: {max_request_length} Actual: {len(serialized_request)}")
+        
+        pre_hits = _caching_attack.cache_info().hits  # pylint: disable=no-value-for-parameter
 
-        attack = attacker.attack_from_json(inputs=data,
-                                           input_field_to_attack=input_field_to_attack,
-                                           grad_input_field=grad_input_field,
-                                           target=target)
+        if use_cache and attack_cache_size > 0:
+            # lru_cache insists that all function arguments be hashable,
+            # so unfortunately we have to stringify the data.
+            attack = _caching_attack(attacker, json.dumps(data), input_field_to_attack, grad_input_field, target)
+            
+        else:
+            # if cache_size is 0, skip caching altogether
+            attack = attacker.attack_from_json(inputs=data,
+                                               input_field_to_attack=input_field_to_attack,
+                                               grad_input_field=grad_input_field,
+                                               target=target)
+
+        post_hits = _caching_attack.cache_info().hits  # pylint: disable=no-value-for-parameter
+        
+        if use_cache and post_hits > pre_hits:
+            # Cache hit, so insert an artifical pause
+            time.sleep(0.25)
+
         return jsonify(attack)
 
     @app.route('/interpret/<model_name>', methods=['POST', 'OPTIONS'])
@@ -368,8 +417,12 @@ def make_app(build_dir: str,
         """
         if request.method == "OPTIONS":
             return Response(response="", status=200)
-        lowered_model_name = model_name.lower()
 
+        # Do use the cache if no argument is specified
+        use_cache = request.args.get("cache", "true").lower() != "false"
+
+        lowered_model_name = model_name.lower()
+    
         data = request.get_json()
         interpreter_name = data.pop("interpreter")
 
@@ -387,7 +440,22 @@ def make_app(build_dir: str,
             raise ServerError(f"Max request length exceeded for interpreter {model_name}! " +
                               f"Max: {max_request_length} Actual: {len(serialized_request)}")
 
-        interpretation = interpreter.saliency_interpret_from_json(data)
+        pre_hits = _caching_interpret.cache_info().hits  # pylint: disable=no-value-for-parameter
+
+        if use_cache and interpret_cache_size > 0:
+            # lru_cache insists that all function arguments be hashable,
+            # so unfortunately we have to stringify the data.
+            interpretation = _caching_interpret(interpreter, json.dumps(data))
+        else:
+            # if cache_size is 0, skip caching altogether
+            interpretation = interpreter.saliency_interpret_from_json(data)
+
+        post_hits = _caching_prediction.cache_info().hits  # pylint: disable=no-value-for-parameter
+        
+        if use_cache and post_hits > pre_hits:
+            # Cache hit, so insert an artifical pause
+            time.sleep(0.25)
+            
         return jsonify(interpretation)
 
     @app.route('/models')
@@ -453,6 +521,8 @@ if __name__ == "__main__":
     parser.add_argument('--port', type=int, default=8000, help='port to serve the demo on')
     parser.add_argument('--demo-dir', type=str, default='demo/', help="directory where the demo HTML is located")
     parser.add_argument('--cache-size', type=int, default=128, help="how many results to keep in memory")
+    parser.add_argument('--interpret-cache-size', type=int, default=128, help="how many interpretation results to keep in memory")
+    parser.add_argument('--attack-cache-size', type=int, default=128, help="how many attack results to keep in memory")
     parser.add_argument('--models-file', type=str, default='models.json', help="json file containing the details of the models to load")
 
     models_group = parser.add_mutually_exclusive_group()
@@ -466,4 +536,6 @@ if __name__ == "__main__":
     main(demo_dir=args.demo_dir,
          port=args.port,
          cache_size=args.cache_size,
+         interpret_cache_size=args.interpret_cache_size,
+         attack_cache_size=args.attack_cache_size,
          models=models)

--- a/app.py
+++ b/app.py
@@ -129,6 +129,9 @@ def make_app(build_dir: str,
             app.max_request_lengths[name] = demo_model.max_request_length
 
             if name in supported_interpret_models:
+                app.interpreters[name]['simple_gradient'] = SimpleGradient(predictor)
+                app.interpreters[name]['integrated_gradient'] = IntegratedGradient(predictor)
+                app.interpreters[name]['smooth_gradient'] = SmoothGradient(predictor)
                 app.attackers[name]["input_reduction"] = InputReduction(predictor)
                 if name == 'masked-lm':
                     app.attackers[name]["hotflip"] = Hotflip(predictor, 'bert')
@@ -144,10 +147,6 @@ def make_app(build_dir: str,
                 else:
                     app.attackers[name]["hotflip"] = Hotflip(predictor)
                     app.attackers[name]["hotflip"].initialize()
-
-                app.interpreters[name]['simple_gradient'] = SimpleGradient(predictor)
-                app.interpreters[name]['integrated_gradient'] = IntegratedGradient(predictor)
-                app.interpreters[name]['smooth_gradient'] = SmoothGradient(predictor)
 
     # Disable caching for HTML documents and API responses so that clients
     # always talk to the source (this server).

--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -131,13 +131,24 @@ class SingleTaskDemo extends React.Component {
         // This is a model we know the component for, so render it.
         return React.createElement(modelComponents[selectedModel], {requestData, responseData, selectedModel, updateData})
     } else if (selectedModel === "user-models") {
+       const developLocallyHeader = "Developing Locally"
+       const developLocallyDescription = (
+        <span>
+          <span>
+            It's possible to run this demo locally with your own model (e.g., to visualize or interpret its predictions). See
+          </span>
+          <ExternalLink href="https://github.com/allenai/allennlp-demo#contributing-a-new-model-to-the-demo" target="_blank" rel="noopener">{' '} this tutorial </ExternalLink>
+          <span>
+            for more information.
+          </span>
+        </span>
       const modelRequest = "User Contributed Models"
       const modelDescription = (
         <span>
           <span>
-            AllenNLP is looking to add contributed models implemented using AllenNLP as either library components or demos (with free hosting!).
+            We are also looking to add user contributed AllenNLP models as either components in the AllenNLP library and optionally on this demo site (with free hosting!).
             If you have a published result or novel model demonstrating strong performance on a dataset and you are interested
-            in adding your model to a list of publically available implementations, as a service to this demo, or as a component in the library itself,
+            in adding your model to a list of publicly available implementations, as a service to this demo, or as a component in the library itself,
             please consider opening an issue on our
           </span>
           <ExternalLink href="https://github.com/allenai/allennlp/issues" target="_blank" rel="noopener">{' '} public Github repository </ExternalLink>
@@ -145,12 +156,15 @@ class SingleTaskDemo extends React.Component {
             or sending us an email at allennlp-contact@allenai.org to discuss what you have in mind.
           </span>
         </span>
+
       );
 
       return (
         <div className="model model__content">
           <div className='model__content'>
             <PaneTop>
+              <ModelIntro title={developLocallyHeader} description={developLocallyDescription}/>
+              <br>
               <ModelIntro title={modelRequest} description={modelDescription}/>
             </PaneTop>
           </div>

--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -131,17 +131,18 @@ class SingleTaskDemo extends React.Component {
         // This is a model we know the component for, so render it.
         return React.createElement(modelComponents[selectedModel], {requestData, responseData, selectedModel, updateData})
     } else if (selectedModel === "user-models") {
-       const developLocallyHeader = "Developing Locally"
-       const developLocallyDescription = (
-        <span>
+     const developLocallyHeader = "Developing Locally"
+     const developLocallyDescription = (
           <span>
-            It's possible to run this demo locally with your own model (e.g., to visualize or interpret its predictions). See
+            <span>
+              It's possible to run this demo locally with your own model (e.g., to visualize or interpret its predictions). See
+            </span>
+            <ExternalLink href="https://github.com/allenai/allennlp-demo#contributing-a-new-model-to-the-demo" target="_blank" rel="noopener">{' '} this tutorial </ExternalLink>
+            <span>
+              for more information.
+            </span>
           </span>
-          <ExternalLink href="https://github.com/allenai/allennlp-demo#contributing-a-new-model-to-the-demo" target="_blank" rel="noopener">{' '} this tutorial </ExternalLink>
-          <span>
-            for more information.
-          </span>
-        </span>
+       );
       const modelRequest = "User Contributed Models"
       const modelDescription = (
         <span>
@@ -164,7 +165,7 @@ class SingleTaskDemo extends React.Component {
           <div className='model__content'>
             <PaneTop>
               <ModelIntro title={developLocallyHeader} description={developLocallyDescription}/>
-              <br>
+              <br />
               <ModelIntro title={modelRequest} description={modelDescription}/>
             </PaneTop>
           </div>

--- a/demo/src/components/Hotflip.js
+++ b/demo/src/components/Hotflip.js
@@ -51,14 +51,21 @@ export default class HotflipComponent extends React.Component {
       activeIds: [],
       activeDepths: {ids:[],depths:[]},
       selectedId: null,
-      isClicking: false
+      isClicking: false,
+      loading: false,
     };
 
+    this.callAttackFunction = this.callAttackFunction.bind(this);
     this.updateTargetWord = this.updateTargetWord.bind(this);
     this.handleHighlightMouseDown = this.handleHighlightMouseDown.bind(this);
     this.handleHighlightMouseOver = this.handleHighlightMouseOver.bind(this);
     this.handleHighlightMouseOut = this.handleHighlightMouseOut.bind(this);
     this.handleHighlightMouseUp = this.handleHighlightMouseUp.bind(this);
+  }
+
+  callAttackFunction = attackFunction => () => {
+    this.setState({ ...this.state, loading: true})
+    attackFunction(this.state)
   }
 
   handleHighlightMouseDown(id, depth) {
@@ -124,7 +131,7 @@ export default class HotflipComponent extends React.Component {
                         type="button"
                         className="btn"
                         style={{margin: "30px 0px"}}
-                        onClick={ () => hotflipFunction(this.state) }
+                        onClick={this.callAttackFunction(hotflipFunction)}
                        >
                          Flip Words
                       </button>
@@ -143,7 +150,12 @@ export default class HotflipComponent extends React.Component {
         {runButton}
       </div>
 
-    const flippedDisplay = (flippedString === " ") ?
+    const controlDisplay = (this.state.loading && flippedString === " ") ?
+      <div><p style={{color: "#7c7c7c"}}>Loading attack...</p></div>
+    :
+      buttonDisplay
+
+    const resultDisplay = (flippedString === " ") ?
       ""
     :
       <div>
@@ -163,8 +175,8 @@ export default class HotflipComponent extends React.Component {
                 <p>
                     <a href="https://arxiv.org/abs/1712.06751" target="_blank" rel="noopener noreferrer">HotFlip</a> flips words in the input to change the model's prediction. We iteratively flip the input word with the highest gradient until the prediction changes.
                 </p>
-                {flippedDisplay}
-                {buttonDisplay}
+                {resultDisplay}
+                {controlDisplay}
             </AccordionItemBody>
         </AccordionItem>
     )

--- a/demo/src/components/InputReduction.js
+++ b/demo/src/components/InputReduction.js
@@ -52,20 +52,39 @@ const colorizeTokensForInputReductionUI = (originalInput, reducedInput) => {
 }
 
 export default class InputReductionComponent extends React.Component {
+    constructor(props) {
+      super(props)
+
+      this.state = {
+        loading: false,
+      }
+
+      this.callReduceFunction = this.callReduceFunction.bind(this)
+    }
+
+    callReduceFunction = reduceFunction => () => {
+      this.setState({ ...this.state, loading: true})
+      reduceFunction({})
+    }
+
     render() {
         const { reduceFunction, reducedInput } = this.props
         const runButton = <button
                             type="button"
                             className="btn"
                             style={{margin: "30px 0px"}}
-                            onClick={ () => reduceFunction({}) }
+                            onClick={this.callReduceFunction(reduceFunction) }
                            >
                              Reduce Input
                           </button>
 
         let displayText = '';
         if (reducedInput === undefined) {
-            displayText = <div><p style={{color: "#7c7c7c"}}>Press "reduce input" to run input reduction.</p>{runButton}</div>
+            if (this.state.loading) {
+              displayText = <div><p style={{color: "#7c7c7c"}}>Loading reduction...</p></div>
+            } else {
+              displayText = <div><p style={{color: "#7c7c7c"}}>Press "reduce input" to run input reduction.</p>{runButton}</div>
+            }
         } else {
             // There are a number of ways to tweak the output of this component:
             // (1) you can provide a context, which shows up on top, e.g., for displaying the

--- a/demo/src/components/Saliency.js
+++ b/demo/src/components/Saliency.js
@@ -144,6 +144,7 @@ export class SaliencyComponent extends React.Component {
           </div>
         )
         saliencyMaps.push(saliencyMap);
+        saliencyMaps.reverse(); // list of interpretations (only used by NER currently) are in the opposite order.
       }
       displayText = <div>{saliencyMaps}</div>
     }

--- a/demo/src/components/Saliency.js
+++ b/demo/src/components/Saliency.js
@@ -138,7 +138,7 @@ export class SaliencyComponent extends React.Component {
             {colorMap}
             <Tooltip /> <input type="range" min={0} max={colorMap.length} step="1" value={k} className="slider" onChange={this.handleInputTopKChange(i)} style={{ padding: "0px", margin: "10px 0px" }} />
             <br/>
-            <span style={{ color: "#72BCFF" }}>Visualizing the top {k} words.</span>
+            <span style={{ color: "#72BCFF" }}>Visualizing the top {k} most important words.</span>
             <br />
             <br />
           </div>

--- a/demo/src/components/Saliency.js
+++ b/demo/src/components/Saliency.js
@@ -61,8 +61,10 @@ export class SaliencyComponent extends React.Component {
 
     this.state = {
       topK: {all: 3}, // 3 words are highlighted by default
+      loading: false,
     }
 
+    this.callInterpretModel = this.callInterpretModel.bind(this)
     this.colorize = this.colorize.bind(this)
     this.handleInputTopKChange = this.handleInputTopKChange.bind(this)
     this.getTopKIndices = this.getTopKIndices.bind(this)
@@ -74,6 +76,11 @@ export class SaliencyComponent extends React.Component {
       format: 'hex',
       nshades: 20
     }
+  }
+
+  callInterpretModel = interpretModel => () => {
+    this.setState({ ...this.state, loading: true})
+    interpretModel()
   }
 
   colorize(tokensWithWeights, topKIdx) {
@@ -130,14 +137,18 @@ export class SaliencyComponent extends React.Component {
                         type="button"
                         className="btn"
                         style={{margin: "30px 0px"}}
-                        onClick={interpretModel}
+                        onClick={this.callInterpretModel(interpretModel)}
                        >
                          Interpret Prediction
                       </button>
 
     let displayText = '';
     if (interpretData === undefined) {
-      displayText = <div><p style={{color: "#7c7c7c"}}>Press "interpret prediction" to show the interpretation.</p>{runButton}</div>
+      if (this.state.loading) {
+        displayText = <div><p style={{color: "#7c7c7c"}}>Loading interpretation...</p></div>
+      } else {
+        displayText = <div><p style={{color: "#7c7c7c"}}>Press "interpret prediction" to show the interpretation.</p>{runButton}</div>
+      }
     } else {
       const saliencyMaps = [];
       for (let i = 0; i < inputTokens.length; i++) {

--- a/demo/src/components/Saliency.js
+++ b/demo/src/components/Saliency.js
@@ -1,7 +1,9 @@
 import React from 'react'
 import colormap from 'colormap'
 import { Tooltip, ColorizedToken } from './Shared';
+import OutputField from './OutputField'
 import {
+  Accordion,
   AccordionItem,
   AccordionItemTitle,
   AccordionItemBody,
@@ -35,6 +37,22 @@ const getTokenWeightPairs = (grads, tokens) => {
     // We do 1 - weight because the colormap is inverted
     return { token, weight: 1 - weight }
   })
+}
+
+export const SaliencyMaps = ({interpretData, inputTokens, inputHeaders, interpretModel, requestData}) => {
+  const simpleGradData = interpretData.simple;
+  const integratedGradData = interpretData.ig;
+  const smoothGradData = interpretData.sg;
+  const interpretationHeader = <>Saliency Maps <i><a href="https://allennlp.org/interpret" target="_blank" rel="noopener noreferrer" style={{paddingLeft: `1em`, fontWeight:100}}>What is this?</a></i></>
+  return (
+    <OutputField label={interpretationHeader}>
+      <Accordion accordion={false}>
+        <SaliencyComponent interpretData={simpleGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, GRAD_INTERPRETER)} interpreter={GRAD_INTERPRETER} />
+        <SaliencyComponent interpretData={integratedGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, IG_INTERPRETER)} interpreter={IG_INTERPRETER} />
+        <SaliencyComponent interpretData={smoothGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, SG_INTERPRETER)} interpreter={SG_INTERPRETER}/>
+      </Accordion>
+    </OutputField>
+  )
 }
 
 export class SaliencyComponent extends React.Component {
@@ -166,4 +184,4 @@ export class SaliencyComponent extends React.Component {
   }
 }
 
-export default SaliencyComponent
+export default SaliencyMaps

--- a/demo/src/components/demos/LanguageModel.js
+++ b/demo/src/components/demos/LanguageModel.js
@@ -6,7 +6,7 @@ import { Footer, ExternalLink } from '@allenai/varnish/components';
 
 import OutputField from '../OutputField'
 import { Accordion } from 'react-accessible-accordion';
-import SaliencyComponent from '../Saliency'
+import SaliencyMaps from '../Saliency'
 import HotflipComponent from '../Hotflip'
 import { FormField, FormLabel, FormTextArea } from '../Form';
 import { API_ROOT } from '../../api-config';
@@ -178,7 +178,7 @@ const getGradData = ({ grad_input_1 }) => {
   return [grad_input_1];
 }
 
-const SaliencyMaps = ({interpretData, tokens, interpretModel, requestData}) => {
+const MySaliencyMaps = ({interpretData, tokens, interpretModel, requestData}) => {
   let simpleGradData = undefined;
   let integratedGradData = undefined;
   let smoothGradData = undefined;
@@ -187,18 +187,19 @@ const SaliencyMaps = ({interpretData, tokens, interpretModel, requestData}) => {
     integratedGradData = IG_INTERPRETER in interpretData ? getGradData(interpretData[IG_INTERPRETER]['instance_1']) : undefined
     smoothGradData = SG_INTERPRETER in interpretData ? getGradData(interpretData[SG_INTERPRETER]['instance_1']) : undefined
   }
-  const inputTokens = [tokens];
+  const inputTokens = [tokens.map((token, index) => {
+    token = token.replace(/Ċ/g, "↵");
+    if (token[0] == 'Ġ') {
+      return token.replace(/Ġ/g, " ");
+    } else if (index != 0 && token != "↵") {
+      return '##' + token;
+    } else {
+      return token;
+    }
+  })];
   const inputHeaders = [<p><strong>Sentence:</strong></p>];
-  const interpretationHeader = Interpretations <i><a href="https://allennlp.org/interpret" target="_blank" rel="noopener noreferrer" style="padding-left:1em;font-weight:100">What is this?</a></i>
-  return (
-    <OutputField label={interpretationHeader}>
-      <Accordion accordion={false}>
-        <SaliencyComponent interpretData={simpleGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, GRAD_INTERPRETER)} interpreter={GRAD_INTERPRETER} />
-        <SaliencyComponent interpretData={integratedGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, IG_INTERPRETER)} interpreter={IG_INTERPRETER} />
-        <SaliencyComponent interpretData={smoothGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, SG_INTERPRETER)} interpreter={SG_INTERPRETER}/>
-      </Accordion>
-    </OutputField>
-  )
+  const allInterpretData = {simple: simpleGradData, ig: integratedGradData, sg: smoothGradData};
+  return <SaliencyMaps interpretData={allInterpretData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel} requestData={requestData} />
 }
 
 const Attacks = ({attackData, attackModel, requestData}) => {
@@ -400,7 +401,7 @@ class App extends React.Component {
           </InputOutput>
         </ModelArea>
       <Accordion accordion={false}>
-        <SaliencyMaps interpretData={interpretData} tokens={tokens} interpretModel={this.interpretModel} requestData={requestData}/>
+        <MySaliencyMaps interpretData={interpretData} tokens={tokens} interpretModel={this.interpretModel} requestData={requestData}/>
         <Attacks attackData={attackData} attackModel={this.attackModel} requestData={requestData}/>
       </Accordion>
     </Wrapper>

--- a/demo/src/components/demos/LanguageModel.js
+++ b/demo/src/components/demos/LanguageModel.js
@@ -189,8 +189,9 @@ const SaliencyMaps = ({interpretData, tokens, interpretModel, requestData}) => {
   }
   const inputTokens = [tokens];
   const inputHeaders = [<p><strong>Sentence:</strong></p>];
+  const interpretationHeader = Interpretations <i><a href="https://allennlp.org/interpret" target="_blank" rel="noopener noreferrer" style="padding-left:1em;font-weight:100">What is this?</a></i>
   return (
-    <OutputField>
+    <OutputField label={interpretationHeader}>
       <Accordion accordion={false}>
         <SaliencyComponent interpretData={simpleGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, GRAD_INTERPRETER)} interpreter={GRAD_INTERPRETER} />
         <SaliencyComponent interpretData={integratedGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, IG_INTERPRETER)} interpreter={IG_INTERPRETER} />

--- a/demo/src/components/demos/MaskedLm.js
+++ b/demo/src/components/demos/MaskedLm.js
@@ -6,7 +6,7 @@ import { Footer, ExternalLink } from '@allenai/varnish/components';
 
 import OutputField from '../OutputField'
 import { Accordion } from 'react-accessible-accordion';
-import SaliencyComponent from '../Saliency'
+import SaliencyMaps from '../Saliency'
 import HotflipComponent from '../Hotflip'
 import { FormField, FormLabel, FormTextArea } from '../Form';
 import { API_ROOT } from '../../api-config';
@@ -161,7 +161,7 @@ const getGradData = ({ grad_input_1 }) => {
   return [grad_input_1];
 }
 
-const SaliencyMaps = ({interpretData, tokens, interpretModel, requestData}) => {
+const MySaliencyMaps = ({interpretData, tokens, interpretModel, requestData}) => {
   let simpleGradData = undefined;
   let integratedGradData = undefined;
   let smoothGradData = undefined;
@@ -172,16 +172,8 @@ const SaliencyMaps = ({interpretData, tokens, interpretModel, requestData}) => {
   }
   const inputTokens = [tokens];
   const inputHeaders = [<p><strong>Sentence:</strong></p>];
-  const interpretationHeader = Interpretations <i><a href="https://allennlp.org/interpret" target="_blank" rel="noopener noreferrer" style="padding-left:1em;font-weight:100">What is this?</a></i>
-  return (
-    <OutputField label={interpretationHeader}>
-      <Accordion accordion={false}>
-        <SaliencyComponent interpretData={simpleGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, GRAD_INTERPRETER)} interpreter={GRAD_INTERPRETER} />
-        <SaliencyComponent interpretData={integratedGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, IG_INTERPRETER)} interpreter={IG_INTERPRETER} />
-        <SaliencyComponent interpretData={smoothGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, SG_INTERPRETER)} interpreter={SG_INTERPRETER}/>
-      </Accordion>
-    </OutputField>
-  )
+  const allInterpretData = {simple: simpleGradData, ig: integratedGradData, sg: smoothGradData};
+  return <SaliencyMaps interpretData={allInterpretData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel} requestData={requestData} />
 }
 
 const Attacks = ({attackData, attackModel, requestData}) => {
@@ -387,7 +379,7 @@ class App extends React.Component {
           </InputOutput>
         </ModelArea>
       <Accordion accordion={false}>
-        <SaliencyMaps interpretData={interpretData} tokens={tokens} interpretModel={this.interpretModel} requestData={requestData}/>
+        <MySaliencyMaps interpretData={interpretData} tokens={tokens} interpretModel={this.interpretModel} requestData={requestData}/>
         <Attacks attackData={attackData} attackModel={this.attackModel} requestData={requestData}/>
       </Accordion>
     </Wrapper>

--- a/demo/src/components/demos/MaskedLm.js
+++ b/demo/src/components/demos/MaskedLm.js
@@ -153,7 +153,7 @@ const DEFAULT_MODEL = "345M"
 
 const description = (
   <span>
-Enter some initial text with at least one "[MASK]" token and the model will generate the most likely words to substitute for "[MASK]".
+Enter text with one or more "[MASK]" tokens and <a href="https://arxiv.org/abs/1810.04805" target="_blank" rel="noopener noreferrer">BERT</a> will generate the most likely token to substitute for each "[MASK]".
   </span>
 )
 

--- a/demo/src/components/demos/MaskedLm.js
+++ b/demo/src/components/demos/MaskedLm.js
@@ -107,8 +107,8 @@ const ChoiceList = styled.ul`
 `
 
 const ChoiceItem = styled.button`
-  color: #2085bc;
-  cursor: pointer;
+  color: black;
+  cursor: auto;
   background: transparent;
   display: inline-flex;
   align-items: center;

--- a/demo/src/components/demos/MaskedLm.js
+++ b/demo/src/components/demos/MaskedLm.js
@@ -172,8 +172,9 @@ const SaliencyMaps = ({interpretData, tokens, interpretModel, requestData}) => {
   }
   const inputTokens = [tokens];
   const inputHeaders = [<p><strong>Sentence:</strong></p>];
+  const interpretationHeader = Interpretations <i><a href="https://allennlp.org/interpret" target="_blank" rel="noopener noreferrer" style="padding-left:1em;font-weight:100">What is this?</a></i>
   return (
-    <OutputField>
+    <OutputField label={interpretationHeader}>
       <Accordion accordion={false}>
         <SaliencyComponent interpretData={simpleGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, GRAD_INTERPRETER)} interpreter={GRAD_INTERPRETER} />
         <SaliencyComponent interpretData={integratedGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, IG_INTERPRETER)} interpreter={IG_INTERPRETER} />

--- a/demo/src/components/demos/NamedEntityRecognition.js
+++ b/demo/src/components/demos/NamedEntityRecognition.js
@@ -15,7 +15,7 @@ import { UsageCode } from '../UsageCode';
 import SyntaxHighlight from '../highlight/SyntaxHighlight';
 
 import { Accordion } from 'react-accessible-accordion';
-import { SaliencyComponent } from '../Saliency';
+import SaliencyMaps from '../Saliency'
 import InputReductionComponent from '../InputReduction'
 import {
   GRAD_INTERPRETER,
@@ -194,7 +194,7 @@ const getGradData = (instances, numGrads) => {
   return grads;
 }
 
-const SaliencyMaps = ({interpretData, tokens, relevantTokens, interpretModel, requestData}) => {
+const MySaliencyMaps = ({interpretData, tokens, relevantTokens, interpretModel, requestData}) => {
   let simpleGradData = undefined;
   let integratedGradData = undefined;
   let smoothGradData = undefined;
@@ -215,16 +215,8 @@ const SaliencyMaps = ({interpretData, tokens, relevantTokens, interpretModel, re
         </div>
     );
   });
-  const interpretationHeader = Interpretations <i><a href="https://allennlp.org/interpret" target="_blank" rel="noopener noreferrer" style="padding-left:1em;font-weight:100">What is this?</a></i>
-  return (
-    <OutputField label={interpretationHeader}>
-      <Accordion accordion={false}>
-        <SaliencyComponent interpretData={simpleGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, GRAD_INTERPRETER)} interpreter={GRAD_INTERPRETER} />
-        <SaliencyComponent interpretData={integratedGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, IG_INTERPRETER)} interpreter={IG_INTERPRETER} />
-        <SaliencyComponent interpretData={smoothGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, SG_INTERPRETER)} interpreter={SG_INTERPRETER}/>
-      </Accordion>
-    </OutputField>
-  )
+  const allInterpretData = {simple: simpleGradData, ig: integratedGradData, sg: smoothGradData};
+  return <SaliencyMaps interpretData={allInterpretData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel} requestData={requestData} />
 }
 
 const Attacks = ({attackData, attackModel, requestData, relevantTokens}) => {
@@ -316,7 +308,7 @@ const Output = ({ responseData, requestData, interpretData, interpretModel, atta
             {formattedTokens.map((token, i) => <TokenSpan key={i} token={token} />)}
           </HighlightContainer>
             <Accordion accordion={false}>
-              <SaliencyMaps interpretData={interpretData} tokens={words} relevantTokens={relevantTokens} interpretModel={interpretModel} requestData={requestData}/>
+              <MySaliencyMaps interpretData={interpretData} tokens={words} relevantTokens={relevantTokens} interpretModel={interpretModel} requestData={requestData}/>
               <Attacks attackData={attackData} attackModel={attackModel} requestData={requestData} relevantTokens={relevantTokens}/>
             </Accordion>
         </FormField>

--- a/demo/src/components/demos/NamedEntityRecognition.js
+++ b/demo/src/components/demos/NamedEntityRecognition.js
@@ -215,8 +215,9 @@ const SaliencyMaps = ({interpretData, tokens, relevantTokens, interpretModel, re
         </div>
     );
   });
+  const interpretationHeader = Interpretations <i><a href="https://allennlp.org/interpret" target="_blank" rel="noopener noreferrer" style="padding-left:1em;font-weight:100">What is this?</a></i>
   return (
-    <OutputField>
+    <OutputField label={interpretationHeader}>
       <Accordion accordion={false}>
         <SaliencyComponent interpretData={simpleGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, GRAD_INTERPRETER)} interpreter={GRAD_INTERPRETER} />
         <SaliencyComponent interpretData={integratedGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, IG_INTERPRETER)} interpreter={IG_INTERPRETER} />

--- a/demo/src/components/demos/ReadingComprehension.js
+++ b/demo/src/components/demos/ReadingComprehension.js
@@ -14,7 +14,7 @@ import { truncateText } from '../DemoInput'
 import { UsageSection } from '../UsageSection';
 import { UsageCode } from '../UsageCode';
 import SyntaxHighlight from '../highlight/SyntaxHighlight';
-import SaliencyComponent from '../Saliency'
+import SaliencyMaps from '../Saliency'
 import InputReductionComponent from '../InputReduction'
 import HotflipComponent from '../Hotflip'
 import {
@@ -145,7 +145,7 @@ const getGradData = ({ grad_input_1: gradInput1, grad_input_2: gradInput2 }) => 
   return [gradInput2, gradInput1];
 }
 
-const SaliencyMaps = ({interpretData, questionTokens, passageTokens, interpretModel, requestData}) => {
+const MySaliencyMaps = ({interpretData, questionTokens, passageTokens, interpretModel, requestData}) => {
   let simpleGradData = undefined;
   let integratedGradData = undefined;
   let smoothGradData = undefined;
@@ -156,15 +156,8 @@ const SaliencyMaps = ({interpretData, questionTokens, passageTokens, interpretMo
   }
   const inputTokens = [questionTokens, passageTokens];
   const inputHeaders = [<p><strong>Question:</strong></p>, <p><strong>Passage:</strong></p>];
-  return (
-    <OutputField>
-      <Accordion accordion={false}>
-        <SaliencyComponent interpretData={simpleGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, GRAD_INTERPRETER)} interpreter={GRAD_INTERPRETER} />
-        <SaliencyComponent interpretData={integratedGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, IG_INTERPRETER)} interpreter={IG_INTERPRETER} />
-        <SaliencyComponent interpretData={smoothGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, SG_INTERPRETER)} interpreter={SG_INTERPRETER}/>
-      </Accordion>
-    </OutputField>
-  )
+  const allInterpretData = {simple: simpleGradData, ig: integratedGradData, sg: smoothGradData};
+  return <SaliencyMaps interpretData={allInterpretData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel} requestData={requestData} />
 }
 
 const Attacks = ({attackData, attackModel, requestData}) => {
@@ -233,7 +226,7 @@ const AnswerByType = ({ responseData, requestData, interpretData, interpretModel
                 {question}
               </OutputField>
 
-              <SaliencyMaps interpretData={interpretData} questionTokens={questionTokens} passageTokens={passageTokens} interpretModel={interpretModel} requestData={requestData}/>
+              <MySaliencyMaps interpretData={interpretData} questionTokens={questionTokens} passageTokens={passageTokens} interpretModel={interpretModel} requestData={requestData}/>
               <Attacks attackData={attackData} attackModel={attackModel} requestData={requestData}/>
               <Attention {...responseData}/>
             </section>
@@ -266,7 +259,7 @@ const AnswerByType = ({ responseData, requestData, interpretData, interpretModel
                   highlightStyles={spans.map(s => "highlight__answer")}/>
               </OutputField>
 
-              <SaliencyMaps interpretData={interpretData} questionTokens={questionTokens} passageTokens={passageTokens} interpretModel = {interpretModel} requestData = {requestData}/>
+              <MySaliencyMaps interpretData={interpretData} questionTokens={questionTokens} passageTokens={passageTokens} interpretModel = {interpretModel} requestData = {requestData}/>
               <Attacks attackData={attackData} attackModel = {attackModel} requestData = {requestData}/>
               <Attention {...responseData}/>
             </section>
@@ -296,7 +289,7 @@ const AnswerByType = ({ responseData, requestData, interpretData, interpretModel
                 {question}
               </OutputField>
 
-              <SaliencyMaps interpretData={interpretData} questionTokens={questionTokens} passageTokens={passageTokens} interpretModel = {interpretModel} requestData = {requestData}/>
+              <MySaliencyMaps interpretData={interpretData} questionTokens={questionTokens} passageTokens={passageTokens} interpretModel = {interpretModel} requestData = {requestData}/>
               <Attacks attackData={attackData} attackModel = {attackModel} requestData = {requestData}/>
               <Attention {...responseData}/>
             </section>
@@ -329,7 +322,7 @@ const AnswerByType = ({ responseData, requestData, interpretData, interpretModel
                 {question}
               </OutputField>
 
-              <SaliencyMaps interpretData={interpretData} questionTokens={questionTokens} passageTokens={passageTokens} interpretModel = {interpretModel} requestData = {requestData}/>
+              <MySaliencyMaps interpretData={interpretData} questionTokens={questionTokens} passageTokens={passageTokens} interpretModel = {interpretModel} requestData = {requestData}/>
               <Attacks attackData={attackData} attackModel = {attackModel} requestData = {requestData}/>
               <Attention {...responseData}/>
             </section>
@@ -360,7 +353,7 @@ const AnswerByType = ({ responseData, requestData, interpretData, interpretModel
                 {question}
               </OutputField>
 
-              <SaliencyMaps interpretData={interpretData} questionTokens={questionTokens} passageTokens={passageTokens} interpretModel = {interpretModel} requestData = {requestData}/>
+              <MySaliencyMaps interpretData={interpretData} questionTokens={questionTokens} passageTokens={passageTokens} interpretModel = {interpretModel} requestData = {requestData}/>
               <Attacks attackData={attackData} attackModel = {attackModel} requestData = {requestData}/>
               <Attention {...responseData}/>
             </section>

--- a/demo/src/components/demos/SentimentAnalysis.js
+++ b/demo/src/components/demos/SentimentAnalysis.js
@@ -95,7 +95,8 @@ const Output = ({ responseData, requestData, interpretData, interpretModel, atta
 
   let t = requestData;
   const tokens = t['sentence'].split(' '); // this model expects space-separated inputs
-
+  const interpretationHeader = Interpretations <i><a href="https://allennlp.org/interpret" target="_blank" rel="noopener noreferrer" style="padding-left:1em;font-weight:100">What is this?</a></i>
+  
   // The "Answer" output field has the models predictions. The other output fields are the
   // reusable HTML/JavaScript for the interpretation methods.
   return (
@@ -104,7 +105,7 @@ const Output = ({ responseData, requestData, interpretData, interpretModel, atta
         {prediction}
       </OutputField>
 
-    <OutputField>
+    <OutputField label={interpretationHeader}>
       <Accordion accordion={false}>
           <SaliencyMaps interpretData={interpretData} tokens={tokens} interpretModel={interpretModel} requestData={requestData}/>
           <Attacks attackData={attackData} attackModel={attackModel} requestData={requestData}/>

--- a/demo/src/components/demos/SentimentAnalysis.js
+++ b/demo/src/components/demos/SentimentAnalysis.js
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router-dom';
 import Model from '../Model'
 import OutputField from '../OutputField'
 import { Accordion } from 'react-accessible-accordion';
-import SaliencyComponent from '../Saliency'
+import SaliencyMaps from '../Saliency'
 import InputReductionComponent from '../InputReduction'
 import HotflipComponent from '../Hotflip'
 import {
@@ -44,7 +44,7 @@ const getGradData = ({ grad_input_1: gradInput1 }) => {
   return [gradInput1];
 }
 
-const SaliencyMaps = ({interpretData, tokens, interpretModel, requestData}) => {
+const MySaliencyMaps = ({interpretData, tokens, interpretModel, requestData}) => {
   let simpleGradData = undefined;
   let integratedGradData = undefined;
   let smoothGradData = undefined;
@@ -55,15 +55,8 @@ const SaliencyMaps = ({interpretData, tokens, interpretModel, requestData}) => {
   }
   const inputTokens = [tokens];
   const inputHeaders = [<p><strong>Sentence:</strong></p>];
-  return (
-    <OutputField>
-      <Accordion accordion={false}>
-        <SaliencyComponent interpretData={simpleGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, GRAD_INTERPRETER)} interpreter={GRAD_INTERPRETER} />
-        <SaliencyComponent interpretData={integratedGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, IG_INTERPRETER)} interpreter={IG_INTERPRETER} />
-        <SaliencyComponent interpretData={smoothGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, SG_INTERPRETER)} interpreter={SG_INTERPRETER}/>
-      </Accordion>
-    </OutputField>
-  )
+  const allInterpretData = {simple: simpleGradData, ig: integratedGradData, sg: smoothGradData};
+  return <SaliencyMaps interpretData={allInterpretData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel} requestData={requestData} />
 }
 
 const Attacks = ({attackData, attackModel, requestData}) => {
@@ -95,8 +88,7 @@ const Output = ({ responseData, requestData, interpretData, interpretModel, atta
 
   let t = requestData;
   const tokens = t['sentence'].split(' '); // this model expects space-separated inputs
-  const interpretationHeader = Interpretations <i><a href="https://allennlp.org/interpret" target="_blank" rel="noopener noreferrer" style="padding-left:1em;font-weight:100">What is this?</a></i>
-  
+
   // The "Answer" output field has the models predictions. The other output fields are the
   // reusable HTML/JavaScript for the interpretation methods.
   return (
@@ -105,9 +97,9 @@ const Output = ({ responseData, requestData, interpretData, interpretModel, atta
         {prediction}
       </OutputField>
 
-    <OutputField label={interpretationHeader}>
+    <OutputField>
       <Accordion accordion={false}>
-          <SaliencyMaps interpretData={interpretData} tokens={tokens} interpretModel={interpretModel} requestData={requestData}/>
+          <MySaliencyMaps interpretData={interpretData} tokens={tokens} interpretModel={interpretModel} requestData={requestData}/>
           <Attacks attackData={attackData} attackModel={attackModel} requestData={requestData}/>
       </Accordion>
     </OutputField>

--- a/demo/src/components/demos/TextualEntailment.js
+++ b/demo/src/components/demos/TextualEntailment.js
@@ -115,8 +115,9 @@ const SaliencyMaps = ({interpretData, premise_tokens, hypothesis_tokens, interpr
   }
   const inputTokens = [premise_tokens, hypothesis_tokens];
   const inputHeaders = [<p><strong>Premise:</strong></p>, <p><strong>Hypothesis:</strong></p>];
+  const interpretationHeader = Interpretations <i><a href="https://allennlp.org/interpret" target="_blank" rel="noopener noreferrer" style="padding-left:1em;font-weight:100">What is this?</a></i>
   return (
-    <OutputField>
+    <OutputField label={interpretationHeader}>
       <Accordion accordion={false}>
         <SaliencyComponent interpretData={simpleGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, GRAD_INTERPRETER)} interpreter={GRAD_INTERPRETER} />
         <SaliencyComponent interpretData={integratedGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, IG_INTERPRETER)} interpreter={IG_INTERPRETER} />

--- a/demo/src/components/demos/TextualEntailment.js
+++ b/demo/src/components/demos/TextualEntailment.js
@@ -19,7 +19,7 @@ import SyntaxHighlight from '../highlight/SyntaxHighlight';
 
 import '../../css/TeComponent.css';
 
-import SaliencyComponent from '../Saliency'
+import SaliencyMaps from '../Saliency'
 import InputReductionComponent from '../InputReduction'
 import HotflipComponent from '../Hotflip'
 import {
@@ -104,7 +104,7 @@ const getGradData = ({ grad_input_1, grad_input_2 }) => {
   return [grad_input_2, grad_input_1];
 }
 
-const SaliencyMaps = ({interpretData, premise_tokens, hypothesis_tokens, interpretModel, requestData}) => {
+const MySaliencyMaps = ({interpretData, premise_tokens, hypothesis_tokens, interpretModel, requestData}) => {
   let simpleGradData = undefined;
   let integratedGradData = undefined;
   let smoothGradData = undefined;
@@ -115,16 +115,8 @@ const SaliencyMaps = ({interpretData, premise_tokens, hypothesis_tokens, interpr
   }
   const inputTokens = [premise_tokens, hypothesis_tokens];
   const inputHeaders = [<p><strong>Premise:</strong></p>, <p><strong>Hypothesis:</strong></p>];
-  const interpretationHeader = Interpretations <i><a href="https://allennlp.org/interpret" target="_blank" rel="noopener noreferrer" style="padding-left:1em;font-weight:100">What is this?</a></i>
-  return (
-    <OutputField label={interpretationHeader}>
-      <Accordion accordion={false}>
-        <SaliencyComponent interpretData={simpleGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, GRAD_INTERPRETER)} interpreter={GRAD_INTERPRETER} />
-        <SaliencyComponent interpretData={integratedGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, IG_INTERPRETER)} interpreter={IG_INTERPRETER} />
-        <SaliencyComponent interpretData={smoothGradData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel(requestData, SG_INTERPRETER)} interpreter={SG_INTERPRETER}/>
-      </Accordion>
-    </OutputField>
-  )
+  const allInterpretData = {simple: simpleGradData, ig: integratedGradData, sg: smoothGradData};
+  return <SaliencyMaps interpretData={allInterpretData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel} requestData={requestData} />
 }
 
 const Attacks = ({attackData, attackModel, requestData}) => {
@@ -267,7 +259,7 @@ const Output = ({ responseData, requestData, interpretData, interpretModel, atta
     </div>
     <OutputField>
       <Accordion accordion={false}>
-        <SaliencyMaps interpretData={interpretData} premise_tokens={premise_tokens} hypothesis_tokens={hypothesis_tokens} interpretModel={interpretModel} requestData={requestData} />
+        <MySaliencyMaps interpretData={interpretData} premise_tokens={premise_tokens} hypothesis_tokens={hypothesis_tokens} interpretModel={interpretModel} requestData={requestData} />
         <Attacks attackData={attackData} attackModel={attackModel} requestData={requestData}/>
 
         <AccordionItem>


### PR DESCRIPTION
General errors:
- [x] input reduction doesn't seem to work for NAQANet, e.g., https://demo.staging.allennlp.org/reading-comprehension/MTA1NjIzNA== I can manually deleted words and it can definitely be reduced but it says no reduction possible. 
- [x] Also, hotflip throws a 500 error for this https://demo.staging.allennlp.org/reading-comprehension/MTA1NzEyOQ==
- [x] GPT2 appends G' to the front of every BPE token to indicate a new word is starting (see simple gradient here https://demo.staging.allennlp.org/next-token-lm?text=The%20doctor%20was%20worried%20about%20their%20patient.%20). The new line symbol also seems to be a Ċ not a newline
- [x] the GPT-2 output differs from the main demo (I tried TH PEOPLEMan goddreams Blacks)
- [x] the [MASK] predictions in BERT are clickable links but they don't do anything
- [x] textual entailment and NER interpretations are failing on staging, not sure if they just aren't loaded or whether something is broken

UI Improvements:
- [x] I think all the interpretation methods should have a header above them called "Interpretations"
- [x] for Masked LM, we can mention BERT somewhere and link to their paper
- [x] loading bar
- [x] add the "What is this?" link
- [x] ner is upside down
- [x] in the "Your model here!" add a link to the tutorial for adding your own model locally.
- [x] maybe instead of "Visualizing the top X words" -> "Visualizing the top X most important words"
- [x] How about: "Enter some initial text with one or more "[MASK]" tokens and the model will generate the most likely tokens to substitute for each "[MASK]".

Speed improvements:
- [x] caching