### PR TITLE
Cleanup various React issues

### DIFF
--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -113,7 +113,7 @@ class SingleTaskDemo extends React.Component {
   // We also need to update the state whenever we receive new props from React router.
   componentDidUpdate({ match }) {
     const { model, slug } = match.params;
-    if (model !== this.state.selectedModel && slug !== this.state.slug) {
+    if (model !== this.state.selectedModel || slug !== this.state.slug) {
       this.setState({ selectedModel: model, slug });
     }
   }

--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -111,9 +111,11 @@ class SingleTaskDemo extends React.Component {
   }
 
   // We also need to update the state whenever we receive new props from React router.
-  componentWillReceiveProps({ match }) {
+  componentDidUpdate({ match }) {
     const { model, slug } = match.params;
-    this.setState({selectedModel: model, slug: slug});
+    if (model !== this.state.selectedModel && slug !== this.state.slug) {
+      this.setState({ selectedModel: model, slug });
+    }
   }
 
   // After the component mounts, we check if we need to fetch the data

--- a/demo/src/components/DemoInput.js
+++ b/demo/src/components/DemoInput.js
@@ -180,7 +180,7 @@ class DemoInput extends React.Component {
                         onKeyDown: canRun ? this.runOnEnter : undefined,
                         id: inputId,
                         type: "text",
-                        required: "true",
+                        required: true,
                         autoFocus: idx === 0,
                         placeholder: field.placeholder || "",
                         value: this.state[field.name],

--- a/demo/src/components/DemoInput.js
+++ b/demo/src/components/DemoInput.js
@@ -321,7 +321,7 @@ function SelectOptionGroup(exampleInfo, groupIndex, fields) {
       return RenderOptions(examples, groupIndex, fields)
   } else {
       return (
-          <Select.OptGroup label={exampleType}>
+          <Select.OptGroup label={exampleType} key={groupIndex}>
               {RenderOptions(examples, groupIndex, fields)}
           </Select.OptGroup>
       )

--- a/demo/src/components/HeatMap.js
+++ b/demo/src/components/HeatMap.js
@@ -54,11 +54,11 @@ export default class HeatMap extends React.Component {
     });
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.setOpacity(this.props);
   }
 
-  componentWillReceiveProps(newProps) {
+  componentDidUpdate(newProps) {
     if(this.props.data !== newProps.data || this.props.normalization !== newProps.normalization) {
         this.setOpacity(newProps);
     }

--- a/demo/src/components/HierplaneVisualization.js
+++ b/demo/src/components/HierplaneVisualization.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Tree } from 'hierplane';
+import { Button } from '@allenai/varnish/components';
 
 
 class HierplaneVisualization extends React.Component {
@@ -32,16 +33,16 @@ class HierplaneVisualization extends React.Component {
         return (
           <div className="hierplane__visualization">
             <div className="hierplane__visualization-verbs">
-              <a className="hierplane__visualization-verbs__prev" onClick={this.selectPrevVerb}>
+              <Button className="hierplane__visualization-verbs__prev" variant="link" ghost onClick={this.selectPrevVerb}>
                 <svg width="12" height="12">
                   <use xlinkHref="#icon__disclosure"></use>
                 </svg>
-              </a>
-              <a onClick={this.selectNextVerb}>
+              </Button>
+              <Button variant="link" ghost onClick={this.selectNextVerb}>
                 <svg width="12" height="12">
                   <use xlinkHref="#icon__disclosure"></use>
                 </svg>
-              </a>
+              </Button>
               <span className="hierplane__visualization-verbs__label">
                 Verb {selectedVerbIdxLabel} of {totalVerbCount}: <strong>{selectedVerb}</strong>
               </span>

--- a/demo/src/components/Hotflip.js
+++ b/demo/src/components/Hotflip.js
@@ -65,7 +65,7 @@ export default class HotflipComponent extends React.Component {
 
   callAttackFunction = attackFunction => () => {
     this.setState({ ...this.state, loading: true})
-    attackFunction(this.state)
+    attackFunction(this.state).then(() => this.setState({ loading: false }));
   }
 
   handleHighlightMouseDown(id, depth) {
@@ -122,9 +122,6 @@ export default class HotflipComponent extends React.Component {
     }
     // data is available, display the results of Hotflip
     else {
-        if (this.state.loading) { // loading is done
-            this.setState({ loading: false });
-        }
         [originalString, flippedString] = colorizeTokensForHotflipUI(hotflipData["original"],
                                                                      hotflipData["final"][0])
         newPrediction = hotflipData["new_prediction"]

--- a/demo/src/components/InputReduction.js
+++ b/demo/src/components/InputReduction.js
@@ -64,7 +64,7 @@ export default class InputReductionComponent extends React.Component {
 
     callReduceFunction = reduceFunction => () => {
       this.setState({ ...this.state, loading: true})
-      reduceFunction({})
+      reduceFunction({}).then(() => this.setState({ loading: false }))
     }
 
     render() {
@@ -91,9 +91,6 @@ export default class InputReductionComponent extends React.Component {
             // premise for SNLI.
             // (2) you can format the original input and the reduced input yourself, to
             // customize the display for, e.g., NER.
-            if (this.state.loading) { // loading is done
-                this.setState({ loading: false });
-            }
             const original = reducedInput.original;
             const formattedOriginal = reducedInput.formattedOriginal;
             let internalText = [];
@@ -121,7 +118,7 @@ export default class InputReductionComponent extends React.Component {
                     internalText.push(noReduction ? <p>(No reduction was possible)</p> : <p></p>)
                 })
             }
-            displayText = <div>{internalText}</div>
+            displayText = <div>{internalText.map((text, i) => <span key={i}>{text}</span>)}</div>
         }
 
         return (

--- a/demo/src/components/Menu.js
+++ b/demo/src/components/Menu.js
@@ -38,7 +38,7 @@ export class MenuBase extends React.Component {
     return (
       <OuterGrid>
         <Logo>
-          <a href="http://www.allennlp.org/" target="_blank" rel="noopener">
+          <a href="http://www.allennlp.org/" target="_blank" rel="noopener noreferrer">
             <img
               src={allenNlpLogo}
               width={"124px"}

--- a/demo/src/components/Model.js
+++ b/demo/src/components/Model.js
@@ -92,7 +92,7 @@ class Model extends React.Component {
     attackModel = (inputs, attacker, inputToAttack, gradInput) => ({target}) => {
       const attackInputs = {...{attacker}, ...{inputToAttack}, ...{gradInput}}
       if (target !== undefined) {
-        return Promise.resolve(attackInputs['target'] = target)
+        attackInputs['target'] = target
       }
 
       const { apiUrlAttack } = this.props

--- a/demo/src/components/Model.js
+++ b/demo/src/components/Model.js
@@ -92,11 +92,11 @@ class Model extends React.Component {
     attackModel = (inputs, attacker, inputToAttack, gradInput) => ({target}) => {
       const attackInputs = {...{attacker}, ...{inputToAttack}, ...{gradInput}}
       if (target !== undefined) {
-        attackInputs['target'] = target
+        return Promise.resolve(attackInputs['target'] = target)
       }
 
       const { apiUrlAttack } = this.props
-      fetch(apiUrlAttack(inputs), {
+      return fetch(apiUrlAttack(inputs), {
         method: 'POST',
         headers: {
           'Accept': 'application/json',

--- a/demo/src/components/Model.js
+++ b/demo/src/components/Model.js
@@ -73,7 +73,7 @@ class Model extends React.Component {
 
     interpretModel = (inputs, interpreter) => () => {
       const { apiUrlInterpret } = this.props
-      fetch(apiUrlInterpret(inputs), {
+      return fetch(apiUrlInterpret(inputs), {
         method: 'POST',
         headers: {
           'Accept': 'application/json',

--- a/demo/src/components/ModelIntro.js
+++ b/demo/src/components/ModelIntro.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Button } from '@allenai/varnish/components';
 
 /*******************************************************************************
   <ModelIntro /> Component
@@ -28,8 +29,8 @@ class ModelIntro extends React.Component {
           {descriptionEllipsed
             ? (
               this.state.showFullDescription
-                ? <span>{description} <span><a onClick={e => this.toggleShowMore()}>Show Less</a></span></span>
-                : <span>{descriptionEllipsed} <span><a onClick={e => this.toggleShowMore()}>Show More</a></span></span>
+                ? <span>{description} <span><Button onClick={e => this.toggleShowMore()} ghost variant="link">Show Less</Button></span></span>
+                : <span>{descriptionEllipsed} <span><Button onClick={e => this.toggleShowMore()} ghost variant="link">Show More</Button></span></span>
             )
             : <span>{description}</span>
           }

--- a/demo/src/components/Permalink.js
+++ b/demo/src/components/Permalink.js
@@ -45,7 +45,7 @@ class Permalink extends React.Component {
             <div className="model__content">
                 <FormField>
                     <FormLabel>Permalink:</FormLabel>
-                    <FormInput variant="text" disabled="true" className="permalink" id="permalink" value={permalink}/>
+                    <FormInput variant="text" disabled className="permalink" id="permalink" value={permalink}/>
                     <Button className="copy__to__clipboard" onClick={() => copyToClipboard(permalink)}>Copy to Clipboard</Button>
                 </FormField>
             </div>

--- a/demo/src/components/Saliency.js
+++ b/demo/src/components/Saliency.js
@@ -81,8 +81,8 @@ export class SaliencyComponent extends React.Component {
   }
 
   callInterpretModel = interpretModel => () => {
-    this.setState({ ...this.state, loading: true})
-    interpretModel()
+    this.setState({ ...this.state, loading: true});
+    interpretModel().then(() => this.setState({ loading: false }));
   }
 
   colorize(tokensWithWeights, topKIdx) {
@@ -152,9 +152,6 @@ export class SaliencyComponent extends React.Component {
         displayText = <div><p style={{color: "#7c7c7c"}}>Press "interpret prediction" to show the interpretation.</p>{runButton}</div>
       }
     } else {
-      if (this.state.loading) { // loading is done
-          this.setState({ loading: false });
-      }
       const saliencyMaps = [];
       
       for (let i = 0; i < inputTokens.length; i++) {

--- a/demo/src/components/demos/Atis.js
+++ b/demo/src/components/demos/Atis.js
@@ -118,7 +118,7 @@ const Output = ({ responseData }) => {
 
   return (
     <div className="model__content answer">
-      <OutputField label="SQL Query" suppressSummary="true">
+      <OutputField label="SQL Query" suppressSummary>
         {query}
       </OutputField>
       {internals}

--- a/demo/src/components/demos/DemoStyles.js
+++ b/demo/src/components/demos/DemoStyles.js
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+import { Tabs } from '@allenai/varnish/components';
+
+export const DemoVisualizationTabs = styled(Tabs)`
+  .ant-tabs-bar.ant-tabs-top-bar {
+    margin: 0;
+  }
+`;

--- a/demo/src/components/demos/Event2Mind.js
+++ b/demo/src/components/demos/Event2Mind.js
@@ -10,6 +10,7 @@ import HighlightArrow from '../highlight/HighlightArrow';
 import HighlightContainer from '../highlight/HighlightContainer';
 import { Highlight } from '../highlight/Highlight';
 import Model from '../Model'
+import { DemoVisualizationTabs } from './DemoStyles'
 import '../../css/Event2MindDiagram.css';
 
 const title = "Event2Mind"
@@ -145,7 +146,7 @@ const Output = (props) => {
 
   return (
     <div className="model__content">
-      <Tabs>
+      <DemoVisualizationTabs>
           {
             Object.keys(VisualizationType).map(tpe => {
               const vizType = VisualizationType[tpe];
@@ -159,7 +160,7 @@ const Output = (props) => {
               )
             })
           }
-      </Tabs>
+      </DemoVisualizationTabs>
     </div>
   )
 }

--- a/demo/src/components/demos/Event2Mind.js
+++ b/demo/src/components/demos/Event2Mind.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ExternalLink } from '@allenai/varnish/components';
+import { ExternalLink, Tabs } from '@allenai/varnish/components';
 import { withRouter } from 'react-router-dom';
 
 import { API_ROOT } from '../../api-config';
@@ -139,50 +139,29 @@ const VisualizationType = {
 };
 Object.freeze(VisualizationType);
 
-// Stateful
-class Output extends React.Component {
-  constructor(props) {
-    super(props);
+const Output = (props) => {
+  const { requestData, responseData } = props;
+  const { source } = requestData
 
-    this.state = {
-      visualizationType: VisualizationType.DIAGRAM
-    }
-  }
-
-  render() {
-    const { requestData, responseData } = this.props;
-    const { visualizationType } = this.state;
-    const { source } = requestData
-
-    const viz = visualizationType === VisualizationType.TEXT
-            ? <TextOutput responseData={responseData} />
-            : <DiagramOutput responseData={responseData} source={source} />
-
-    return (
-        <div>
-            <ul className="visualization-types">
-                {
-                    Object.keys(VisualizationType).map(tpe => {
-                        const vizType = VisualizationType[tpe];
-                        const className = (
-                            visualizationType === vizType
-                            ? 'visualization-types__active-type'
-                            : null
-                        )
-                        return (
-                            <li key={vizType} className={className}>
-                            <a onClick={() => this.setState({ visualizationType: vizType })}>
-                                {vizType}
-                            </a>
-                            </li>
-                        )
-                    })
-                }
-            </ul>
-            {viz}
-        </div>
-    )
-  }
+  return (
+    <div className="model__content">
+      <Tabs>
+          {
+            Object.keys(VisualizationType).map(tpe => {
+              const vizType = VisualizationType[tpe];
+              const viz = vizType === VisualizationType.TEXT
+                ? <TextOutput responseData={responseData} />
+                : <DiagramOutput responseData={responseData} source={source} />
+              return (
+                <Tabs.TabPane key={vizType} tab={vizType}>
+                  {viz}
+                </Tabs.TabPane>
+              )
+            })
+          }
+      </Tabs>
+    </div>
+  )
 }
 
 const examples = [

--- a/demo/src/components/demos/LanguageModel.js
+++ b/demo/src/components/demos/LanguageModel.js
@@ -383,7 +383,7 @@ class App extends React.Component {
             <InputOutputColumn>
               <FormLabel>Sentence:</FormLabel>
                 <TextInput type="text"
-                          autosize={{ minRows: 5, maxRows: 10 }}
+                          autoSize={{ minRows: 5, maxRows: 10 }}
                           value={this.state.output}
                           onChange={this.setOutput}/>
                 {this.state.loading ? (
@@ -419,7 +419,7 @@ class App extends React.Component {
   }
 
   interpretModel = (inputs, interpreter) => () => {
-    fetch(apiUrlInterpret(inputs), {
+    return fetch(apiUrlInterpret(inputs), {
       method: 'POST',
       headers: {
         'Accept': 'application/json',
@@ -441,7 +441,7 @@ class App extends React.Component {
       attackInputs['target'] = {words: [[target]]}
     }
 
-    fetch(apiUrlAttack(inputs), {
+    return fetch(apiUrlAttack(inputs), {
       method: 'POST',
       headers: {
         'Accept': 'application/json',

--- a/demo/src/components/demos/LanguageModel.js
+++ b/demo/src/components/demos/LanguageModel.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { withRouter } from 'react-router-dom';
 import styled from 'styled-components';
 import _ from 'lodash';
-import { Footer, ExternalLink } from '@allenai/varnish/components';
+import { ExternalLink } from '@allenai/varnish/components';
 
 import OutputField from '../OutputField'
 import { Accordion } from 'react-accessible-accordion';

--- a/demo/src/components/demos/MaskedLm.js
+++ b/demo/src/components/demos/MaskedLm.js
@@ -359,7 +359,7 @@ class App extends React.Component {
             <InputOutputColumn>
               <FormLabel>Sentence:</FormLabel>
                 <TextInput type="text"
-                          autosize={{ minRows: 5, maxRows: 10 }}
+                          autoSize={{ minRows: 5, maxRows: 10 }}
                           value={this.state.output}
                           onChange={this.setOutput}/>
                 {this.state.loading ? (
@@ -386,7 +386,7 @@ class App extends React.Component {
   }
 
   interpretModel = (inputs, interpreter) => () => {
-    fetch(apiUrlInterpret(inputs), {
+    return fetch(apiUrlInterpret(inputs), {
       method: 'POST',
       headers: {
         'Accept': 'application/json',
@@ -408,7 +408,7 @@ class App extends React.Component {
       attackInputs['target'] = {words: [[target]]}
     }
 
-    fetch(apiUrlAttack(inputs), {
+    return fetch(apiUrlAttack(inputs), {
       method: 'POST',
       headers: {
         'Accept': 'application/json',

--- a/demo/src/components/demos/MaskedLm.js
+++ b/demo/src/components/demos/MaskedLm.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { withRouter } from 'react-router-dom';
 import styled from 'styled-components';
 import _ from 'lodash';
-import { Footer, ExternalLink } from '@allenai/varnish/components';
 
 import OutputField from '../OutputField'
 import { Accordion } from 'react-accessible-accordion';

--- a/demo/src/components/demos/Nlvr.js
+++ b/demo/src/components/demos/Nlvr.js
@@ -87,7 +87,7 @@ const Output = ({ responseData }) => {
             { denotations[0] }
           </OutputField>
 
-          <OutputField label="Logical Form" suppressSummary="true">
+          <OutputField label="Logical Form" suppressSummary>
             <SyntaxHighlight language="lisp">
                 {logical_form}
             </SyntaxHighlight>

--- a/demo/src/components/demos/OpenIe.js
+++ b/demo/src/components/demos/OpenIe.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ExternalLink } from '@allenai/varnish/components';
+import { ExternalLink, Tabs } from '@allenai/varnish/components';
 import { withRouter } from 'react-router-dom';
 
 import { API_ROOT } from '../../api-config';
@@ -192,53 +192,36 @@ const VisualizationType = {
 };
 Object.freeze(VisualizationType);
 
-// Stateful output component
-class Output extends React.Component {
-    constructor(props) {
-        super(props);
+const Output = props => {
+  const { responseData } = props
+  const { verbs } = responseData
 
-        this.state = { visualizationType: VisualizationType.TREE }
-    }
-
-    render() {
-        const { visualizationType } = this.state
-        const { responseData } = this.props
-        const { verbs } = responseData
-
-        let viz = null;
-        switch(visualizationType) {
-        case VisualizationType.TEXT:
-            viz = <TextVisualization verbs={verbs} model="oie"/>;
-            break;
-        case VisualizationType.TREE:
-        default:
-            viz = <HierplaneVisualization trees={toHierplaneTrees(responseData)} />
-            break;
-        }
-
-    return (
-      <div>
-          <ul className="visualization-types">
-            {Object.keys(VisualizationType).map(tpe => {
+  return (
+    <div className="model__content">
+      <Tabs>
+          {
+            Object.keys(VisualizationType).map(tpe => {
               const vizType = VisualizationType[tpe];
-              const className = (
-                visualizationType === vizType
-                  ? 'visualization-types__active-type'
-                  : null
-              );
+              let viz = null;
+              switch(vizType) {
+                case VisualizationType.TEXT:
+                  viz = <TextVisualization verbs={verbs} model="oie"/>;
+                  break;
+                case VisualizationType.TREE:
+                default:
+                  viz = <HierplaneVisualization trees={toHierplaneTrees(responseData)} />
+                  break;
+              }
               return (
-                <li key={vizType} className={className}>
-                  <a onClick={() => this.setState({ visualizationType: vizType })}>
-                    {vizType}
-                  </a>
-                </li>
-              );
-            })}
-          </ul>
-          {viz}
-      </div>
-    )
-  }
+                <Tabs.TabPane key={vizType} tab={vizType}>
+                  {viz}
+                </Tabs.TabPane>
+              )
+            })
+          }
+      </Tabs>
+    </div>
+  )
 }
 
 const examples = [

--- a/demo/src/components/demos/OpenIe.js
+++ b/demo/src/components/demos/OpenIe.js
@@ -10,6 +10,7 @@ import { UsageSection } from '../UsageSection';
 import { UsageHeader } from '../UsageHeader';
 import { UsageCode } from '../UsageCode';
 import SyntaxHighlight from '../highlight/SyntaxHighlight';
+import { DemoVisualizationTabs } from './DemoStyles';
 
 const title = "Open Information Extraction";
 
@@ -198,7 +199,7 @@ const Output = props => {
 
   return (
     <div className="model__content">
-      <Tabs>
+      <DemoVisualizationTabs>
           {
             Object.keys(VisualizationType).map(tpe => {
               const vizType = VisualizationType[tpe];
@@ -219,7 +220,7 @@ const Output = props => {
               )
             })
           }
-      </Tabs>
+      </DemoVisualizationTabs>
     </div>
   )
 }

--- a/demo/src/components/demos/SemanticRoleLabeling.js
+++ b/demo/src/components/demos/SemanticRoleLabeling.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ExternalLink } from  '@allenai/varnish/components';
+import { ExternalLink, Tabs } from  '@allenai/varnish/components';
 import { withRouter } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -191,67 +191,48 @@ const NoOutputMessage = styled.div`
   padding: 2rem;
 `;
 
-// Stateful output component
-class Output extends React.Component {
-    constructor(props) {
-        super(props)
+const Output = props => {
+  const { responseData } = props
+  const { verbs } = responseData
 
-        this.state = { visualizationType: VisualizationType.TREE }
-    }
+  return (
+      <div className="model__content">
+        <Tabs>
+          {
+            Object.keys(VisualizationType).map(tpe => {
+              const vizType = VisualizationType[tpe];
+              let viz = null;
 
-    render() {
-        const { visualizationType } = this.state
-        const { responseData } = this.props
-        const { verbs } = responseData
-
-        let viz = null;
-
-        // If there's no verbs, there's no output to display.
-        if (Array.isArray(verbs) && verbs.length > 0) {
-          switch(visualizationType) {
-            case VisualizationType.TEXT:
-              viz = <TextVisualization verbs={verbs} model="srl" />;
-              break;
-            case VisualizationType.TREE:
-            default:
-              viz = <HierplaneVisualization trees={toHierplaneTrees(responseData)} />
-              break;
+              // If there's no verbs, there's no output to display.
+              if (Array.isArray(verbs) && verbs.length > 0) {
+                switch(vizType) {
+                  case VisualizationType.TEXT:
+                    viz = <TextVisualization verbs={verbs} model="srl" />;
+                    break;
+                  case VisualizationType.TREE:
+                  default:
+                    viz = <HierplaneVisualization trees={toHierplaneTrees(responseData)} />
+                    break;
+                }
+              }
+      
+              if (viz == null) {
+                return (
+                  <NoOutputMessage>
+                    No output. Please revise the sentence and try again.
+                  </NoOutputMessage>
+                );
+              }
+              return (
+                <Tabs.TabPane key={vizType} tab={vizType}>
+                  {viz}
+                </Tabs.TabPane>
+              )
+            })
           }
-        }
-
-        if (viz == null) {
-          return (
-            <NoOutputMessage>
-              No output. Please revise the sentence and try again.
-            </NoOutputMessage>
-          );
-        }
-
-        return (
-            <div>
-                <ul className="visualization-types">
-                    {
-                        Object.keys(VisualizationType).map(tpe => {
-                            const vizType = VisualizationType[tpe];
-                            const className = (
-                                visualizationType === vizType
-                                ? 'visualization-types__active-type'
-                                : null
-                            )
-                            return (
-                                <li key={vizType} className={className}>
-                                <a onClick={() => this.setState({ visualizationType: vizType })}>
-                                    {vizType}
-                                </a>
-                                </li>
-                            )
-                        })
-                    }
-                </ul>
-                {viz}
-            </div>
-        )
-    }
+        </Tabs>
+      </div>
+  )
 }
 
 const examples = [

--- a/demo/src/components/demos/SemanticRoleLabeling.js
+++ b/demo/src/components/demos/SemanticRoleLabeling.js
@@ -10,6 +10,7 @@ import TextVisualization from '../TextVisualization'
 import { UsageSection } from '../UsageSection';
 import { UsageHeader } from '../UsageHeader';
 import { UsageCode } from '../UsageCode';
+import { DemoVisualizationTabs } from './DemoStyles';
 import SyntaxHighlight from '../highlight/SyntaxHighlight';
 
 const title = "Semantic Role Labeling"
@@ -197,7 +198,7 @@ const Output = props => {
 
   return (
       <div className="model__content">
-        <Tabs>
+        <DemoVisualizationTabs>
           {
             Object.keys(VisualizationType).map(tpe => {
               const vizType = VisualizationType[tpe];
@@ -230,7 +231,7 @@ const Output = props => {
               )
             })
           }
-        </Tabs>
+        </DemoVisualizationTabs>
       </div>
   )
 }

--- a/demo/src/components/demos/TextualEntailment.js
+++ b/demo/src/components/demos/TextualEntailment.js
@@ -21,13 +21,11 @@ import '../../css/TeComponent.css';
 
 import SaliencyMaps from '../Saliency'
 import InputReductionComponent from '../InputReduction'
-import HotflipComponent from '../Hotflip'
 import {
   GRAD_INTERPRETER,
   IG_INTERPRETER,
   SG_INTERPRETER,
-  INPUT_REDUCTION_ATTACKER,
-  HOTFLIP_ATTACKER
+  INPUT_REDUCTION_ATTACKER
 } from '../InterpretConstants'
 
 const apiUrl = () => `${API_ROOT}/predict/textual-entailment`

--- a/demo/src/components/demos/WikiTables.js
+++ b/demo/src/components/demos/WikiTables.js
@@ -88,7 +88,7 @@ const Output = ({ responseData }) => {
           { answer }
         </OutputField>
 
-        <OutputField label="Logical Form" suppressSummary="true">
+        <OutputField label="Logical Form">
           <SyntaxHighlight language="lisp">
               {logical_form[0].toString()}
           </SyntaxHighlight>

--- a/demo/src/css/hierplane-overrides.css
+++ b/demo/src/css/hierplane-overrides.css
@@ -10,11 +10,11 @@
   margin-right: 1em;
 }
 
-.hierplane__visualization-verbs a svg {
+.hierplane__visualization-verbs button svg {
   fill: rgba(28, 47, 58, .5);
 }
 
-.hierplane__visualization-verbs a:hover svg {
+.hierplane__visualization-verbs button:hover svg {
   fill: #1c2f3a;
 }
 


### PR DESCRIPTION
This PR:

* Updates deprecated React Lifecycle Hooks
* Removes any state updates within render methods
* Changes anchor tags to buttons where we utilize `onClick` rather than href as recommended by the a11y linter
* Adds keys to rendered lists of React elements
* Removes unused imports
* Addresses other console warnings and errors as appropriate