### PR TITLE
Port NAQANet to the new serving mechanism.

### DIFF
--- a/allennlp_demo/common/testing.py
+++ b/allennlp_demo/common/testing.py
@@ -23,7 +23,7 @@ class ModelEndpointTests:
 
     def test_predict(self, client: FlaskClient):
         resp = client.post("/predict", query_string={ "no_cache": True },
-                                     json=self.rc_input())
+                           json=self.rc_input())
         assert resp.status_code == 200
         assert resp.json is not None
         assert len(resp.json["best_span"]) > 0

--- a/allennlp_demo/naqanet/.skiff/naqanet.jsonnet
+++ b/allennlp_demo/naqanet/.skiff/naqanet.jsonnet
@@ -1,0 +1,17 @@
+/**
+ * This file defines the infrastructure we need to run the API endpoint on Kubernetes.
+ *
+ * For more information on the JSONNET language, see:
+ * https://jsonnet.org/learning/getting_started.html
+ */
+
+local common = import '../../common/.skiff/common.libsonnet';
+local model = import '../model.json';
+
+function(image, cause, sha, env, branch, repo, buildId)
+    // This tells Kubernetes what resources we need to run.
+    // For more information see:
+    // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+    local cpu = '50m';
+    local memory = '2Gi';
+    common.ModelEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)

--- a/allennlp_demo/naqanet/Dockerfile
+++ b/allennlp_demo/naqanet/Dockerfile
@@ -1,0 +1,17 @@
+# This Dockerfile is specific to the naqanet model, but is meant to be executed in the `allennlp_demo`
+# directory, so that the build context includes common libraries that are shared across models.
+# This is why paths here include the naqanet/ prefix.
+FROM python:3.7.7-stretch
+LABEL maintainer="allennlp-contact@allenai.org"
+
+WORKDIR /allennlp_demo
+COPY naqanet/requirements.txt naqanet/requirements.txt
+RUN pip install -r naqanet/requirements.txt
+
+RUN spacy download en_core_web_sm
+
+COPY common common
+COPY naqanet naqanet
+
+ENTRYPOINT [ "python" ]
+CMD [ "naqanet/api.py" ]

--- a/allennlp_demo/naqanet/api.py
+++ b/allennlp_demo/naqanet/api.py
@@ -1,0 +1,15 @@
+import sys
+import os
+# This adds ../ to the PYTHONPATH, so that allennlp_demo imports work.
+sys.path.insert(0, os.path.dirname(os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))))
+
+from allennlp_demo.common import config, http
+
+class NAQANetModelEndpoint(http.ModelEndpoint):
+    def __init__(self):
+        c = config.Model.from_file(os.path.join(os.path.dirname(__file__), "model.json"))
+        super().__init__(c)
+
+if __name__ == "__main__":
+    endpoint = NAQANetModelEndpoint()
+    endpoint.run()

--- a/allennlp_demo/naqanet/model.json
+++ b/allennlp_demo/naqanet/model.json
@@ -1,0 +1,5 @@
+{
+    "id": "naqanet",
+    "archive_file": "https://storage.googleapis.com/allennlp-public-models/naqanet-2020.02.19.tar.gz",
+    "predictor_name": "reading-comprehension"
+}

--- a/allennlp_demo/naqanet/requirements.txt
+++ b/allennlp_demo/naqanet/requirements.txt
@@ -1,0 +1,3 @@
+allennlp-models==1.0.0rc3
+Flask==1.1.2
+pytest==5.4.1

--- a/allennlp_demo/naqanet/test_api.py
+++ b/allennlp_demo/naqanet/test_api.py
@@ -17,7 +17,7 @@ class TestNAQANetModelEndpoint(ModelEndpointTests):
 
     def test_predict(self, client: FlaskClient):
         resp = client.post("/predict", query_string={ "no_cache": True },
-                                     json=self.rc_input())
+                           json=self.rc_input())
         assert resp.status_code == 200
         assert resp.json is not None
         assert "answer" in resp.json

--- a/allennlp_demo/naqanet/test_api.py
+++ b/allennlp_demo/naqanet/test_api.py
@@ -1,0 +1,25 @@
+import pytest
+
+from flask.testing import FlaskClient
+from allennlp_demo.common.testing import ModelEndpointTests
+from allennlp_demo.naqanet.api import NAQANetModelEndpoint
+from typing import List
+
+@pytest.fixture
+def client():
+    endpoint = NAQANetModelEndpoint()
+    return endpoint.app.test_client()
+
+class TestNAQANetModelEndpoint(ModelEndpointTests):
+    def attacker_ids(self) -> List[str]:
+        # The hotflip attack for this model is currently broken.
+        return [ aid for aid in super().attacker_ids() if aid != "hotflip" ]
+
+    def test_predict(self, client: FlaskClient):
+        resp = client.post("/predict", query_string={ "no_cache": True },
+                                     json=self.rc_input())
+        assert resp.status_code == 200
+        assert resp.json is not None
+        assert "answer" in resp.json
+        assert len(resp.json["passage_question_attention"]) > 0
+


### PR DESCRIPTION
This adds code for serving the NAQANet reading comprehension model
via the new mechanism.

The hotflip attacker is again disabled due to an outstanding bug,
and prediction test needed to be modified as the output is different.