### PR TITLE
now the sentiment analysis interpret uses tokens returned by predict_json, rather than requested data

### DIFF
--- a/demo/src/components/Model.js
+++ b/demo/src/components/Model.js
@@ -54,7 +54,7 @@ class Model extends React.Component {
         this.props.updateData(inputs, json)
         //
         // requestData, responseData
-
+        this.setState({tokens: json['tokens']});
         if (window.frameElement) {
           // Based on http://www.awongcm.io/blog/2018/11/25/using-iframes-api-to-toggle-client-side-routing-of-react-router-for-legacy-web-apps/
           window.frameElement.ownerDocument.defaultView.history.pushState({}, '', newPath)

--- a/demo/src/components/Model.js
+++ b/demo/src/components/Model.js
@@ -54,7 +54,7 @@ class Model extends React.Component {
         this.props.updateData(inputs, json)
         //
         // requestData, responseData
-        this.setState({tokens: json['tokens']});
+
         if (window.frameElement) {
           // Based on http://www.awongcm.io/blog/2018/11/25/using-iframes-api-to-toggle-client-side-routing-of-react-router-for-legacy-web-apps/
           window.frameElement.ownerDocument.defaultView.history.pushState({}, '', newPath)

--- a/demo/src/components/demos/SentimentAnalysis.js
+++ b/demo/src/components/demos/SentimentAnalysis.js
@@ -131,7 +131,7 @@ const Output = ({ responseData, requestData, interpretData, interpretModel, atta
 
   const [positiveClassProbability, negativeClassProbability] = responseData['probs']
   const prediction = negativeClassProbability < positiveClassProbability ? "Positive" : "Negative"
-  const tokens = responseData['tokens'];
+  const tokens = responseData['tokens'] || requestData['sentence'].split(' ');
   // The RoBERTa-large model is very slow to be attacked
   const attacks = model && model.includes('RoBERTa') ?
     " "

--- a/demo/src/components/demos/SentimentAnalysis.js
+++ b/demo/src/components/demos/SentimentAnalysis.js
@@ -126,14 +126,11 @@ const Attacks = ({attackData, attackModel, requestData}) => {
 }
 
 // What is rendered as Output when the user hits buttons on the demo.
-const Output = ({ responseData, requestData, interpretData, interpretModel, attackData, attackModel}) => {
+const Output = ({ tokens, responseData, requestData, interpretData, interpretModel, attackData, attackModel}) => {
   const model = requestData ? requestData.model : undefined;
 
   const [positiveClassProbability, negativeClassProbability] = responseData['probs']
   const prediction = negativeClassProbability < positiveClassProbability ? "Positive" : "Negative"
-
-  let t = requestData;
-  const tokens = t['sentence'].split(' '); // this model expects space-separated inputs
 
   // The RoBERTa-large model is very slow to be attacked
   const attacks = model && model.includes('RoBERTa') ?

--- a/demo/src/components/demos/SentimentAnalysis.js
+++ b/demo/src/components/demos/SentimentAnalysis.js
@@ -126,12 +126,12 @@ const Attacks = ({attackData, attackModel, requestData}) => {
 }
 
 // What is rendered as Output when the user hits buttons on the demo.
-const Output = ({ tokens, responseData, requestData, interpretData, interpretModel, attackData, attackModel}) => {
+const Output = ({ responseData, requestData, interpretData, interpretModel, attackData, attackModel}) => {
   const model = requestData ? requestData.model : undefined;
 
   const [positiveClassProbability, negativeClassProbability] = responseData['probs']
   const prediction = negativeClassProbability < positiveClassProbability ? "Positive" : "Negative"
-
+  const tokens = responseData['tokens'];
   // The RoBERTa-large model is very slow to be attacked
   const attacks = model && model.includes('RoBERTa') ?
     " "


### PR DESCRIPTION
PR created in reference to #339. This is just a very simple fix so that the interpret code uses tokens returned by `predict_json` rather than the requested data. This way special tokenization (like wordpiece) can work properly for saliency maps. 

As mentioned, this would require changes in allennlp too. Do you want me to do that as well? If so, should I change the `make_output_human_readable` method or something else? @matt-gardner 