### PR TITLE
Add interpret functionality to the new bidaf endpoint.

### DIFF
--- a/allennlp_demo/bidaf/api.py
+++ b/allennlp_demo/bidaf/api.py
@@ -6,24 +6,25 @@ import logging
 sys.path.insert(0, os.path.dirname(os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))))
 
 from allennlp.version import VERSION
+from allennlp.interpret.saliency_interpreters import SimpleGradient, IntegratedGradient, SmoothGradient
 from allennlp.predictors import Predictor
 from allennlp.common import JsonDict
 from allennlp_demo.common import logs, config
 from allennlp_plugins import allennlp_models
 from dataclasses import asdict
 from functools import lru_cache
-from flask import Flask, jsonify, request, after_this_request, Response
+from flask import Flask, jsonify, request, after_this_request, Response, Request, abort
 from flask.logging import default_handler
 from typing import Dict
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app = Flask(__name__)
     logs.init(app)
 
-    model = config.Model.from_file(os.path.join(os.path.dirname(__file__), 'model.json'))
+    model = config.Model.from_file(os.path.join(os.path.dirname(__file__), "model.json"))
     predictor = Predictor.from_path(model.archive_file, model.predictor_name)
 
-    @app.route('/')
+    @app.route("/")
     def info() -> str:
         return jsonify({ **asdict(model), "allennlp": VERSION })
 
@@ -31,10 +32,9 @@ if __name__ == '__main__':
     def caching_predict(data: str):
         return predictor.predict_json(json.loads(data))
 
-    @app.route('/predict', methods=['POST'])
-    def predict() -> JsonDict:
-        no_cache = "nocache" in request.args
-        if no_cache:
+    @app.route("/predict", methods=["POST"])
+    def predict_handler() -> JsonDict:
+        if "nocache" in request.args:
             return predictor.predict_json(request.get_json())
 
         # This allows us to determine if the response we're serving was cached. It's safe to
@@ -47,15 +47,59 @@ if __name__ == '__main__':
         if cinfo.hits - pre_hits == 1:
             @after_this_request
             def add_cache_hit_header(r: Response):
-                r.headers['X-Cache-Hit'] = "1"
+                r.headers["X-Cache-Hit"] = "1"
                 return r
-        return r
+
+        return jsonify(r)
+
+    class UnknownInterpreterError(RuntimeError):
+        pass
+
+    def interpret(interpreter: str, data: str):
+        if interpreter == "simple":
+            i = SimpleGradient(predictor)
+            return i.saliency_interpret_from_json(json.loads(data))
+        elif interpreter == "smooth":
+            i = SmoothGradient(predictor)
+            return i.saliency_interpret_from_json(json.loads(data))
+        elif interpreter == "integrated":
+            i = IntegratedGradient(predictor)
+            return i.saliency_interpret_from_json(json.loads(data))
+        else:
+            raise UnknownInterpreterError(f"Unknown Interpreter: {interpreter}")
+
+    @lru_cache(maxsize=1024)
+    def caching_interpret(interpreter: str, data: str):
+        return interpret(interpreter, data)
+
+    @app.route("/interpret/<string:interpreter>", methods=["POST"])
+    def interpret_handler(interpreter: str) -> JsonDict:
+        try:
+            if "nocache" in request.args:
+                interpret(interpreter, request.data)
+
+            # This allows us to determine if the response we're serving was cached. It's safe to
+            # do because we use a single-threaded server.
+            pre_hits = caching_interpret.cache_info().hits
+            r = caching_interpret(interpreter, request.data)
+            cinfo = caching_interpret.cache_info()
+
+            # If it's a cache hit add a HTTP header
+            if cinfo.hits - pre_hits == 1:
+                @after_this_request
+                def add_cache_hit_header(r: Response):
+                    r.headers["X-Cache-Hit"] = "1"
+                    return r
+
+            return jsonify(r)
+        except UnknownInterpreterError as err:
+            abort(400)
 
     # For simplicity, we use Flask's built in server. This isn't recommended, per:
     # https://flask.palletsprojects.com/en/1.1.x/tutorial/deploy/#run-with-a-production-server
     #
     # That said we think this is preferable because:
-    #   - It's simple. No need to install another WSGI server and add logic for enabling it in
+    #   - It"s simple. No need to install another WSGI server and add logic for enabling it in
     #     the right context.
     #   - Our workload is CPU bound, so event loop based WSGI servers don't get us much.
     #   - We use Kubernetes to scale horizontally, and run an NGINX proxy at the front-door, which

--- a/allennlp_demo/bidaf/api.py
+++ b/allennlp_demo/bidaf/api.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
         return jsonify({ **asdict(model), "allennlp": VERSION })
 
     @lru_cache(maxsize=1024)
-    def caching_predict(data: str):
+    def caching_predict(data: str) -> JsonDict:
         return predictor.predict_json(json.loads(data))
 
     @app.route("/predict", methods=["POST"])
@@ -55,7 +55,7 @@ if __name__ == "__main__":
     class UnknownInterpreterError(RuntimeError):
         pass
 
-    def interpret(interpreter: str, data: str):
+    def interpret(interpreter: str, data: str) -> JsonDict:
         if interpreter == "simple":
             i = SimpleGradient(predictor)
             return i.saliency_interpret_from_json(json.loads(data))
@@ -69,7 +69,7 @@ if __name__ == "__main__":
             raise UnknownInterpreterError(f"Unknown Interpreter: {interpreter}")
 
     @lru_cache(maxsize=1024)
-    def caching_interpret(interpreter: str, data: str):
+    def caching_interpret(interpreter: str, data: str) -> JsonDict:
         return interpret(interpreter, data)
 
     @app.route("/interpret/<string:interpreter>", methods=["POST"])

--- a/allennlp_demo/common/logs.py
+++ b/allennlp_demo/common/logs.py
@@ -53,7 +53,7 @@ def init(app: Flask):
     # Output logs as JSON
     handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(JsonLogFormatter())
-    logging.basicConfig(level=os.getenv('LOG_LEVEL', logging.INFO), handlers=[handler])
+    logging.basicConfig(level=os.getenv("LOG_LEVEL", logging.INFO), handlers=[handler])
 
     # Disable the default request log, as we add our own
     logging.getLogger("werkzeug").setLevel(logging.WARN)
@@ -68,8 +68,8 @@ def init(app: Flask):
     def log_request(r: Response) -> Response:
         t = time.perf_counter() - g.start
         rl = RequestLogEntry(r.status_code, request.method, request.path, request.args,
-                             request.remote_addr, request.headers.get('X-Forwarded-For'), t,
-                             r.headers.get('X-Cache-Hit', "0") == "1")
+                             request.remote_addr, request.headers.get("X-Forwarded-For"), t,
+                             r.headers.get("X-Cache-Hit", "0") == "1")
         logging.getLogger("request").info(asdict(rl))
         return r
 


### PR DESCRIPTION
This adds the `/interpret` endpoint to the new approach. I also
replaced `'`s with `"`s, as that appeared to be more consistent
with the existing codebase.