### PR TITLE
Use the new API to create permalinks as well.

### DIFF
--- a/api/allennlp_demo/permalinks/api.py
+++ b/api/allennlp_demo/permalinks/api.py
@@ -11,11 +11,19 @@ from allennlp_demo.common.logs import configure_logging
 
 
 def get_client_ip(r: Request) -> str:
+    """
+    Returns the best attempt at a client IP address. If the request includes
+    the X-Forwarded-For header we accept the first IP address, otherwise we
+    fallback to the remote address. This isn't used for anything sensitive so
+    we're fine blindly trusting the client.
+    """
     forwarded_for = r.headers.get("X-Forwarded-For")
     if forwarded_for is None:
         return r.remote_addr
     ips = forwarded_for.split(",")
-    return ips.pop()
+    # Take the first.
+    # See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
+    return ips[0]
 
 
 class PermaLinkService(Flask):

--- a/api/allennlp_demo/permalinks/api.py
+++ b/api/allennlp_demo/permalinks/api.py
@@ -1,10 +1,21 @@
 from typing import Optional
+
 import psycopg2
-from flask import Flask, Response, jsonify
+
+from flask import Flask, Request, Response, jsonify, request
 from werkzeug.exceptions import BadRequest, InternalServerError, NotFound
+
 from allennlp_demo.permalinks.db import DemoDatabase, PostgresDemoDatabase
-from allennlp_demo.permalinks.models import slug_to_int
+from allennlp_demo.permalinks.models import slug_to_int, int_to_slug
 from allennlp_demo.common.logs import configure_logging
+
+
+def get_client_ip(r: Request) -> str:
+    forwarded_for = r.headers.get("X-Forwarded-For")
+    if forwarded_for is None:
+        return r.remote_addr
+    ips = forwarded_for.split(",")
+    return ips.pop()
 
 
 class PermaLinkService(Flask):
@@ -25,7 +36,7 @@ class PermaLinkService(Flask):
             self.logger.error(err)
             return jsonify({"error": "Something went wrong."}), 500
 
-        @self.route("/")
+        @self.route("/", methods=["GET"])
         def info():
             """
             The simplest of info routes. We can add more here later.
@@ -41,22 +52,50 @@ class PermaLinkService(Flask):
             if self.db is None:
                 raise BadRequest("Permalinks are not enabled")
 
-            perma_id = slug_to_int(slug)
-            if perma_id is None:
+            link_id = slug_to_int(slug)
+            if link_id is None:
                 # Malformed slug
                 raise BadRequest(f"Unrecognized permalink: {slug}")
 
             # Fetch the results from the database.
             try:
-                link = self.db.get_result(perma_id)
+                link = self.db.get_result(link_id)
             except psycopg2.Error:
-                self.logger.exception(f"Unable to get results from database: {perma_id}")
+                self.logger.exception(f"Unable to get results from database: {link_id}")
                 raise InternalServerError("Database error")
 
             if link is None:
                 raise NotFound(f"Permalink not found: {slug}")
 
             return jsonify({"requestData": link.request_data})
+
+        @self.route("/", methods=["POST"])
+        def create_permalink() -> Response:
+            """
+            Creates a new permalink.
+            """
+            # If we don't have a database configured, there are no permalinks.
+            if self.db is None:
+                raise BadRequest("Permalinks are not enabled")
+
+            model_name = request.json.get("model_name")
+            if model_name is None:
+                raise BadRequest("You must provide a model name")
+
+            request_data = request.json.get("request_data")
+            if request_data is None:
+                raise BadRequest("You must provide request data")
+
+            try:
+                id = self.db.insert_request(
+                    requester=get_client_ip(request),
+                    model_name=model_name,
+                    request_data=request_data,
+                )
+                return jsonify(int_to_slug(id))
+            except psycopg2.Error as err:
+                self.logger.exception(f"Error saving permalink: ", err)
+                raise InternalServerError("Unable to create permalink")
 
 
 if __name__ == "__main__":

--- a/api/allennlp_demo/permalinks/db.py
+++ b/api/allennlp_demo/permalinks/db.py
@@ -21,7 +21,7 @@ class DemoDatabase:
     In the future it could also be used to store user-submitted feedback about predictions.
     """
 
-    def insert_request(self, requester: str, model_name: str, inputs: Dict) -> Optional[int]:
+    def insert_request(self, requester: str, model_name: str, request_data: Dict) -> Optional[int]:
         """
         Add the request to the database so that it can later
         be retrieved via permalink.
@@ -108,7 +108,7 @@ class PostgresDemoDatabase(DemoDatabase):
             logger.info("Relevant environment variables not found, so no demo database")
             return None
 
-    def insert_request(self, requester: str, model_name: str, inputs: Dict) -> Optional[int]:
+    def insert_request(self, requester: str, model_name: str, request_data: Dict) -> Optional[int]:
         try:
             conn = self.connect()
             with conn.cursor() as curs:
@@ -119,7 +119,7 @@ class PostgresDemoDatabase(DemoDatabase):
                     {
                         "model_name": model_name,
                         "requester": requester,
-                        "request_data": json.dumps(inputs),
+                        "request_data": json.dumps(request_data),
                         "timestamp": datetime.datetime.now(),
                     },
                 )
@@ -164,8 +164,8 @@ class InMemoryDemoDatabase(DemoDatabase):
     def __init__(self):
         self.data: List[PermaLink] = []
 
-    def insert_request(self, requester: str, model_name: str, inputs: Dict) -> Optional[int]:
-        self.data.append(PermaLink(model_name, inputs))
+    def insert_request(self, requester: str, model_name: str, request_data: Dict) -> Optional[int]:
+        self.data.append(PermaLink(model_name, request_data))
         return len(self.data) - 1
 
     def get_result(self, perma_id: int) -> Optional[PermaLink]:

--- a/api/allennlp_demo/permalinks/test_api.py
+++ b/api/allennlp_demo/permalinks/test_api.py
@@ -28,3 +28,25 @@ def test_get_permalink():
     assert resp.status_code == 200
     assert resp.json["requestData"]["slug"] == "zilla"
     assert len(resp.json.keys()) == 1
+
+
+def test_create_permalink():
+    db = InMemoryDemoDatabase()
+    app = PermaLinkService("testpermalinks", db)
+    client = app.test_client()
+
+    resp = client.post(
+        "/",
+        json={
+            "model_name": "bidaf",
+            "request_data": {"passage": "The dog barked.", "question": "Did the dog bark?"},
+        },
+    )
+    assert resp.status_code == 200
+    slug = resp.json
+    assert len(slug) != 0
+
+    get_resp = client.get(f"/{slug}")
+    assert get_resp.status_code == 200
+    assert get_resp.json["requestData"]["passage"] == "The dog barked."
+    assert get_resp.json["requestData"]["question"] == "Did the dog bark?"

--- a/dev/proxy.conf
+++ b/dev/proxy.conf
@@ -14,12 +14,14 @@ server {
     # We direct all of these to the legacy stack.
     location ~ ^/(predict|interpret|attack|info) {
         proxy_pass http://old:8000;
+        proxy_set_header X-Forwarded-For $remote_addr;
     }
 
     # Permalink requests go to a dedicated endpoint.
     location /api/permalink {
         rewrite /api/permalink(/(.*))? /$2 break;
         proxy_pass http://permalinks:8000;
+        proxy_set_header X-Forwarded-For $remote_addr;
     }
 
     # Requests for new endpoints are prefixed by `/api/:model_id`. In local development we
@@ -28,6 +30,7 @@ server {
     location /api {
         rewrite /api/(.+)(/(.*))? /$3 break;
         proxy_pass http://model:8000;
+        proxy_set_header X-Forwarded-For $remote_addr;
     }
 
     # This provides a websocket connection between the client and server,
@@ -37,6 +40,7 @@ server {
         proxy_pass http://ui:3000;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
+        proxy_set_header X-Forwarded-For $remote_addr;
     }
 
     # Send everything else to the UI. In development we run a HTTP server that's provided with
@@ -44,6 +48,7 @@ server {
     # serve the precompiled assets from disk using NGINX.
     location / {
         proxy_pass http://ui:3000;
+        proxy_set_header X-Forwarded-For $remote_addr;
     }
 }
 

--- a/ui/src/components/Model.js
+++ b/ui/src/components/Model.js
@@ -51,6 +51,9 @@ class Model extends React.Component {
         },
         body: JSON.stringify(inputs)
       }).then((response) => {
+        if (response.status !== 200) {
+            throw Error('Predict call failed.');
+        }
         return response.json();
       }).then((json) => {
         this.props.updateData(inputs, json)

--- a/ui/src/components/Model.js
+++ b/ui/src/components/Model.js
@@ -53,26 +53,35 @@ class Model extends React.Component {
       }).then((response) => {
         return response.json();
       }).then((json) => {
-        // If the response contains a `slug` for a permalink, we want to redirect
-        // to the corresponding path using `history.push`.
-        const { slug } = json;
-        const newPath = slug ? `/${selectedModel}/${slug}` : `/${selectedModel}`
-
-        // We'll pass the request and response data along as part of the location object
-        // so that the `Demo` component can use them to re-render.
-        const location = {
-          pathname: newPath
-        }
-
         this.props.updateData(inputs, json)
-
-        // Update the URL
-        if (!disablePermadata) {
-          this.props.history.push(location)
-        }
-
         this.setState({outputState: "received"})
 
+        if (!disablePermadata) {
+          // Extract the model name from the URL by taking the last portion
+          // of the path. The model name in this respect is the key in
+          // `models.json` that corresponds to the model being invoked. It
+          // may include the task name and model name, or one or the other.
+          //
+          // In the near future we plan to stop storing and relying on this
+          // field at all, which makes this an acceptable workaround.
+          const u = new URL(url, window.location.origin);
+          const modelName = u.pathname.split('/').pop();
+
+          fetch(`/api/permalink/`, {
+            method: 'POST',
+            headers: {
+              'Accept': 'application/json',
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+              model_name: modelName,
+              request_data: inputs
+            })
+          }).then(r => r.json()).then(slug => {
+            const newPath = `/${selectedModel}/${slug}`;
+            this.props.history.push(newPath);
+          });
+        }
       }).catch((error) => {
         this.setState({outputState: "error"});
         console.error(error);


### PR DESCRIPTION
This is part two of the great permalinks refactor. In this PR I
remove the code from the old Python application that writes permalinks
to the database and use the new service instead.

The API contract didn't change as to prevent the number of things
that are changing at once. Future PRs will start reshaping things into
the format we need for the new endpoints.