### PR TITLE
Don't serve the UI with Python.

### DIFF
--- a/.skiff/cloudbuild-deploy.yaml
+++ b/.skiff/cloudbuild-deploy.yaml
@@ -4,7 +4,7 @@
 # variable).
 #
 steps:
-# Pull the current latest image, so we can use its cached layers.
+# Build the Python API. All models (currently) run in the same image.
 - id: 'pull'
   name: 'gcr.io/cloud-builders/docker'
   entrypoint: '/bin/bash'
@@ -12,7 +12,7 @@ steps:
     '-c',
     'docker pull gcr.io/$PROJECT_ID/$REPO_NAME:latest || exit 0'
   ]
-# Build the Docker image and tag with the current SHA and latest.
+  waitFor: [ '-' ]
 - id: 'build'
   name: 'gcr.io/cloud-builders/docker'
   args: [
@@ -22,45 +22,79 @@ steps:
     '--cache-from', 'gcr.io/$PROJECT_ID/$REPO_NAME:latest',
     '.'
   ]
-# Push the image tagged by the SHA
+  waitFor: [ 'pull' ]
 - id: 'push'
   name: 'gcr.io/cloud-builders/docker'
   args: [
     'push',
     'gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA',
   ]
-# Generate our Kubernetes configuration
+  waitFor: [ 'push' ]
+# Build an image that serves the files required for the UI from disk via
+# NGINX
+- id: 'ui.pull'
+  name: 'gcr.io/cloud-builders/docker'
+  entrypoint: '/bin/bash'
+  args: [
+    '-c',
+    'docker pull gcr.io/$PROJECT_ID/$REPO_NAME-ui:latest || exit 0'
+  ]
+  waitFor: [ '-']
+- id: 'ui.build'
+  name: 'gcr.io/cloud-builders/docker'
+  args: [
+    'build',
+    '-t', 'gcr.io/$PROJECT_ID/$REPO_NAME-ui:$COMMIT_SHA',
+    '-t', 'gcr.io/$PROJECT_ID/$REPO_NAME-ui:latest',
+    '--cache-from', 'gcr.io/$PROJECT_ID/$REPO_NAME-ui:latest',
+    '--build-arg', 'API_ROOT=/',
+    '.'
+  ]
+  dir: 'demo'
+  waitFor: [ 'ui.pull' ]
+- id: 'ui.push'
+  name: 'gcr.io/cloud-builders/docker'
+  args: [
+    'push',
+    'gcr.io/$PROJECT_ID/$REPO_NAME-ui:$COMMIT_SHA',
+  ]
+  waitFor: [ 'ui.build' ]
+# Generate the Kubernetes config
 - id: 'config'
   name: 'gcr.io/ai2-reviz/jsonnet'
   args: [
-    'eval',
     '-y',
-    '--output-file', './webapp.json',
+    '--output-file', './webapp.yaml',
     '--ext-str', 'env=$_ENV',
     '--ext-str', 'image=gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA',
+    '--ext-str', 'uiImage=gcr.io/$PROJECT_ID/$REPO_NAME-ui:$COMMIT_SHA',
     '--ext-str', 'sha=$COMMIT_SHA',
     '--ext-str', 'buildId=$BUILD_ID',
     '--ext-str', 'repo=$REPO_NAME',
     './webapp.jsonnet'
   ]
   dir: '.skiff'
+  waitFor: [ '-' ]
 # Deploy the image to Kubernetes
 - id: 'deploy'
   name: 'gcr.io/ai2-reviz/rudder'
   args: [
     'deploy',
     '-f',
-    'webapp.json'
+    'webapp.yaml'
   ]
   dir: '.skiff'
+  waitFor: [ 'push', 'ui.push', 'config' ]
 substitutions:
   _ENV: staging
 images: [
   'gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA',
   'gcr.io/$PROJECT_ID/$REPO_NAME:latest',
+  'gcr.io/$PROJECT_ID/$REPO_NAME-ui:$COMMIT_SHA',
+  'gcr.io/$PROJECT_ID/$REPO_NAME-ui:latest'
 ]
 artifacts:
   objects:
     location: 'gs://skiff-archive/$REPO_NAME/$_ENV/$COMMIT_SHA/$BUILD_ID'
-    paths: ['.skiff/webapp.json']
+    paths: [ '.skiff/webapp.yaml' ]
 timeout: 1800s

--- a/.skiff/cloudbuild-deploy.yaml
+++ b/.skiff/cloudbuild-deploy.yaml
@@ -29,7 +29,7 @@ steps:
     'push',
     'gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA',
   ]
-  waitFor: [ 'push' ]
+  waitFor: [ 'build' ]
 # Build an image that serves the files required for the UI from disk via
 # NGINX
 - id: 'ui.pull'
@@ -39,7 +39,7 @@ steps:
     '-c',
     'docker pull gcr.io/$PROJECT_ID/$REPO_NAME-ui:latest || exit 0'
   ]
-  waitFor: [ '-']
+  waitFor: [ '-' ]
 - id: 'ui.build'
   name: 'gcr.io/cloud-builders/docker'
   args: [

--- a/.skiff/cloudbuild-deploy.yaml
+++ b/.skiff/cloudbuild-deploy.yaml
@@ -47,7 +47,6 @@ steps:
     '-t', 'gcr.io/$PROJECT_ID/$REPO_NAME-ui:$COMMIT_SHA',
     '-t', 'gcr.io/$PROJECT_ID/$REPO_NAME-ui:latest',
     '--cache-from', 'gcr.io/$PROJECT_ID/$REPO_NAME-ui:latest',
-    '--build-arg', 'API_ROOT=/',
     '.'
   ]
   dir: 'demo'

--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -326,7 +326,7 @@ local deployment = {
                         resources: {
                             requests: {
                                 cpu: '50m',
-                                memory: '100m'
+                                memory: '100Mi'
                             }
                         },
                         env: env_variables

--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -47,6 +47,7 @@ local model_names = std.objectFields(models);
 // These values are provided at runtime.
 local env = std.extVar('env');
 local image = std.extVar('image');
+local uiImage = std.extVar('uiImage');
 local sha = std.extVar('sha');
 
 // Use 2 replicas in prod, only 1 in staging.
@@ -231,7 +232,7 @@ local ingress = {
                         {
                             backend: {
                                 serviceName: fullyQualifiedName,
-                                servicePort: config.httpPort
+                                servicePort: 80
                             },
                             path: '/.*'
                         }
@@ -314,18 +315,18 @@ local deployment = {
                 containers: [
                     {
                         name: config.appName,
-                        image: image,
-                        args: [ '--no-models' ],
-                        readinessProbe: readinessProbe,
+                        image: uiImage,
+                        readinessProbe: {
+                            httpGet: {
+                                path: '/',
+                                port: 80,
+                                scheme: 'HTTP'
+                            }
+                        },
                         resources: {
                             requests: {
-                                // Our machines currently have 2 vCPUs, so this
-                                // will allow 4 apps to run per machine
-                                cpu: '0.2',
-                                // Each machine has 13 GB of RAM. We target 4
-                                // apps per machine, so we reserve 3 GB of RAM
-                                // for each (whether they use it our not).
-                                memory: '1Gi'
+                                cpu: '50m',
+                                memory: '100m'
                             }
                         },
                         env: env_variables
@@ -405,7 +406,7 @@ local service = {
         selector: ui_server_labels,
         ports: [
             {
-                port: config.httpPort,
+                port: 80,
                 name: 'http'
             }
         ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,8 @@
 # This Dockerfile is used to serve the AllenNLP demo.
-
 FROM allennlp/commit:adeb1b1278619ff2d74d4fd82825e50a36f95ff4
 LABEL maintainer="allennlp-contact@allenai.org"
 
 WORKDIR /stage/allennlp
-
-# Install npm early so layer is cached when mucking with the demo
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && apt-get install -y nodejs
 
 # Install python dependencies
 COPY requirements.txt requirements.txt
@@ -17,10 +13,6 @@ RUN spacy download en_core_web_sm
 
 COPY scripts/ scripts/
 COPY server/models.py server/models.py
-
-# Now install and build the demo
-COPY demo/ demo/
-RUN ./scripts/build_demo.py
 
 COPY tests/ tests/
 COPY app.py app.py

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ docker run -p 8000:8000 \
 ```
 
 You can change `reading-comprehension` to the name of the model [here](https://github.com/allenai/allennlp-demo/blob/master/models.json) that you'd like to run. You probably shouldn't try to
-run all of them, as it's quite slow.
+run all of them, as they will take a long time to download and require a significant
+amount of memory.
 
 Note that the `run` process may get killed prematurely if there is insufficient memory allocated to Docker. As of September 14, 2018, setting a memory limit of 10GB was sufficient to run the demo. See [Docker Docs](https://docs.docker.com/docker-for-mac/#advanced) for more on setting memory allocation preferences.
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,11 @@ To run the demo locally for development, you will need to:
 
 ## Running with Docker
 
-Here is an example for how to manually build the Docker image and run the demo on port 8000.
-As above, you probably don't want to load every model,
-so you should specify the specific models you want in your `docker run` command.
+We use `docker` to package the application and serve it using Kubernetes. Below are instructions
+for running things locally in a fashion that's close to how we do things in production, which
+can be useful for troubleshooting weird issues.
+
+**First, start up the backend / API for a model like so:**
 
 ```bash
 export GIT_HASH=`git log -1 --pretty=format:"%H"`
@@ -82,12 +84,24 @@ docker run -p 8000:8000 \
            -v $HOME/.allennlp:/root/.allennlp \
            --rm \
            allennlp/demo:$GIT_HASH \
-           --model model1 --model model2
+           --model reading-comprehension
 ```
 
-Where you see "model1" and "model2" examples above, you would use actual model names which are listed as JSON object key names [here](https://github.com/allenai/allennlp-demo/blob/master/models.json).
+Youc an change `reading-comprehension` to the name of the model [here](https://github.com/allenai/allennlp-demo/blob/master/models.json) that you'd like to run. You probably shouldn't try to
+run all of them, as it's quite slow.
 
 Note that the `run` process may get killed prematurely if there is insufficient memory allocated to Docker. As of September 14, 2018, setting a memory limit of 10GB was sufficient to run the demo. See [Docker Docs](https://docs.docker.com/docker-for-mac/#advanced) for more on setting memory allocation preferences.
+
+**Next, in a separate terminal, start up the UI:**
+
+```bash
+export GIT_HASH=`git log -1 --pretty=format:"%H"`
+docker build -t allennlp/demo-ui:$GIT_HASH .
+docker run -p 8080:80 --rm allennlp/demo-ui:$GIT_HASH
+```
+
+Now open up [http://localhost:8080`](http://localhost:8080). You can hit the API directly on
+port `:8000`.
 
 ## Deploying
 

--- a/README.md
+++ b/README.md
@@ -77,13 +77,12 @@ can be useful for troubleshooting weird issues.
 **First, start up the backend / API for a model like so:**
 
 ```bash
-export GIT_HASH=`git log -1 --pretty=format:"%H"`
-docker build -t allennlp/demo:$GIT_HASH .
+docker build -t allennlp/demo:latest
 mkdir -p $HOME/.allennlp
 docker run -p 8000:8000 \
            -v $HOME/.allennlp:/root/.allennlp \
            --rm \
-           allennlp/demo:$GIT_HASH \
+           allennlp/demo:latest \
            --model reading-comprehension
 ```
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ docker run -p 8000:8000 \
            --model reading-comprehension
 ```
 
-Youc an change `reading-comprehension` to the name of the model [here](https://github.com/allenai/allennlp-demo/blob/master/models.json) that you'd like to run. You probably shouldn't try to
+You can change `reading-comprehension` to the name of the model [here](https://github.com/allenai/allennlp-demo/blob/master/models.json) that you'd like to run. You probably shouldn't try to
 run all of them, as it's quite slow.
 
 Note that the `run` process may get killed prematurely if there is insufficient memory allocated to Docker. As of September 14, 2018, setting a memory limit of 10GB was sufficient to run the demo. See [Docker Docs](https://docs.docker.com/docker-for-mac/#advanced) for more on setting memory allocation preferences.

--- a/demo/.dockerignore
+++ b/demo/.dockerignore
@@ -1,0 +1,3 @@
+node_modules/
+**/*.md
+Dockerfile

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -5,9 +5,6 @@ WORKDIR /ui
 COPY package.json package-lock.json ./
 RUN npm install
 
-ARG API_ROOT
-ENV API_ROOT ${API_ROOT}
-
 COPY config-overrides.js .
 COPY public public
 COPY src src

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:12.16.2 as build
+
+WORKDIR /ui
+
+COPY package.json package-lock.json ./
+RUN npm install
+
+ARG API_ROOT
+ENV API_ROOT ${API_ROOT}
+
+COPY config-overrides.js .
+COPY public public
+COPY src src
+
+RUN npm run build
+
+FROM nginx:1.17.0
+
+COPY --from=build /ui/build  /ui
+COPY ui.conf /etc/nginx/conf.d/default.conf
+

--- a/demo/src/api-config.js
+++ b/demo/src/api-config.js
@@ -1,18 +1,4 @@
-/**
- * The backend always runs on port 8000. In production we also
- * serve the frontend from there. However, for development
- * we want to `npm run serve` the unminified js on port 3000.
- * This allows us to get the correct API root either way.
- */
-
-let apiRoot;
-
-const origin = window && window.location && window.location.origin;
-
-if (origin.includes(':3000')) {
-    apiRoot = origin.replace(":3000", ":8000");
-} else {
-    apiRoot = origin;
-}
-
-export const API_ROOT = apiRoot;
+// The origin (scheme, hostname and port) of the API. Defaults to
+// a value that works locally. For deployed environments this is set
+// at build time. See: .skiff/cloudbuild-deploy.yaml.
+export const API_ROOT = process.env.API_ROOT || 'http://localhost:8000';

--- a/demo/src/api-config.js
+++ b/demo/src/api-config.js
@@ -1,4 +1,4 @@
-// The origin (scheme, hostname and port) of the API. Defaults to
-// a value that works locally. For deployed environments this is set
-// at build time. See: .skiff/cloudbuild-deploy.yaml.
-export const API_ROOT = process.env.API_ROOT || 'http://localhost:8000';
+// Locally the API is always on port 8000. In deployed environments we can safely assume it's
+// at the same origin as the UI.
+const isLocal = window.location.hostname === 'localhost';
+export const API_ROOT = isLocal ? 'http://localhost:8000' : window.location.origin;

--- a/demo/ui.conf
+++ b/demo/ui.conf
@@ -1,0 +1,26 @@
+# This configures NGINX to serve the UI from files on disk.
+server {
+    listen       80;
+
+    # We disable the cache, as for a small site it's more trouble than
+    # it's worth.
+    expires -1;
+
+    # The application is an SPA, which means routing is handled by
+    # client side code (JavaScript). We try to serve the file based
+    # on the request URI just in case it's a request for a file
+    # on disk (i.e. the JavaScript itself) and otherwise fallback to
+    # serving the HTML page. This means there's no true 404s, which
+    # is a little weird.
+    location / {
+        root /ui;
+        try_files $uri /index.html;
+    }
+
+    # This is pulled from NGINX's default configuration, and just ensures
+    # 500 errors get handled correctly.
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/server/models.py
+++ b/server/models.py
@@ -21,17 +21,12 @@ from server.gpt2 import Gpt2DemoModel
 # will be served at the `/predict/<name-of-task>` API endpoint.
 
 def load_demo_models(models_file: str,
-                     task_names: List[str] = None,
-                     model_names_only: bool = False) -> Dict[str, DemoModel]:
+                     task_names: List[str] = None) -> Dict[str, DemoModel]:
     with open(models_file) as f:
         blob = json.load(f)
 
     # If no task names specified, load all of them
     task_names = task_names or blob.keys()
-
-    # No models, so return None for everything
-    if model_names_only:
-        return {task_name: None for task_name in task_names}
 
     # Otherwise
     demo_models = {}

--- a/tests/coref_tests/coref_test.py
+++ b/tests/coref_tests/coref_test.py
@@ -38,13 +38,10 @@ class TestFlask(AllenNlpTestCase):
 
     def setUp(self):
         super().setUp()
-        self.TEST_DIR = pathlib.Path(tempfile.mkdtemp())
-        # Create index.html in TEST_DIR
-        (self.TEST_DIR / 'index.html').touch()  # pylint: disable=no-member
 
         if self.client is None:
 
-            self.app = make_app(build_dir=self.TEST_DIR, models={})
+            self.app = make_app(models={})
             self.app.predictors = PREDICTORS
             self.app.max_request_lengths = LIMITS
             self.app.testing = True

--- a/tests/general_tests/server_test.py
+++ b/tests/general_tests/server_test.py
@@ -77,13 +77,10 @@ class TestFlask(AllenNlpTestCase):
 
     def setUp(self):
         super().setUp()
-        self.TEST_DIR = pathlib.Path(tempfile.mkdtemp())
-        # Create index.html in TEST_DIR
-        (self.TEST_DIR / 'index.html').touch()  # pylint: disable=no-member
 
         if self.client is None:
 
-            self.app = make_app(build_dir=self.TEST_DIR, models={})
+            self.app = make_app(models={})
             self.app.predictors = PREDICTORS
             self.app.max_request_lengths = LIMITS
             self.app.testing = True
@@ -189,7 +186,7 @@ class TestFlask(AllenNlpTestCase):
 
     def test_disable_caching(self):
         predictor = CountingPredictor()
-        application = make_app(build_dir=self.TEST_DIR, models={}, cache_size=0)
+        application = make_app(models={}, cache_size=0)
         application.predictors = {"counting": predictor}
         application.max_request_lengths["counting"] = 100
         application.testing = True
@@ -211,16 +208,8 @@ class TestFlask(AllenNlpTestCase):
             assert predictor.calls[key] == i + 1
             assert len(predictor.calls) == 1
 
-    def test_missing_static_dir(self):
-        fake_dir = self.TEST_DIR / 'this' / 'directory' / 'does' / 'not' / 'exist'
-
-        with self.assertRaises(SystemExit) as context:
-            make_app(fake_dir, models={})
-
-        assert context.exception.code == -1  # pylint: disable=no-member
-
     def test_permalinks_fail_gracefully_with_no_database(self):
-        application = make_app(build_dir=self.TEST_DIR, models={})
+        application = make_app(models={})
         predictor = CountingPredictor()
         application.predictors = {"counting": predictor}
         application.max_request_lengths["counting"] = 100
@@ -243,7 +232,7 @@ class TestFlask(AllenNlpTestCase):
 
     def test_permalinks_work(self):
         db = InMemoryDemoDatabase()
-        application = make_app(build_dir=self.TEST_DIR, demo_db=db, models={})
+        application = make_app(demo_db=db, models={})
         predictor = CountingPredictor()
         application.predictors = {"counting": predictor}
         application.max_request_lengths["counting"] = 100
@@ -274,7 +263,7 @@ class TestFlask(AllenNlpTestCase):
 
     def test_db_resilient_to_prediction_failure(self):
         db = InMemoryDemoDatabase()
-        application = make_app(build_dir=self.TEST_DIR, demo_db=db, models={})
+        application = make_app(demo_db=db, models={})
         predictor = FailingPredictor()
         application.predictors = {"failing": predictor}
         application.max_request_lengths["failing"] = 100
@@ -308,7 +297,7 @@ class TestFlask(AllenNlpTestCase):
                                                LIMITS['reading-comprehension'])
         }
 
-        app = make_app(build_dir=self.TEST_DIR, models=models)
+        app = make_app(models=models)
         app.testing = True
 
 


### PR DESCRIPTION
This change sets up a dedicated, NGINX container for serving the UI.
NGINX is a great candidate for this, as the files are static and can
be served from disk without executing code on the server.

This also allows us to remove all code from the Python application
related to serving UI files, which makes things simpler.

I tested this locally via the revized instructions for running things
via `docker`, and will deploy an ad-hoc shortly to confirm the changes
in full.

I changed the Python application's root URL to return some information
about the AllenNLP version and the models it's configured to serve.
This information isn't leaking anything, as the repository is already
public, so it felt like a safe change. I can remove this if we feel
otherwise.

@schmmd I'm assigning you, but please feel free to reassign
to whomever is best.