### PR TITLE
Add coref model attribution

### DIFF
--- a/demo/src/components/demos/Coref.js
+++ b/demo/src/components/demos/Coref.js
@@ -34,6 +34,9 @@ const description = (
     in early 2017. The model here is based on that paper, but we have substituted the GloVe embeddings
     that it uses with BERT embeddings. On Ontonotes that gives an F1 score of 72.13 on test.
     </span>
+    <p>
+      <b>Contributed by:</b> Zhaofeng Wu
+    </p>
   </span>
 );
 


### PR DESCRIPTION
As suggested by @schmmd. In the future, this could become a standard field for all models, just like `title` and `description`, so that we can control the formatting easier (say in `ModelIntro.js`).