### PR TITLE
Give labels to all the sets of accordion menus

### DIFF
--- a/demo/src/components/demos/LanguageModel.js
+++ b/demo/src/components/demos/LanguageModel.js
@@ -219,7 +219,7 @@ const Attacks = ({attackData, attackModel, requestData}) => {
     hotflipData["final"][0] = cleanTokensForDisplay(hotflipData["final"][0]);
   }
   return (
-    <OutputField>
+    <OutputField label="Model Attacks">
       <Accordion accordion={false}>
         <HotflipComponent hotflipData={hotflipData} hotflipFunction={attackModel(requestData, HOTFLIP_ATTACKER, NAME_OF_INPUT_TO_ATTACK, NAME_OF_GRAD_INPUT)} />
       </Accordion>

--- a/demo/src/components/demos/MaskedLm.js
+++ b/demo/src/components/demos/MaskedLm.js
@@ -182,7 +182,7 @@ const Attacks = ({attackData, attackModel, requestData}) => {
     hotflipData["new_prediction"] = hotflipData["outputs"]["words"][0][0];
   }
   return (
-    <OutputField>
+    <OutputField label="Model Attacks">
       <Accordion accordion={false}>
         <HotflipComponent hotflipData={hotflipData} hotflipFunction={attackModel(requestData, HOTFLIP_ATTACKER, NAME_OF_INPUT_TO_ATTACK, NAME_OF_GRAD_INPUT)} targeted={true}/>
       </Accordion>

--- a/demo/src/components/demos/ReadingComprehension.js
+++ b/demo/src/components/demos/ReadingComprehension.js
@@ -69,7 +69,7 @@ const fields = [
 const Attention = ({passage_question_attention, question_tokens, passage_tokens}) => {
   if(passage_question_attention && question_tokens && passage_tokens) {
     return (
-        <OutputField label="Model internals">
+        <OutputField label="Model Internals">
           <Accordion accordion={false}>
             <AccordionItem expanded={false}>
               <AccordionItemTitle>
@@ -200,7 +200,7 @@ const Attacks = ({attackData, attackModel, requestData}) => {
     <InputReductionComponent reducedInput={reducedInput} reduceFunction={attackModel(requestData, INPUT_REDUCTION_ATTACKER, NAME_OF_INPUT_TO_ATTACK, NAME_OF_GRAD_INPUT)} />
 
   return (
-    <OutputField>
+    <OutputField label="Model Attacks">
       <Accordion accordion={false}>
         {inputReduction}
         <HotflipComponent hotflipData={hotflipData} hotflipFunction={attackModel(requestData, HOTFLIP_ATTACKER, NAME_OF_INPUT_TO_ATTACK, NAME_OF_GRAD_INPUT)} />

--- a/demo/src/components/demos/SentimentAnalysis.js
+++ b/demo/src/components/demos/SentimentAnalysis.js
@@ -75,7 +75,7 @@ const Attacks = ({attackData, attackModel, requestData}) => {
     reducedInput = {original: reductionData["original"], reduced: [reductionData["final"][0]]};
   }
   return (
-    <OutputField>
+    <OutputField label="Model Attacks">
       <Accordion accordion={false}>
         <InputReductionComponent reducedInput={reducedInput} reduceFunction={attackModel(requestData, INPUT_REDUCTION_ATTACKER, NAME_OF_INPUT_TO_ATTACK, NAME_OF_GRAD_INPUT)} />
         <HotflipComponent hotflipData={hotflipData} hotflipFunction={attackModel(requestData, HOTFLIP_ATTACKER, NAME_OF_INPUT_TO_ATTACK, NAME_OF_GRAD_INPUT)} />

--- a/demo/src/components/demos/TextualEntailment.js
+++ b/demo/src/components/demos/TextualEntailment.js
@@ -155,7 +155,7 @@ const Attacks = ({attackData, attackModel, requestData}) => {
     };
   }
   return (
-    <OutputField>
+    <OutputField label="Model Attacks">
       <Accordion accordion={false}>
         <InputReductionComponent reducedInput={reducedInput} reduceFunction={attackModel(requestData, INPUT_REDUCTION_ATTACKER, NAME_OF_INPUT_TO_ATTACK, NAME_OF_GRAD_INPUT)} />
       </Accordion>


### PR DESCRIPTION
This PR:

Adds labels to all the sets of accordion menus so that it doesn't look weird to have random spaces between categories.

<img width="778" alt="Screen Shot 2020-02-06 at 3 58 24 PM" src="https://user-images.githubusercontent.com/10873798/73989120-8c87fb80-48f9-11ea-9621-56b8ad12a615.png">
