### PR TITLE
UI Fixes for the Demo

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,11 +47,12 @@ logger.addHandler(handler)
 logger.propagate = False
 
 supported_interpret_models = {'named-entity-recognition',
+                              'fine-grained-named-entity-recognition',
                               'sentiment-analysis',
                               'textual-entailment',
                               'reading-comprehension',
+                              'elmo-reading-comprehension',
                               'naqanet-reading-comprehension',
-                              'fine-grained-named-entity-recognition',
                               'masked-lm',
                               'next-token-lm'}
 

--- a/app.py
+++ b/app.py
@@ -169,13 +169,6 @@ def make_app(build_dir: str,
         Just a wrapper around ``model.predict_json`` that allows us to use a cache decorator.
         """
         return model.predict_json(json.loads(data))
-    
-    
-        attack = attacker.attack_from_json(inputs=data,
-                                           input_field_to_attack=input_field_to_attack,
-                                           grad_input_field=grad_input_field,
-                                           target=target)
-        
         
     @lru_cache(maxsize=interpret_cache_size)
     def _caching_interpret(interpreter: SaliencyInterpreter, data: str) -> JsonDict:

--- a/app.py
+++ b/app.py
@@ -105,8 +105,8 @@ def make_app(build_dir: str,
              models: Dict[str, DemoModel],
              demo_db: Optional[DemoDatabase] = None,
              cache_size: int = 128,
-             interpret_cache_size: int = 128,
-             attack_cache_size: int = 128) -> Flask:
+             interpret_cache_size: int = 500,
+             attack_cache_size: int = 500) -> Flask:
     if not os.path.exists(build_dir):
         logger.error("app directory %s does not exist, aborting", build_dir)
         sys.exit(-1)
@@ -513,8 +513,8 @@ if __name__ == "__main__":
     parser.add_argument('--port', type=int, default=8000, help='port to serve the demo on')
     parser.add_argument('--demo-dir', type=str, default='demo/', help="directory where the demo HTML is located")
     parser.add_argument('--cache-size', type=int, default=128, help="how many results to keep in memory")
-    parser.add_argument('--interpret-cache-size', type=int, default=128, help="how many interpretation results to keep in memory")
-    parser.add_argument('--attack-cache-size', type=int, default=128, help="how many attack results to keep in memory")
+    parser.add_argument('--interpret-cache-size', type=int, default=500, help="how many interpretation results to keep in memory")
+    parser.add_argument('--attack-cache-size', type=int, default=500, help="how many attack results to keep in memory")
     parser.add_argument('--models-file', type=str, default='models.json', help="json file containing the details of the models to load")
 
     models_group = parser.add_mutually_exclusive_group()

--- a/app.py
+++ b/app.py
@@ -179,14 +179,13 @@ def make_app(build_dir: str,
 
     @lru_cache(maxsize=attack_cache_size)
     def _caching_attack(attacker: Attacker, data: str, input_field_to_attack: str, grad_input_field: str, target: str) -> JsonDict:
-        attacker, json.dumps(data), input_field_to_attack, grad_input_field, target
         """
         Just a wrapper around ``model.attack_from_json`` that allows us to use a cache decorator.
         """
         return attacker.attack_from_json(inputs=json.loads(data),
                                          input_field_to_attack=input_field_to_attack,
                                          grad_input_field=grad_input_field,
-                                         target=target)
+                                         target=json.loads(target))
     
     @app.route('/')
     def index() -> Response: # pylint: disable=unused-variable
@@ -385,7 +384,7 @@ def make_app(build_dir: str,
         if use_cache and attack_cache_size > 0:
             # lru_cache insists that all function arguments be hashable,
             # so unfortunately we have to stringify the data.
-            attack = _caching_attack(attacker, json.dumps(data), input_field_to_attack, grad_input_field, target)
+            attack = _caching_attack(attacker, json.dumps(data), input_field_to_attack, grad_input_field, json.dumps(target))
             
         else:
             # if cache_size is 0, skip caching altogether

--- a/demo/src/components/Hotflip.js
+++ b/demo/src/components/Hotflip.js
@@ -142,7 +142,7 @@ export default class HotflipComponent extends React.Component {
     const target = targeted === undefined ?
       " "
     :
-      <p> Change prediction to (leave blank to allow any change): <FormInput type="text" onChange={ this.updateTargetWord }/> </p>
+      <p> Leave blank to allow any change (untargeted). For targeted attacks, enter a single token that you want to flip the mask to: <FormInput type="text" onChange={ this.updateTargetWord }/> </p>
 
     const buttonDisplay = (flippedString !== " " && targeted === undefined) ?
       " "

--- a/demo/src/components/Hotflip.js
+++ b/demo/src/components/Hotflip.js
@@ -122,6 +122,9 @@ export default class HotflipComponent extends React.Component {
     }
     // data is available, display the results of Hotflip
     else {
+        if (this.state.loading) { // loading is done
+            this.setState({ loading: false });
+        }
         [originalString, flippedString] = colorizeTokensForHotflipUI(hotflipData["original"],
                                                                      hotflipData["final"][0])
         newPrediction = hotflipData["new_prediction"]

--- a/demo/src/components/InputReduction.js
+++ b/demo/src/components/InputReduction.js
@@ -91,6 +91,9 @@ export default class InputReductionComponent extends React.Component {
             // premise for SNLI.
             // (2) you can format the original input and the reduced input yourself, to
             // customize the display for, e.g., NER.
+            if (this.state.loading) { // loading is done
+                this.setState({ loading: false });
+            }
             const original = reducedInput.original;
             const formattedOriginal = reducedInput.formattedOriginal;
             let internalText = [];

--- a/demo/src/components/Saliency.js
+++ b/demo/src/components/Saliency.js
@@ -43,7 +43,7 @@ export const SaliencyMaps = ({interpretData, inputTokens, inputHeaders, interpre
   const simpleGradData = interpretData.simple;
   const integratedGradData = interpretData.ig;
   const smoothGradData = interpretData.sg;
-  const interpretationHeader = <>Saliency Maps <i><a href="https://allennlp.org/interpret" target="_blank" rel="noopener noreferrer" style={{paddingLeft: `1em`, fontWeight:100}}>What is this?</a></i></>
+  const interpretationHeader = <>Model Interpretations <i><a href="https://allennlp.org/interpret" target="_blank" rel="noopener noreferrer" style={{paddingLeft: `1em`, fontWeight:100}}>What is this?</a></i></>
   return (
     <OutputField label={interpretationHeader}>
       <Accordion accordion={false}>
@@ -82,7 +82,7 @@ export class SaliencyComponent extends React.Component {
     this.setState({ ...this.state, loading: true})
     interpretModel()
   }
-
+ 
   colorize(tokensWithWeights, topKIdx) {
     const {colormapProps} = this.props
     // colormap package takes minimum of 6 shades
@@ -150,6 +150,9 @@ export class SaliencyComponent extends React.Component {
         displayText = <div><p style={{color: "#7c7c7c"}}>Press "interpret prediction" to show the interpretation.</p>{runButton}</div>
       }
     } else {
+      if (this.state.loading) { // loading is done
+          this.setState({ loading: false });
+      }
       const saliencyMaps = [];
       for (let i = 0; i < inputTokens.length; i++) {
         const grads = interpretData[i];

--- a/demo/src/components/Saliency.js
+++ b/demo/src/components/Saliency.js
@@ -154,8 +154,9 @@ export class SaliencyComponent extends React.Component {
           this.setState({ loading: false });
       }
       const saliencyMaps = [];
+      
       for (let i = 0; i < inputTokens.length; i++) {
-        const grads = interpretData[i];
+        const grads = interpretData[inputTokens.length - 1 - i];
         const tokens = inputTokens[i];
         const header = inputHeaders[i];
         const tokenWeights = getTokenWeightPairs(grads, tokens);
@@ -176,7 +177,6 @@ export class SaliencyComponent extends React.Component {
           </div>
         )
         saliencyMaps.push(saliencyMap);
-        saliencyMaps.reverse(); // list of interpretations (only used by NER currently) are in the opposite order.
       }
       displayText = <div>{saliencyMaps}</div>
     }

--- a/demo/src/components/Saliency.js
+++ b/demo/src/components/Saliency.js
@@ -82,7 +82,7 @@ export class SaliencyComponent extends React.Component {
     this.setState({ ...this.state, loading: true})
     interpretModel()
   }
- 
+
   colorize(tokensWithWeights, topKIdx) {
     const {colormapProps} = this.props
     // colormap package takes minimum of 6 shades
@@ -156,7 +156,7 @@ export class SaliencyComponent extends React.Component {
       const saliencyMaps = [];
       
       for (let i = 0; i < inputTokens.length; i++) {
-        const grads = interpretData[inputTokens.length - 1 - i];
+        const grads = interpretData[inputTokens.length - 1 - i]; // reverse the order for NER
         const tokens = inputTokens[i];
         const header = inputHeaders[i];
         const tokenWeights = getTokenWeightPairs(grads, tokens);

--- a/demo/src/components/demos/LanguageModel.js
+++ b/demo/src/components/demos/LanguageModel.js
@@ -38,7 +38,6 @@ const Wrapper = styled.div`
 
 const ModelArea = styled.div`
   background: ${({theme}) => theme.palette.common.white};
-  min-height: 30em;
 `
 
 const Loading = styled.div`

--- a/demo/src/components/demos/LanguageModel.js
+++ b/demo/src/components/demos/LanguageModel.js
@@ -38,6 +38,7 @@ const Wrapper = styled.div`
 
 const ModelArea = styled.div`
   background: ${({theme}) => theme.palette.common.white};
+  min-height: 30em;
 `
 
 const Loading = styled.div`

--- a/demo/src/components/demos/LanguageModel.js
+++ b/demo/src/components/demos/LanguageModel.js
@@ -179,6 +179,20 @@ const getGradData = ({ grad_input_1 }) => {
   return [grad_input_1];
 }
 
+const cleanTokensForDisplay = (tokens) => {
+  console.log(tokens)
+  return tokens.map((token, index) => {
+    token = token.replace(/Ċ/g, "↵");
+    if (token[0] === 'Ġ') {
+      return token.replace(/Ġ/g, " ");
+    } else if (index !== 0 && token !== "↵") {
+      return '##' + token;
+    } else {
+      return token;
+    }
+  });
+}
+
 const MySaliencyMaps = ({interpretData, tokens, interpretModel, requestData}) => {
   let simpleGradData = undefined;
   let integratedGradData = undefined;
@@ -188,16 +202,7 @@ const MySaliencyMaps = ({interpretData, tokens, interpretModel, requestData}) =>
     integratedGradData = IG_INTERPRETER in interpretData ? getGradData(interpretData[IG_INTERPRETER]['instance_1']) : undefined
     smoothGradData = SG_INTERPRETER in interpretData ? getGradData(interpretData[SG_INTERPRETER]['instance_1']) : undefined
   }
-  const inputTokens = [tokens.map((token, index) => {
-    token = token.replace(/Ċ/g, "↵");
-    if (token[0] == 'Ġ') {
-      return token.replace(/Ġ/g, " ");
-    } else if (index != 0 && token != "↵") {
-      return '##' + token;
-    } else {
-      return token;
-    }
-  })];
+  const inputTokens = [cleanTokensForDisplay(tokens)];
   const inputHeaders = [<p><strong>Sentence:</strong></p>];
   const allInterpretData = {simple: simpleGradData, ig: integratedGradData, sg: smoothGradData};
   return <SaliencyMaps interpretData={allInterpretData} inputTokens={inputTokens} inputHeaders={inputHeaders} interpretModel={interpretModel} requestData={requestData} />
@@ -207,7 +212,9 @@ const Attacks = ({attackData, attackModel, requestData}) => {
   let hotflipData = undefined;
   if (attackData && attackData.hotflip) {
     hotflipData = attackData["hotflip"];
-    hotflipData["new_prediction"] = hotflipData["outputs"]["words"][0][0];
+    hotflipData["new_prediction"] = cleanTokensForDisplay([hotflipData["outputs"]["words"][0][0]])[0];
+    hotflipData["original"] = cleanTokensForDisplay(hotflipData["original"]);
+    hotflipData["final"][0] = cleanTokensForDisplay(hotflipData["final"][0]);
   }
   return (
     <OutputField>

--- a/demo/src/components/demos/MaskedLm.js
+++ b/demo/src/components/demos/MaskedLm.js
@@ -34,7 +34,6 @@ const Wrapper = styled.div`
 
 const ModelArea = styled.div`
   background: ${({theme}) => theme.palette.common.white};
-  min-height: 30em;
 `
 
 const Loading = styled.div`

--- a/demo/src/components/demos/MaskedLm.js
+++ b/demo/src/components/demos/MaskedLm.js
@@ -34,6 +34,7 @@ const Wrapper = styled.div`
 
 const ModelArea = styled.div`
   background: ${({theme}) => theme.palette.common.white};
+  min-height: 30em;
 `
 
 const Loading = styled.div`
@@ -352,7 +353,7 @@ class App extends React.Component {
     }
     return (
       <Wrapper classname="model">
-        <ModelArea className="model__content answer">
+        <ModelArea className="model__content answer" >
           <h2><span>{title}</span></h2>
           <p><span>{description}</span></p>
 

--- a/demo/src/components/demos/ReadingComprehension.js
+++ b/demo/src/components/demos/ReadingComprehension.js
@@ -43,13 +43,18 @@ const taskModels = [
     desc: "Reimplementation of BiDAF (Seo et al, 2017), or Bi-Directional Attention Flow,<br/>a widely used MC baseline that achieved state-of-the-art accuracies on<br/>the SQuAD dataset (Wikipedia sentences) in early 2017."
   },
   {
+    name: "ELMo-BiDAF (trained on SQuAD)",
+    desc: "Same as the BiDAF model except it uses ELMo embeddings instead of GloVe."
+  },
+  {
     name: "NAQANet (trained on DROP)",
     desc: "An augmented version of QANet that adds rudimentary numerical reasoning ability,<br/>trained on DROP (Dua et al., 2019), as published in the original DROP paper."
   }
 ]
 
 const taskEndpoints = {
-  "BiDAF (trained on SQuAD)": "reading-comprehension", // TODO: we should rename tha back-end model to reading-comprehension
+  "BiDAF (trained on SQuAD)": "reading-comprehension",
+  "ELMo-BiDAF (trained on SQuAD)": "elmo-reading-comprehension",
   "NAQANet (trained on DROP)": "naqanet-reading-comprehension"
 };
 

--- a/demo/src/css/model.css
+++ b/demo/src/css/model.css
@@ -58,7 +58,7 @@
 }
 
 .model__content.answer {
-  min-height: 40em;
+  min-height: 30em;
   padding-top: 0.9em;
 }
 

--- a/models.json
+++ b/models.json
@@ -5,6 +5,12 @@
         "predictor_name": "machine-comprehension",
         "max_request_length": 311108
     },
+    "elmo-reading-comprehension": {
+        "archive_file": "https://storage.googleapis.com/allennlp-public-models/bidaf-elmo-model-2018.11.30-charpad.tar.gz",
+        "memory": "2Gi",
+        "predictor_name": "machine-comprehension",
+        "max_request_length": 311108
+     },
     "naqanet-reading-comprehension": {
         "archive_file": "https://storage.googleapis.com/allennlp-public-models/naqanet-2019.04.29-fixed-weight-names.tar.gz",
         "predictor_name": "machine-comprehension",

--- a/models.json
+++ b/models.json
@@ -1,6 +1,6 @@
 {
     "reading-comprehension": {
-        "archive_file": "https://storage.googleapis.com/allennlp-public-models/bidaf-elmo-model-2018.11.30-charpad.tar.gz",
+        "archive_file": "https://s3-us-west-2.amazonaws.com/allennlp/models/bidaf-model-2017.09.15-charpad.tar.gz",
         "memory": "2Gi",
         "predictor_name": "machine-comprehension",
         "max_request_length": 311108


### PR DESCRIPTION
- [x] Hotflip for LM still has G' (replaced it)
- [x] Hotflip for LM isn't doing the equality check correctly, so it changes every single word even though the prediction has changed (seems to work fine, was a one-off problem )
- [x] NER is out of order still (reverse fixed)
- [x] NER input reduction still not reducing all the way (its fine, the beam was is just too small sometimes)
- [x] Switch BiDAF back to GloVe version for speed? (added a third option)
- [x] When the input is modified for GPT-2 and BERT, the interpretation either shows the old one, or it says loading forever. When the input is modified, there needs to be some sort reset. (set loading to false)
- [x] Add an "Adversarial Attacks" header similar to "Saliency Maps" (changed Saliency maps to interpretations)