### PR TITLE
Update left nav to use Varnish layouts

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@allenai/varnish": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/@allenai/varnish/-/varnish-0.8.6.tgz",
-      "integrity": "sha512-hX9y8pRhSPdw1t86lDy5sWp/jbjxnyf7J+Xk1VMR624m6CrqT5d4oI57FCS3o/OzgDQRkEngMlVq/d5ElxFuaA=="
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@allenai/varnish/-/varnish-0.8.11.tgz",
+      "integrity": "sha512-kEYW3/XqwxTSCz68iPJj/tqYi/zAkwACnFgy3aEK54SiuLFRB0B0iv/A29ugjilWbMvPfe5mj/m2D9kTL5CxCA=="
     },
     "@ant-design/colors": {
       "version": "3.2.2",

--- a/demo/package.json
+++ b/demo/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@allenai/varnish": "0.8.6",
+    "@allenai/varnish": "0.8.11",
     "ajv": "^6.10.0",
     "antd": "^3.23.2",
     "colormap": "^2.3.1",

--- a/demo/public/index.html
+++ b/demo/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="stylesheet" type="text/css" href="https://unpkg.com/hierplane@0.0.9/dist/static/hierplane.min.css">
-    <link rel=stylesheet href="https://cdn.jsdelivr.net/npm/@allenai/varnish@0.8.6/dist/theme.min.css" />
+    <link rel=stylesheet href="https://cdn.jsdelivr.net/npm/@allenai/varnish@0.8.11/dist/theme.min.css" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <title>AllenNLP - Demo</title>

--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -3,14 +3,15 @@ import styled from 'styled-components';
 import { BrowserRouter as Router, Route, Redirect, Switch } from 'react-router-dom';
 import { ThemeProvider } from '@allenai/varnish/theme';
 import { DefaultLayoutProvider } from '@allenai/varnish/layout';
-import { Header, ExternalLink } from '@allenai/varnish/components';
+import { Header, ExternalLink, Content, Layout, HeaderColumns, Footer } from '@allenai/varnish/components';
 
 import { API_ROOT } from './api-config';
-import { Menu } from './components/Menu';
+import Menu from './components/Menu';
 import ModelIntro from './components/ModelIntro';
 import { modelComponents, modelRedirects } from './models'
 import { PaneTop } from './components/Pane';
 import WaitingForPermalink from './components/WaitingForPermalink';
+import allenNlpLogo from './components/allennlp_logo.svg';
 
 import './css/App.css';
 import './css/fonts.css';
@@ -75,15 +76,37 @@ const Demo = (props) => {
   const redirectedModel = modelRedirects[model] || model
 
   return (
-    <React.Fragment>
-      <Header alwaysVisible={true} />
-      <div className="pane-container">
-        <Menu selectedModel={redirectedModel} clearData={() => {}}/>
-        <SingleTaskFrame model={redirectedModel} slug={slug} search={search} />
-      </div>
-    </React.Fragment>
-  )
+    <Layout bgcolor="white">
+      <Header alwaysVisible={true}>
+          <HeaderColumnsWithSpace gridTemplateColumns="auto auto 1fr">
+            <Logo width="124px"
+              height="22px"
+              alt="AllenNLP"
+            />
+          </HeaderColumnsWithSpace>
+        </Header>
+      <Layout>
+        <Menu redirectedModel={redirectedModel} />
+        <Layout>
+          <Content>
+            <SingleTaskFrame model={redirectedModel} slug={slug} search={search} />
+          </Content>
+          <Footer />
+        </Layout>
+      </Layout>
+    </Layout>
+  );  
 }
+
+const Logo = styled.img.attrs({
+  src: allenNlpLogo
+})`
+  height: 56px;
+`;
+
+const HeaderColumnsWithSpace = styled(HeaderColumns)`
+    padding: 11.5px 0;
+`;
 
 // Load the task in an iframe
 const SingleTaskFrame = (props) => {
@@ -91,7 +114,7 @@ const SingleTaskFrame = (props) => {
   const maybeSlug = slug ? `/${slug}` : ''
   const url = `/task/${model}${maybeSlug}${search}`
 
-  return <iframe title={`SingleTaskFrame for ${model}`} src={url} style={{width: "100%", borderWidth: 0}}/>
+  return <iframe title={`SingleTaskFrame for ${model}`} src={url} style={{width: "100%", height: "100%", borderWidth: 0}}/>
 }
 
 

--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -86,10 +86,12 @@ const Demo = (props) => {
     <Layout bgcolor="white">
       <Header alwaysVisible={true}>
           <HeaderColumnsWithSpace gridTemplateColumns="auto auto 1fr">
-            <Logo width="124px"
-              height="22px"
-              alt="AllenNLP"
-            />
+          <a href="http://www.allennlp.org/" target="_blank" rel="noopener noreferrer">
+              <Logo width="124px"
+                height="22px"
+                alt="AllenNLP"
+              />
+            </a>
           </HeaderColumnsWithSpace>
         </Header>
       <Layout>

--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -3,15 +3,22 @@ import styled from 'styled-components';
 import { BrowserRouter as Router, Route, Redirect, Switch } from 'react-router-dom';
 import { ThemeProvider } from '@allenai/varnish/theme';
 import { DefaultLayoutProvider } from '@allenai/varnish/layout';
-import { Header, ExternalLink, Content, Layout, HeaderColumns, Footer } from '@allenai/varnish/components';
+import { 
+  Content,
+  ExternalLink,
+  Footer,
+  Header,
+  HeaderColumns,
+  Layout,
+} from '@allenai/varnish/components';
 
+import allenNlpLogo from './components/allennlp_logo.svg';
 import { API_ROOT } from './api-config';
 import Menu from './components/Menu';
 import ModelIntro from './components/ModelIntro';
 import { modelComponents, modelRedirects } from './models'
 import { PaneTop } from './components/Pane';
 import WaitingForPermalink from './components/WaitingForPermalink';
-import allenNlpLogo from './components/allennlp_logo.svg';
 
 import './css/App.css';
 import './css/fonts.css';

--- a/demo/src/components/Menu.js
+++ b/demo/src/components/Menu.js
@@ -18,11 +18,6 @@ import { modelGroups } from '../models'
 
 export default class Menu extends React.Component {
   siderWidthExpanded = '300px';
-  /**
-   * TODO: Figure out why this must be 80px, and no other value, antd
-   * sets this explicitly in CSS, so I'm not sure why the collapsedWidth
-   * property is provided.
-   */
   siderWidthCollapsed = '80px';
   constructor(props) {
       super(props);
@@ -35,6 +30,7 @@ export default class Menu extends React.Component {
   handleMenuCollapse = () => {
       this.setState({ menuCollapsed: !this.state.menuCollapsed });
   };
+  
   render() {
     return (
       <LeftSider

--- a/demo/src/components/Menu.js
+++ b/demo/src/components/Menu.js
@@ -1,5 +1,14 @@
 import React from 'react';
-import { LeftSider, InternalLink, LeftMenu, IconMenuItemColumns, ImgIcon, Wrapping, BodySmall, LeftMenuItem } from '@allenai/varnish/components';
+import { 
+  BodySmall, 
+  IconMenuItemColumns, 
+  ImgIcon, 
+  InternalLink, 
+  LeftMenu, 
+  LeftMenuItem,
+  LeftSider,
+  Wrapping, 
+} from '@allenai/varnish/components';
 
 import { modelGroups } from '../models'
 

--- a/demo/src/components/Menu.js
+++ b/demo/src/components/Menu.js
@@ -1,122 +1,68 @@
 import React from 'react';
-import styled from 'styled-components';
-import { Menu as AntMenu } from 'antd';
-import { InternalLink, ImgIcon } from '@allenai/varnish/components';
+import { LeftSider, InternalLink, LeftMenu, IconMenuItemColumns, ImgIcon, Wrapping, BodySmall, LeftMenuItem } from '@allenai/varnish/components';
 
-import allenNlpLogo from './allennlp_logo.svg';
 import { modelGroups } from '../models'
 
 /*******************************************************************************
   <Menu /> Component
 *******************************************************************************/
 
-export class MenuBase extends React.Component {
+export default class Menu extends React.Component {
+  siderWidthExpanded = '300px';
+  /**
+   * TODO: Figure out why this must be 80px, and no other value, antd
+   * sets this explicitly in CSS, so I'm not sure why the collapsedWidth
+   * property is provided.
+   */
+  siderWidthCollapsed = '80px';
+  constructor(props) {
+      super(props);
+
+      this.state = {
+          menuCollapsed: false
+      };
+  }
+
+  handleMenuCollapse = () => {
+      this.setState({ menuCollapsed: !this.state.menuCollapsed });
+  };
   render() {
-    const { selectedModel, clearData } = this.props;
-
-    const ModelGroup = ({modelGroup, expanded, ...other}) => (
-      <NarrowSubMenu
-        {...other}
-        title={
-          <span>
-            <ImgIcon src={modelGroup.iconSrc} />
-            <span>{modelGroup.label}</span>
-          </span>
-        }>
-          {modelGroup.models.map(m => <ModelLink key={m.model} model={m.model} name={m.name} />)}
-      </NarrowSubMenu>
-    );
-
-    const ModelLink = ({model, name, ...other}) => (
-      <NarrowMenuItem {...other}>
-          <WrappingLink to={"/" + model} onClick={clearData}>
-            <span>{name}</span>
-          </WrappingLink>
-      </NarrowMenuItem>
-    );
-
     return (
-      <OuterGrid>
-        <Logo>
-          <a href="http://www.allennlp.org/" target="_blank" rel="noopener noreferrer">
-            <img
-              src={allenNlpLogo}
-              width={"124px"}
-              height={"22px"}
-              alt="AllenNLP" />
-          </a>
-        </Logo>
-        <MenuContent
-          onClick={clearData}
-          defaultOpenKeys={modelGroups.filter((mg) => mg.defaultOpen).map((mg) => mg.label)}
-          defaultSelectedKeys={selectedModel ? [selectedModel] : undefined}
-          mode="inline">
-          {modelGroups.map((mg) =>
-            <ModelGroup key={mg.label} modelGroup={mg}/>
-          )}
-        </MenuContent>
-      </OuterGrid>
-    );
+      <LeftSider
+        width={this.siderWidthExpanded}
+        collapsedWidth={this.siderWidthCollapsed}
+        collapsible
+        collapsed={this.state.menuCollapsed}
+        onCollapse={this.handleMenuCollapse}>
+          <LeftMenu
+            defaultSelectedKeys={[this.props.redirectedModel]}
+            defaultOpenKeys={modelGroups.filter(g => g.defaultOpen).map(g => g.label)}
+          >
+            {modelGroups.map(g => (
+              <LeftMenu.SubMenu
+                key={g.label}
+                title={
+                  <IconMenuItemColumns>
+                    {g.iconSrc && (
+                      <ImgIcon src={g.iconSrc} />
+                    )}
+                    <Wrapping>
+                      <BodySmall>{g.label}</BodySmall>
+                    </Wrapping>
+                  </IconMenuItemColumns>
+                }
+              >
+                {g.models.map(m => (
+                  <LeftMenuItem key={m.model}>
+                    <InternalLink to={"/" + m.model} onClick={() => {}}>
+                      <span>{m.name}</span>
+                    </InternalLink>
+                  </LeftMenuItem>
+                ))}
+              </LeftMenu.SubMenu>
+            ))}
+          </LeftMenu>
+      </LeftSider>
+    )
   }
 }
-
-export const Menu = styled(MenuBase)`
-  height: 100%;
-  position: fixed;
-  z-index: 2;
-`;
-
-const OuterGrid = styled.div`
-  display: grid;
-  grid-template-rows: min-content 1fr;
-  height: 100%;
-`;
-
-const Logo = styled.div`
-  z-index: 3;
-  padding: ${({theme}) => `1.3125rem ${theme.spacing.xl}`} 1.3125rem 1.5rem; /* match position of initial placement of model title in right pane */
-  box-shadow: ${({theme}) => `0 ${theme.spacing.md} ${theme.spacing.md} -${theme.spacing.sm} ${theme.palette.border.main}`};
-  border-right: ${({theme}) => `1px solid ${theme.palette.border.main}`};
-`;
-
-const MenuContent = styled(AntMenu)`
-  &&& {
-    min-width: 15em;
-    max-width: 20em;
-    overflow-x: hidden;
-    overflow-y: auto;
-    padding: ${({theme}) => `${theme.spacing.md} 0`};
-  }
-`;
-
-const NarrowMenuItem = styled(AntMenu.Item)`
-  &&& {
-    line-height: 1.4em;
-    height: initial;
-    padding-bottom: 0.375em;
-    padding-top: 0.375em;
-    margin-bottom: -0.125em;
-    margin-top: -0.125em;
-  }
-`;
-
-const NarrowSubMenu = styled(AntMenu.SubMenu)`
-  &&& {
-    margin-bottom: ${({theme}) => theme.spacing.md};
-
-    div { /* .ant-menu-submenu-title */
-      line-height: 1.4em;
-      height: initial;
-      font-weight: bold;
-
-      img {
-        vertical-align: initial;
-      }
-    }
-  }
-`;
-
-const WrappingLink = styled(InternalLink)`
-    white-space: pre-wrap;
-    word-wrap: break-word;
-`;

--- a/demo/src/components/Pane.js
+++ b/demo/src/components/Pane.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Footer } from '@allenai/varnish/components';
 
 import '../css/Pane.css';
 import '../css/model.css';
@@ -50,7 +49,6 @@ class ResultDisplay extends React.Component {
         <div className={`pane__${resultPane} model__output ${outputState !== "received" ? "model__output--empty" : ""}`}>
           <div className="pane__thumb"></div>
           {outputContent}
-          <Footer />
         </div>
       );
     }


### PR DESCRIPTION
This PR:

* Removes the old bespoke menu in favor of the Varnish left menu layout so that it matches PRIOR and others.

NEW
<img width="1206" alt="Screen Shot 2020-02-06 at 3 14 56 PM" src="https://user-images.githubusercontent.com/10873798/73986872-9870bf00-48f3-11ea-90c8-b62cae2889c5.png">

OLD
<img width="1202" alt="Screen Shot 2020-02-06 at 3 16 58 PM" src="https://user-images.githubusercontent.com/10873798/73986941-c7873080-48f3-11ea-97c3-34417b93bb8c.png">

