### PR TITLE
Fix remaining character when user cleared input of language model

### DIFF
--- a/demo/src/components/demos/LanguageModel.js
+++ b/demo/src/components/demos/LanguageModel.js
@@ -273,6 +273,17 @@ class App extends React.Component {
 
       this.debouncedChoose()
     }
+    else { // Update text input without request to backend server
+      this.setState({
+          output: value,
+          words: null,
+          logits: null,
+          probabilities: null,
+          interpretData: null,
+          attackData: null,
+          loading: false
+      })
+    }
   }
 
   createRequestId() {

--- a/demo/src/components/demos/MaskedLm.js
+++ b/demo/src/components/demos/MaskedLm.js
@@ -237,6 +237,17 @@ class App extends React.Component {
 
       this.debouncedChoose()
     }
+    else { // Update text input without request to backend server
+      this.setState({
+          output: value,
+          words: null,
+          logits: null,
+          probabilities: null,
+          interpretData: null,
+          attackData: null,
+          loading: false
+      })
+    }
   }
 
   createRequestId() {


### PR DESCRIPTION
Previous code did not update component state when user cleared all
text input, probably to avoid backend request.
However, it resulted in a UI bug where the last character could
not be deleted as user might expect.