### PR TITLE
Fix permalinks for a few models.

### DIFF
--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -155,7 +155,7 @@ local cloudsql_volumes = [
 ];
 
 // Each model typically has its own service running that handles several different endpoints
-// (/predict, /permadata, /task, /attack, etc.).  This is a convenience function that will route
+// (/predict, /task, /attack, etc.).  This is a convenience function that will route
 // all of those endpoints to the model service, instead of the main frontend.
 // TODO(mattg): we might want to change this some day so that all model backend services start with
 // /model/[model-name], so that we only have to have one route per backend, instead of this mess of
@@ -166,81 +166,6 @@ local model_path(model_name, endpoint, url_extra='') = {
         serviceName: fullyQualifiedName + '-' + model_name,
         servicePort: config.httpPort
     },
-};
-
-
-
-local ingress = {
-    apiVersion: 'extensions/v1beta1',
-    kind: 'Ingress',
-    metadata: {
-        name: fullyQualifiedName + '-ingress',
-        namespace: namespaceName,
-        labels: labels,
-        annotations: {
-            'certmanager.k8s.io/cluster-issuer': 'letsencrypt-prod',
-            'kubernetes.io/ingress.class': 'nginx',
-            'nginx.ingress.kubernetes.io/ssl-redirect': 'true',
-            'nginx.ingress.kubernetes.io/enable-cors': 'false',
-            'nginx.ingress.kubernetes.io/use-regex': 'true',
-            'apps.allenai.org/build': std.extVar('buildId'),
-            'apps.allenai.org/sha': std.extVar('sha'),
-            'apps.allenai.org/repo': std.extVar('repo')
-        }
-    },
-    spec: {
-        tls: [
-            {
-                secretName: fullyQualifiedName + '-tls',
-                hosts: hosts
-            }
-        ],
-        rules: [
-            {
-                host: host,
-                http: {
-                    paths: [
-                        // The backend for each model is served at /predict/{model_name} (in its
-                        // own service) so we need to generate an ingress path entry that points
-                        // that path to that service.
-                        model_path(model_name, 'predict')
-                        for model_name in model_names
-                    ] + [
-                        // Attacking is handled by the model backend.
-                        model_path(model_name, 'attack')
-                        for model_name in model_names
-                    ] + [
-                        // Interpreting is handled by the model backend.
-                        model_path(model_name, 'interpret')
-                        for model_name in model_names
-                    ] + [
-                        // The (chromeless) frontend for each model is served at /task/{model_name}
-                        // (in its own service) so we need to generate an ingress path entry that
-                        // points that path to that service.
-                        // The extra bit on the url is because this will sometimes have permadata
-                        // on it also.
-                        // TODO: allow the frontend and the backend to be different services?
-                        model_path(model_name, 'task', "(/[.*])?")
-                        for model_name in model_names
-                    ] + [
-                        // We also want to pass through the permadata/ requests to each model,
-                        // because different models might handle them in different ways (or not at
-                        // all).
-                        model_path(model_name, 'permadata')
-                        for model_name in model_names
-                    ] + [
-                        {
-                            backend: {
-                                serviceName: fullyQualifiedName,
-                                servicePort: 80
-                            },
-                            path: '/.*'
-                        }
-                    ]
-                }
-            } for host in hosts
-        ]
-    }
 };
 
 local readinessProbe = {
@@ -329,6 +254,69 @@ local deployment = {
     }
 };
 
+local permadata_labels = labels + {
+    'role': 'permadata-server'
+};
+
+local permadata_deployment = {
+    apiVersion: 'extensions/v1beta1',
+    kind: 'Deployment',
+    metadata: {
+        labels: permadata_labels,
+        name: fullyQualifiedName + '-permadata',
+        namespace: namespaceName,
+    },
+    spec: {
+        revisionHistoryLimit: 3,
+        replicas: num_replicas,
+        template: {
+            metadata: {
+                name: fullyQualifiedName + '-permadata',
+                namespace: namespaceName,
+                labels: permadata_labels
+            },
+            spec: {
+                containers: [
+                    {
+                        name: 'permadata',
+                        image: image,
+                        args: [ '--no-models' ],
+                        readinessProbe: readinessProbe,
+                        resources: {
+                            requests: {
+                                cpu: '50m',
+                                memory: '500Mi'
+                            }
+                        },
+                        env: db_env_variables
+                    },
+                    cloudsql_proxy_container
+                ],
+                volumes: cloudsql_volumes
+            }
+        }
+    }
+};
+
+local permadata_service = {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+        name: fullyQualifiedName + '-permadata',
+        namespace: namespaceName,
+        labels: permadata_labels
+    },
+    spec: {
+        selector: permadata_labels,
+        ports: [
+            {
+                port: config.httpPort,
+                name: 'http'
+            }
+        ]
+    }
+};
+
 // We allow each model's JSON to specify how much memory and CPU it needs.
 // If not specified, we fall back to defaults.
 local DEFAULT_CPU = "0.2";
@@ -340,8 +328,6 @@ local get_memory(model_name) = if std.objectHas(models[model_name], "memory") th
 // A model can specify its own docker image by providing an environment
 // variable with the image name. It needs to run a server on config.port
 // that serves up the model at /predict/{model_name}
-// and that serves up the front-end at /task/{model_name}
-// and that (optionally) serves up permalinks at /permadata/{model_name},
 local get_image(model_name) = if std.objectHas(models[model_name], "image") then models[model_name]["image"] else image;
 
 local model_deployment(model_name) = {
@@ -423,11 +409,77 @@ local model_service(model_name) = {
     }
 };
 
+local ingress = {
+    apiVersion: 'extensions/v1beta1',
+    kind: 'Ingress',
+    metadata: {
+        name: fullyQualifiedName + '-ingress',
+        namespace: namespaceName,
+        labels: labels,
+        annotations: {
+            'certmanager.k8s.io/cluster-issuer': 'letsencrypt-prod',
+            'kubernetes.io/ingress.class': 'nginx',
+            'nginx.ingress.kubernetes.io/ssl-redirect': 'true',
+            'nginx.ingress.kubernetes.io/enable-cors': 'false',
+            'nginx.ingress.kubernetes.io/use-regex': 'true',
+            'apps.allenai.org/build': std.extVar('buildId'),
+            'apps.allenai.org/sha': std.extVar('sha'),
+            'apps.allenai.org/repo': std.extVar('repo')
+        }
+    },
+    spec: {
+        tls: [
+            {
+                secretName: fullyQualifiedName + '-tls',
+                hosts: hosts
+            }
+        ],
+        rules: [
+            {
+                host: host,
+                http: {
+                    paths: [
+                        // The backend for each model is served at /predict/{model_name} (in its
+                        // own service) so we need to generate an ingress path entry that points
+                        // that path to that service.
+                        model_path(model_name, 'predict')
+                        for model_name in model_names
+                    ] + [
+                        // Attacking is handled by the model backend.
+                        model_path(model_name, 'attack')
+                        for model_name in model_names
+                    ] + [
+                        // Interpreting is handled by the model backend.
+                        model_path(model_name, 'interpret')
+                        for model_name in model_names
+                    ] + [
+                        {
+                            path: '/permadata',
+                            backend: {
+                                serviceName: permadata_service.metadata.name,
+                                servicePort: config.httpPort
+                            }
+                        },
+                        {
+                            backend: {
+                                serviceName: fullyQualifiedName,
+                                servicePort: 80
+                            }
+                        }
+                    ]
+                }
+            } for host in hosts
+        ]
+    }
+};
+
 [
     namespace,
     ingress,
     deployment,
     service,
+    permadata_deployment,
+    permadata_service,
 ] + [
     model_deployment(model_name)
     for model_name in model_names

--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -155,7 +155,7 @@ local cloudsql_volumes = [
 ];
 
 // Each model typically has its own service running that handles several different endpoints
-// (/predict, /task, /attack, etc.).  This is a convenience function that will route
+// (/predict, /attack, etc.).  This is a convenience function that will route
 // all of those endpoints to the model service, instead of the main frontend.
 // TODO(mattg): we might want to change this some day so that all model backend services start with
 // /model/[model-name], so that we only have to have one route per backend, instead of this mess of

--- a/app.py
+++ b/app.py
@@ -218,8 +218,8 @@ def make_app(
             loaded_modules[n] = m.__dict__
         return jsonify({"allennlp_version": VERSION, "models": loaded_modules})
 
-    @app.route("/permadata/<model_name>", methods=["POST", "OPTIONS"])
-    def permadata(model_name: str) -> Response:  # pylint: disable=unused-variable
+    @app.route("/permadata", methods=["POST", "OPTIONS"])
+    def permadata() -> Response:  # pylint: disable=unused-variable
         """
         If the user requests a permalink, the front end will POST here with the payload
             { slug: slug }
@@ -251,7 +251,7 @@ def make_app(
             # No data found, invalid id?
             raise ServerError("Unrecognized permalink: {}".format(slug), 400)
 
-        return jsonify({"modelName": permadata.model_name, "requestData": permadata.request_data})
+        return jsonify({"requestData": permadata.request_data})
 
     @app.route("/predict/<model_name>", methods=["POST", "OPTIONS"])
     def predict(model_name: str) -> Response:  # pylint: disable=unused-variable
@@ -538,6 +538,11 @@ if __name__ == "__main__":
         default="models.json",
         help="json file containing the details of the models to load",
     )
+    parser.add_argument(
+        "--no-models",
+        action="store_true",
+        help="if specified don't load any models"
+    )
 
     models_group = parser.add_mutually_exclusive_group()
     models_group.add_argument(
@@ -550,7 +555,10 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    models = load_demo_models(args.models_file, args.model)
+    if args.no_models == False:
+        models = load_demo_models(args.models_file, args.model)
+    else:
+        models = {}
 
     main(
         demo_dir=args.demo_dir,

--- a/app.py
+++ b/app.py
@@ -539,9 +539,7 @@ if __name__ == "__main__":
         help="json file containing the details of the models to load",
     )
     parser.add_argument(
-        "--no-models",
-        action="store_true",
-        help="if specified don't load any models"
+        "--no-models", action="store_true", help="if specified don't load any models"
     )
 
     models_group = parser.add_mutually_exclusive_group()
@@ -555,7 +553,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    if args.no_models == False:
+    if not args.no_models:
         models = load_demo_models(args.models_file, args.model)
     else:
         models = {}

--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -159,7 +159,7 @@ class SingleTaskDemo extends React.Component {
     if (slug && !responseData) {
       // Make an ajax call to get the permadata,
       // and then use it to update the state.
-      fetch(`${API_ROOT}/permadata/${model}`, {
+      fetch(`${API_ROOT}/permadata`, {
         method: 'POST',
         headers: {
           'Accept': 'application/json',

--- a/tests/general_tests/server_test.py
+++ b/tests/general_tests/server_test.py
@@ -239,7 +239,7 @@ class TestFlask(AllenNlpTestCase):
         assert "slug" not in result
 
         # With permalinks not enabled, a post to the /permadata endpoint should be a 400.
-        response = self.client.post("/permadata/counting", data="""{"slug": "someslug"}""")
+        response = self.client.post("/permadata", data="""{"slug": "someslug"}""")
         assert response.status_code == 400
 
     def test_permalinks_work(self):
@@ -262,14 +262,13 @@ class TestFlask(AllenNlpTestCase):
         slug = result.get("slug")
         assert slug is not None
 
-        response = post("/permadata/counting", data={"slug": "not the right slug"})
+        response = post("/permadata", data={"slug": "not the right slug"})
         assert response.status_code == 400
 
-        response = post("/permadata/counting", data={"slug": slug})
+        response = post("/permadata", data={"slug": slug})
         assert response.status_code == 200
         result2 = json.loads(response.get_data())
-        assert set(result2.keys()) == {"modelName", "requestData"}
-        assert result2["modelName"] == "counting"
+        assert set(result2.keys()) == {"requestData"}
         assert result2["requestData"] == data
 
     def test_db_resilient_to_prediction_failure(self):
@@ -293,11 +292,10 @@ class TestFlask(AllenNlpTestCase):
         # in the database for subsequent analysis.
         slug = app.int_to_slug(0)
 
-        response = post("/permadata/counting", data={"slug": slug})
+        response = post("/permadata", data={"slug": slug})
         assert response.status_code == 200
         result = json.loads(response.get_data())
-        assert set(result.keys()) == {"modelName", "requestData"}
-        assert result["modelName"] == "failing"
+        assert set(result.keys()) == {"requestData"}
         assert result["requestData"] == data
 
     def test_microservice(self):


### PR DESCRIPTION
This fixes permalinks for a few models by:

- Modifying `/permadata` to not require the model name, since it's
  not used.
- Adding the `--no-models` flag which starts up a Flask server
  without any models. We use this to serve the `/permadata` from
  a single deployment.
- Deploy a single version of the Python app and route all `/permadata`
  requests to it.
- Remove rules routing requests to `/permadata/:model-name` to each
  model endpoint.
- Set the default backend, rather than using a path that captures
  all traffic.
- Remove the `/task` endpoints which aren't used anymore.

Permalinks for 3 tasks (sentiment analysis, dependency parsing and
textual entailment) broke when I factored the UI out to be served by
NGINX.

The issue is that for these three tasks there's no model which matches
the URL path. This causes the `/permadata` request to be issued to the
NGINX container instead of the Python application, which doesn't work.

For instance, for the reading comprehension task the bidaf model has
the name `reading-comprehension`. The request for
`/permadata/reading-comprehension` is therefore sent to the Python
endpoint for that model. The permadata requests for the other
reading comprehension models are *also* sent to that endpoint, but 
this works fine as the model name parameter isn't used.

For textual entailment and the tasks where this doesn't work there's
no generic model whose name matches the URL path for the task exactly.
The default route therefore forwards the request to the NGINX server
that serves the UI, which obviously isn't well suited to handle the request.

This all felt too brittle to maintain, so I factored this out into
something that makes a little more sense and is closer to where we're
headed. Luckily this has only been broken for a week or so, not months.