### PR TITLE
Add tests for the new bidaf endpoint.

### DIFF
--- a/allennlp_demo/bidaf/README.md
+++ b/allennlp_demo/bidaf/README.md
@@ -25,7 +25,7 @@ The API is used by the [AllenNLP demo](https://demo.allennlp.org).
 3. Make sure it's working:
 
     ```bash
-    pytest
+    curl http://localhost:8000
     ```
 
 You can get predictions like so:
@@ -35,3 +35,7 @@ curl -X POST -H 'Content-Type: application/json' \
     -d '{ "question": "Why do dogs bark?", "passage": "Dogs bark because they like to." }' \
     http://localhost:8000/predict
 ```
+
+## Tests
+
+You can run the tests by running `pytest`.

--- a/allennlp_demo/bidaf/README.md
+++ b/allennlp_demo/bidaf/README.md
@@ -25,7 +25,7 @@ The API is used by the [AllenNLP demo](https://demo.allennlp.org).
 3. Make sure it's working:
 
     ```bash
-    curl http://localhost:8000
+    pytest
     ```
 
 You can get predictions like so:

--- a/allennlp_demo/bidaf/api.py
+++ b/allennlp_demo/bidaf/api.py
@@ -5,7 +5,11 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(os.path.join(os.path.dirname(
 
 from allennlp_demo.common import config, http
 
+class BidafModelEndpoint(http.ModelEndpoint):
+    def __init__(self):
+        c = config.Model.from_file(os.path.join(os.path.dirname(__file__), "model.json"))
+        super().__init__(c)
+
 if __name__ == "__main__":
-    config = config.Model.from_file(os.path.join(os.path.dirname(__file__), "model.json"))
-    endpoint = http.ModelEndpoint(config)
+    endpoint = BidafModelEndpoint()
     endpoint.run()

--- a/allennlp_demo/bidaf/requirements.txt
+++ b/allennlp_demo/bidaf/requirements.txt
@@ -1,4 +1,3 @@
 allennlp-models==1.0.0rc3
 Flask==1.1.2
 pytest==5.4.1
-requests==2.23.0

--- a/allennlp_demo/bidaf/requirements.txt
+++ b/allennlp_demo/bidaf/requirements.txt
@@ -1,2 +1,4 @@
 allennlp-models==1.0.0rc3
 Flask==1.1.2
+pytest==5.4.1
+requests==2.23.0

--- a/allennlp_demo/bidaf/test_api.py
+++ b/allennlp_demo/bidaf/test_api.py
@@ -1,0 +1,8 @@
+import os
+import requests
+
+from allennlp_demo.common.testing import ModelEndpointTests
+
+# For this endpoint we can simply use the standard tests.
+class TestBidafEndpoint(ModelEndpointTests):
+    pass

--- a/allennlp_demo/bidaf/test_api.py
+++ b/allennlp_demo/bidaf/test_api.py
@@ -1,8 +1,14 @@
 import os
 import requests
+import pytest
 
 from allennlp_demo.common.testing import ModelEndpointTests
+from allennlp_demo.bidaf.api import BidafModelEndpoint
 
-# For this endpoint we can simply use the standard tests.
-class TestBidafEndpoint(ModelEndpointTests):
+@pytest.fixture
+def client():
+    endpoint = BidafModelEndpoint()
+    return endpoint.app.test_client()
+
+class TestBidafModelEndpoint(ModelEndpointTests):
     pass

--- a/allennlp_demo/bidaf/test_api.py
+++ b/allennlp_demo/bidaf/test_api.py
@@ -1,5 +1,3 @@
-import os
-import requests
 import pytest
 
 from allennlp_demo.common.testing import ModelEndpointTests

--- a/allennlp_demo/common/fixtures/rc.json
+++ b/allennlp_demo/common/fixtures/rc.json
@@ -1,0 +1,4 @@
+{
+    "passage": "A reusable launch system (RLS, or reusable launch vehicle, RLV) is a launch system which is capable of launching a payload into space more than once. This contrasts with expendable launch systems, where each launch vehicle is launched once and then discarded. No completely reusable orbital launch system has ever been created. Two partially reusable launch systems were developed, the Space Shuttle and Falcon 9. The Space Shuttle was partially reusable: the orbiter (which included the Space Shuttle main engines and the Orbital Maneuvering System engines), and the two solid rocket boosters were reused after several months of refitting work for each launch. The external tank was discarded after each flight.",
+    "question": "How many partially reusable launch systems were developed?"
+}

--- a/allennlp_demo/common/http.py
+++ b/allennlp_demo/common/http.py
@@ -183,9 +183,9 @@ class ModelEndpoint:
         # https://flask.palletsprojects.com/en/1.1.x/tutorial/deploy/#run-with-a-production-server
         #
         # That said we think this is preferable because:
-        #   - It"s simple. No need to install another WSGI server and add logic for enabling it in
+        #   - It's simple. No need to install another WSGI server and add logic for enabling it in
         #     the right context.
         #   - Our workload is CPU bound, so event loop based WSGI servers don't get us much.
-        #   - We use Kubernetes to scale horizontally, and run an NGINX proxy at the front-door, which
-        #     adds the resiliency and other things we need for production.
+        #   - We use Kubernetes to scale horizontally, and run an NGINX proxy at the front-door,
+        #     which adds the resiliency and other things we need for production.
         self.app.run(host="0.0.0.0", port=port)

--- a/allennlp_demo/common/http.py
+++ b/allennlp_demo/common/http.py
@@ -46,7 +46,7 @@ class NotFoundError(RuntimeError):
 
 class UnknownInterpreterError(NotFoundError):
     def __init__(self, interpreter_id: str):
-        super().__init__(f"No Interpreter with id {interpreter_id}")
+        super().__init__(f"No interpreter with id {interpreter_id}")
 
 class UnknownAttackerError(NotFoundError):
     def __init__(self, attacker_id: str):

--- a/allennlp_demo/common/testing.py
+++ b/allennlp_demo/common/testing.py
@@ -1,10 +1,11 @@
 import os
-import requests
 import pytest
 import json
 
 from secrets import token_urlsafe
 from typing import Mapping, List
+from flask.testing import FlaskClient
+from flask import Response
 
 class ModelEndpointTests:
     """
@@ -15,73 +16,67 @@ class ModelEndpointTests:
         with open(os.path.join(os.path.dirname(__file__), "fixtures", "rc.json"), "r") as fh:
             return json.load(fh)
 
-    def url(self, path: str = "/") -> str:
-        origin = os.getenv("ORIGIN", "http://localhost:8000")
-        return f"{origin}{path}"
-
     def interpreter_ids(self) -> List[str]:
         return [ "simple", "smooth", "integrated" ]
 
     def attacker_ids(self) -> List[str]:
         return [ "hotflip", "input-reduction" ]
 
-    def test_predict(self):
-        resp = requests.post(self.url("/predict"),
-                             params={ "no_cache": True }, json=self.rc_input())
-        resp.raise_for_status()
-        prediction = resp.json()
-        assert prediction is not None
-        assert len(prediction["best_span"]) > 0
-        assert len(prediction["best_span_str"].strip()) > 0
+    def test_predict(self, client: FlaskClient):
+        client.post()
+        resp: Response = client.post("/predict", query_string={ "no_cache": True },
+                                     json=self.rc_input())
+        assert resp.status_code == 200
+        assert resp.json is not None
+        assert len(resp.json["best_span"]) > 0
+        assert len(resp.json["best_span_str"].strip()) > 0
 
-    def test_interpret(self):
+    def test_interpret(self, client: FlaskClient):
         for interpreter_id in self.interpreter_ids():
-            resp = requests.post(self.url(f"/interpret/{interpreter_id}"),
-                                 params={ "no_cache": True }, json=self.rc_input())
-            resp.raise_for_status()
-            saliency = resp.json()
-            assert saliency is not None
-            assert len(saliency["instance_1"]) > 0
-            assert len(saliency["instance_1"]["grad_input_1"]) > 0
-            assert len(saliency["instance_1"]["grad_input_2"]) > 0
+            resp = client.post(f"/interpret/{interpreter_id}", query_string={ "no_cache": True },
+                               json=self.rc_input())
+            assert resp.status_code == 200
+            assert resp.json is not None
+            assert len(resp.json["instance_1"]) > 0
+            assert len(resp.json["instance_1"]["grad_input_1"]) > 0
+            assert len(resp.json["instance_1"]["grad_input_2"]) > 0
 
-    def test_invalid_interpreter_id(self):
-        resp = requests.post(self.url("/interpret/invalid"), json={})
+    def test_invalid_interpreter_id(self, client: FlaskClient):
+        resp = client.post("/interpret/invalid", json={})
         assert resp.status_code == 404
-        assert resp.json()["error"] == "No interpreter with id invalid"
+        assert resp.json["error"] == "No interpreter with id invalid"
 
-    def test_attack(self):
+    def test_attack(self, client: FlaskClient):
         data = { "inputs": self.rc_input(), "input_field_to_attack": "question",
                 "grad_input_field": "grad_input_2" }
         for attacker_id in self.attacker_ids():
-            resp = requests.post(self.url(f"/attack/{attacker_id}"), json=data,
-                                 params={ "no_cache": True })
-            resp.raise_for_status()
-            attack = resp.json()
-            assert len(attack["final"]) > 0
-            assert len(attack["original"]) > 0
+            resp = client.post(f"/attack/{attacker_id}", json=data,
+                               query_string={ "no_cache": True })
+            assert resp.status_code == 200
+            assert len(resp.json["final"]) > 0
+            assert len(resp.json["original"]) > 0
 
-    def test_invalid_attacker_id(self):
-        resp = requests.post(self.url("/attack/invalid"), json={})
+    def test_invalid_attacker_id(self, client: FlaskClient):
+        resp = client.post("/attack/invalid", json={})
         assert resp.status_code == 404
-        assert resp.json()["error"] == "No attacker with id invalid"
+        assert resp.json["error"] == "No attacker with id invalid"
 
-    def test_invalid_json(self):
-        resp = requests.post(self.url("/predict"), data="{ invalid: json }",
-                            headers={ "Content-Type": "application/json"})
+    def test_invalid_json(self, client: FlaskClient):
+        resp = client.post("/predict", data="{ invalid: json }",
+                           headers={ "Content-Type": "application/json"})
         assert resp.status_code == 400
 
-    def test_cache(self):
+    def test_cache(self, client: FlaskClient):
         prompt = { "question": f"Was this cached? {token_urlsafe(8)}",
                    "passage": "Only the model knows." }
-        resp = requests.post(self.url("/predict"), json=prompt)
-        resp.raise_for_status()
+        resp = client.post("/predict", json=prompt)
+        assert resp.status_code == 200
         assert "X-Cache-Hit" not in resp.headers
 
-        cached_resp = requests.post(self.url("/predict"), json=prompt)
-        cached_resp.raise_for_status()
+        cached_resp = client.post("/predict", json=prompt)
+        assert resp.status_code == 200
         assert cached_resp.headers.get("X-Cache-Hit") == "1"
 
-        no_cache_resp = requests.post(self.url("/predict"), params={ "no_cache": True }, json=prompt)
-        no_cache_resp.raise_for_status()
+        no_cache_resp = client.post("/predict", query_string={ "no_cache": True }, json=prompt)
+        assert resp.status_code == 200
         assert "X-Cache-Hit" not in no_cache_resp.headers

--- a/allennlp_demo/common/testing.py
+++ b/allennlp_demo/common/testing.py
@@ -1,0 +1,87 @@
+import os
+import requests
+import pytest
+import json
+
+from secrets import token_urlsafe
+from typing import Mapping, List
+
+class ModelEndpointTests:
+    """
+    Defines a standard battery of tests for model endpoints. Invididual methods can be overriden
+    to change behavior.
+    """
+    def rc_input(self) -> Mapping:
+        with open(os.path.join(os.path.dirname(__file__), "fixtures", "rc.json"), "r") as fh:
+            return json.load(fh)
+
+    def url(self, path: str = "/") -> str:
+        origin = os.getenv("ORIGIN", "http://localhost:8000")
+        return f"{origin}{path}"
+
+    def interpreter_ids(self) -> List[str]:
+        return [ "simple", "smooth", "integrated" ]
+
+    def attacker_ids(self) -> List[str]:
+        return [ "hotflip", "input-reduction" ]
+
+    def test_predict(self):
+        resp = requests.post(self.url("/predict"),
+                             params={ "no_cache": True }, json=self.rc_input())
+        resp.raise_for_status()
+        prediction = resp.json()
+        assert prediction is not None
+        assert len(prediction["best_span"]) > 0
+        assert len(prediction["best_span_str"].strip()) > 0
+
+    def test_interpret(self):
+        for interpreter_id in self.interpreter_ids():
+            resp = requests.post(self.url(f"/interpret/{interpreter_id}"),
+                                 params={ "no_cache": True }, json=self.rc_input())
+            resp.raise_for_status()
+            saliency = resp.json()
+            assert saliency is not None
+            assert len(saliency["instance_1"]) > 0
+            assert len(saliency["instance_1"]["grad_input_1"]) > 0
+            assert len(saliency["instance_1"]["grad_input_2"]) > 0
+
+    def test_invalid_interpreter_id(self):
+        resp = requests.post(self.url("/interpret/invalid"), json={})
+        assert resp.status_code == 404
+        assert resp.json()["error"] == "No interpreter with id invalid"
+
+    def test_attack(self):
+        data = { "inputs": self.rc_input(), "input_field_to_attack": "question",
+                "grad_input_field": "grad_input_2" }
+        for attacker_id in self.attacker_ids():
+            resp = requests.post(self.url(f"/attack/{attacker_id}"), json=data,
+                                 params={ "no_cache": True })
+            resp.raise_for_status()
+            attack = resp.json()
+            assert len(attack["final"]) > 0
+            assert len(attack["original"]) > 0
+
+    def test_invalid_attacker_id(self):
+        resp = requests.post(self.url("/attack/invalid"), json={})
+        assert resp.status_code == 404
+        assert resp.json()["error"] == "No attacker with id invalid"
+
+    def test_invalid_json(self):
+        resp = requests.post(self.url("/predict"), data="{ invalid: json }",
+                            headers={ "Content-Type": "application/json"})
+        assert resp.status_code == 400
+
+    def test_cache(self):
+        prompt = { "question": f"Was this cached? {token_urlsafe(8)}",
+                   "passage": "Only the model knows." }
+        resp = requests.post(self.url("/predict"), json=prompt)
+        resp.raise_for_status()
+        assert "X-Cache-Hit" not in resp.headers
+
+        cached_resp = requests.post(self.url("/predict"), json=prompt)
+        cached_resp.raise_for_status()
+        assert cached_resp.headers.get("X-Cache-Hit") == "1"
+
+        no_cache_resp = requests.post(self.url("/predict"), params={ "no_cache": True }, json=prompt)
+        no_cache_resp.raise_for_status()
+        assert "X-Cache-Hit" not in no_cache_resp.headers


### PR DESCRIPTION
Before porting over a new model I thought it'd be nice to get
some tests in place for verying these endpoints.

This tests for the new bidaf endpoint and does so in
a fashion that should make them repurposable across endpoints
where possible.

~~The tests are integration tests and depend on a running server and not
yet wired up to CI -- that'll come later.~~

The tests can now be executed without a server.