### PR TITLE
Set the canonical host only for prod environments.

### DIFF
--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -58,18 +58,16 @@ local num_replicas = (
 );
 
 local topLevelDomain = '.apps.allenai.org';
-local canonicalTopLevelDomain = '.allennlp.org';
 
-local hosts = [
+// Only register demo.allennlp.org for production environments, there's 
+// no wildcard entry (*.allennlp.org) directing URLs with the environment
+// as a subdomain to the Skiff cluster. If a URL is included here that
+// isn't routed to the cluster a TLS certificate can't be issued.
+local hosts =
     if env == 'prod' then
-        config.appName + topLevelDomain
+        [ config.appName + topLevelDomain, 'demo.allennlp.org' ]
     else
-        config.appName + '.' + env + topLevelDomain,
-    if env == 'prod' then
-        'demo' + canonicalTopLevelDomain
-    else
-        'demo' + '.' + env + canonicalTopLevelDomain
-];
+        [ config.appName + '.' + env + topLevelDomain ];
 
 // Each app gets it's own namespace
 local namespaceName = config.appName;


### PR DESCRIPTION
This fixes an issue where Skiff ad-hoc environments weren't working because `demo.$env.allennlp.org` wouldn't resolve to the Skiff cluster. When this occurred this prevented a TLS certificate from being issued.

I confirmed this by live `kubectl edit`ing @brendan-ai2's `dv-4` ad-hoc.  Removing the `allennlp.org` entries resolved the issue.