### PR TITLE
Remove DB config from the UI server.

### DIFF
--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -287,13 +287,6 @@ local db_env_variables = [
     }
 ];
 
-local env_variables = db_env_variables + [
-    {
-        name: 'GIT_SHA',
-        value: sha
-    }
-];
-
 local deployment = {
     apiVersion: 'extensions/v1beta1',
     kind: 'Deployment',
@@ -328,12 +321,9 @@ local deployment = {
                                 cpu: '50m',
                                 memory: '100Mi'
                             }
-                        },
-                        env: env_variables
-                    },
-                    cloudsql_proxy_container
+                        }
+                    }
                 ],
-                volumes: cloudsql_volumes
             }
         }
     }
@@ -384,7 +374,7 @@ local model_deployment(model_name) = {
                                 memory: get_memory(model_name)
                             }
                         },
-                        env: env_variables
+                        env: db_env_variables
                     },
                     cloudsql_proxy_container
                 ],


### PR DESCRIPTION
The UI is now served by NGINX and doesn't access the database, this
PR removes the database related config from the deployment, making
it a bit simpler and following the principle of least priviledge.

I also removed the `GIT_SHA` environment variable as that's been
unused for some time.