### PR TITLE
Revert "Adjust skiff config so adhocs don't register on allennlp.org."

### DIFF
--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -67,7 +67,7 @@ local hosts = [
         config.appName + '.' + env + topLevelDomain,
     if env == 'prod' then
         'demo' + canonicalTopLevelDomain
-    else if env == 'staging' then
+    else
         'demo' + '.' + env + canonicalTopLevelDomain
 ];
 


### PR DESCRIPTION
Reverts allenai/allennlp-demo#291

Instead of creating a length 1 list this made a length 2 list where one item was nil.