### PR TITLE
Undo a rename from earlier. We can't rename pinned models.

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,7 +47,7 @@ logger.addHandler(handler)
 logger.propagate = False
 
 supported_interpret_models = {'named-entity-recognition',
-                              'fine-grained-ner',
+                              'fine-grained-named-entity-recognition',
                               'glove-sentiment-analysis',
                               'roberta-sentiment-analysis',
                               'elmo-snli',

--- a/demo/src/components/demos/NamedEntityRecognition.js
+++ b/demo/src/components/demos/NamedEntityRecognition.js
@@ -79,7 +79,7 @@ const taskModels = [
 
 const taskEndpoints = {
   "elmo-ner": "named-entity-recognition",
-  "fine-grained-ner": "fine-grained-ner"
+  "fine-grained-ner": "fine-grained-named-entity-recognition"
 };
 
 const fields = [

--- a/models.json
+++ b/models.json
@@ -57,7 +57,7 @@
         "predictor_name": "sentence-tagger",
         "max_request_length": 94864
     },
-    "fine-grained-ner": {
+    "fine-grained-named-entity-recognition": {
         "archive_file": "https://storage.googleapis.com/allennlp-public-models/fine-grained-ner-model-elmo-2018.12.21.tar.gz",
         "predictor_name": "sentence-tagger",
         "max_request_length": 22878,


### PR DESCRIPTION
Marina requires short names, so I renamed `fine-grained-named-entity-recognition` to `fine-grained-ner`. But that model is also pinned, and when you rename pinned models, they crash. So this is renaming it back. Let's hope this branch name is short enough.