### PR TITLE
adds remaining models

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -36,11 +36,15 @@ typecheck :
 	docker run --rm \
 		-p $(DOCKER_PORT):8000 \
 		-v $$HOME/.allennlp:/root/.allennlp \
+		-v $$HOME/.cache/torch:/root/.cache/torch \
+		-v $$HOME/nltk_data:/root/nltk_data \
 		$(DOCKER_BASE_NAME)-$*:$(DOCKER_TAG)
 
 %-test : %-build
 	docker run --rm \
 		-v $$HOME/.allennlp:/root/.allennlp \
+		-v $$HOME/.cache/torch:/root/.cache/torch \
+		-v $$HOME/nltk_data:/root/nltk_data \
 		--entrypoint=python \
 		$(DOCKER_BASE_NAME)-$*:$(DOCKER_TAG) \
 		-m pytest -v --color=yes

--- a/api/allennlp_demo/atis_parser/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/atis_parser/.skiff/webapp.jsonnet
@@ -1,0 +1,17 @@
+/**
+ * This file defines the infrastructure we need to run the API endpoint on Kubernetes.
+ *
+ * For more information on the JSONNET language, see:
+ * https://jsonnet.org/learning/getting_started.html
+ */
+
+local common = import '../../common/.skiff/common.libsonnet';
+local model = import '../model.json';
+
+function(image, cause, sha, env, branch, repo, buildId)
+    // This tells Kubernetes what resources we need to run.
+    // For more information see:
+    // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+    local cpu = '50m';
+    local memory = '1Gi';
+    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)

--- a/api/allennlp_demo/atis_parser/Dockerfile
+++ b/api/allennlp_demo/atis_parser/Dockerfile
@@ -1,0 +1,17 @@
+FROM allennlp/commit:93024e53c1445cb4630ee5c07926abff8943715f
+
+WORKDIR /app/
+COPY allennlp_demo/atis_parser/requirements.txt allennlp_demo/atis_parser/requirements.txt
+ENV EXCLUDE_ALLENNLP_IN_SETUP true
+RUN pip install -r allennlp_demo/atis_parser/requirements.txt
+
+RUN spacy download en_core_web_sm
+
+COPY allennlp_demo/__init__.py allennlp_demo/__init__.py
+COPY allennlp_demo/common allennlp_demo/common
+COPY allennlp_demo/atis_parser allennlp_demo/atis_parser
+
+ENV PYTHONPATH /app/
+
+ENTRYPOINT [ "python" ]
+CMD [ "allennlp_demo/atis_parser/api.py" ]

--- a/api/allennlp_demo/atis_parser/api.py
+++ b/api/allennlp_demo/atis_parser/api.py
@@ -1,0 +1,15 @@
+import os
+
+from allennlp_demo.common import config, http
+from allennlp_semparse import predictors, models  # noqa: F401
+
+
+class AtisParserModelEndpoint(http.ModelEndpoint):
+    def __init__(self):
+        c = config.Model.from_file(os.path.join(os.path.dirname(__file__), "model.json"))
+        super().__init__(c)
+
+
+if __name__ == "__main__":
+    endpoint = AtisParserModelEndpoint()
+    endpoint.run()

--- a/api/allennlp_demo/atis_parser/model.json
+++ b/api/allennlp_demo/atis_parser/model.json
@@ -1,0 +1,5 @@
+{
+    "id": "atis-parser",
+    "archive_file": "https://allennlp.s3.amazonaws.com/models/atis-parser-2020.02.10.tar.gz",
+    "predictor_name": "atis-parser"
+}

--- a/api/allennlp_demo/atis_parser/requirements.txt
+++ b/api/allennlp_demo/atis_parser/requirements.txt
@@ -1,0 +1,14 @@
+git+https://github.com/allenai/allennlp-semparse.git@937d5945488a33c61d0047bd74d8106e60340bbd
+Flask==1.1.2
+pytest==5.4.1
+dateparser==0.7.4
+dataclasses==0.7.0
+parsimonious>=0.8.0
+# Used to format and postprocess SQL
+sqlparse>=0.2.4
+# Used to process tables in WikiTableQuestions
+unidecode
+# Used in KnowledgeGraphField
+editdistance
+# Used for the type system for some languages
+nltk

--- a/api/allennlp_demo/atis_parser/test_api.py
+++ b/api/allennlp_demo/atis_parser/test_api.py
@@ -1,0 +1,7 @@
+from allennlp_demo.atis_parser.api import AtisParserModelEndpoint
+from allennlp_demo.common.testing import ModelEndpointTestCase
+
+
+class TestAtisParserModelEndpoint(ModelEndpointTestCase):
+    endpoint = AtisParserModelEndpoint()
+    predict_input = {"utterance": "show me the flights from detroit to westchester county"}

--- a/api/allennlp_demo/bidaf/requirements.txt
+++ b/api/allennlp_demo/bidaf/requirements.txt
@@ -1,3 +1,0 @@
-allennlp-models==1.0.0rc3
-Flask==1.1.2
-pytest==5.4.1

--- a/api/allennlp_demo/bidaf_elmo/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/bidaf_elmo/.skiff/webapp.jsonnet
@@ -16,4 +16,4 @@ function(image, cause, sha, env, branch, repo, buildId)
     local memory = '1.3Gi';
     // The amount of time to wait for the container to startup.
     local startupTime = 180;
-    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId, 180)
+    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId, startupTime)

--- a/api/allennlp_demo/common/logs.py
+++ b/api/allennlp_demo/common/logs.py
@@ -3,6 +3,7 @@ import sys
 import json
 import logging
 import time
+from typing import Mapping
 
 from flask import Flask, request, Response, g
 from dataclasses import dataclass, asdict
@@ -32,7 +33,7 @@ class JsonLogFormatter(logging.Formatter):
             # In development we just return the exception with the default formatting, as this
             # is easiest for the end user.
             if os.getenv("FLASK_ENV") == "development":
-                return self.formatException(r.exc_info)
+                return super().format(r)
 
             # Otherwise we still output them as JSON
             m = r.getMessage() % r.__dict__
@@ -45,7 +46,7 @@ class JsonLogFormatter(logging.Formatter):
                     "stack": self.formatStack(r.stack_info),
                 }
             )
-        if not isinstance(r.msg, str):
+        if isinstance(r.msg, Mapping):
             return json.dumps({"logname": r.name, "severity": r.levelname, **r.msg})
         else:
             m = r.getMessage() % r.__dict__

--- a/api/allennlp_demo/coref/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/coref/.skiff/webapp.jsonnet
@@ -1,6 +1,5 @@
 /**
  * This file defines the infrastructure we need to run the API endpoint on Kubernetes.
- *
  * For more information on the JSONNET language, see:
  * https://jsonnet.org/learning/getting_started.html
  */
@@ -13,5 +12,7 @@ function(image, cause, sha, env, branch, repo, buildId)
     // For more information see:
     // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
     local cpu = '50m';
-    local memory = '1Gi';
+    local memory = '5Gi';
+    // The amount of time to wait for the container to startup.
+    local startupTime = 180;
     common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)

--- a/api/allennlp_demo/coref/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/coref/.skiff/webapp.jsonnet
@@ -15,4 +15,4 @@ function(image, cause, sha, env, branch, repo, buildId)
     local memory = '5Gi';
     // The amount of time to wait for the container to startup.
     local startupTime = 180;
-    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)
+    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId, startupTime)

--- a/api/allennlp_demo/coref/test_api.py
+++ b/api/allennlp_demo/coref/test_api.py
@@ -1,0 +1,7 @@
+from allennlp_demo.common.testing import ModelEndpointTestCase
+from allennlp_demo.coref.api import CorefModelEndpoint
+
+
+class TestCorefModelEndpoint(ModelEndpointTestCase):
+    endpoint = CorefModelEndpoint()
+    predict_input = {"document": "The woman reading a newspaper sat on the bench with her dog."}

--- a/api/allennlp_demo/dependency_parser/test_api.py
+++ b/api/allennlp_demo/dependency_parser/test_api.py
@@ -1,0 +1,7 @@
+from allennlp_demo.common.testing import ModelEndpointTestCase
+from allennlp_demo.dependency_parser.api import DependencyParserModelEndpoint
+
+
+class TestDependencyParserModelEndpoint(ModelEndpointTestCase):
+    endpoint = DependencyParserModelEndpoint()
+    predict_input = {"sentence": "If I bring 10 dollars tomorrow, can you buy me lunch?"}

--- a/api/allennlp_demo/elmo_snli/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/elmo_snli/.skiff/webapp.jsonnet
@@ -15,4 +15,4 @@ function(image, cause, sha, env, branch, repo, buildId)
     local cpu = '50m';
     local memory = '4Gi';
     local startupTime = 180;
-    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)
+    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId, startupTime)

--- a/api/allennlp_demo/elmo_snli/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/elmo_snli/.skiff/webapp.jsonnet
@@ -13,5 +13,6 @@ function(image, cause, sha, env, branch, repo, buildId)
     // For more information see:
     // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
     local cpu = '50m';
-    local memory = '1Gi';
+    local memory = '4Gi';
+    local startupTime = 180;
     common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)

--- a/api/allennlp_demo/elmo_snli/model.json
+++ b/api/allennlp_demo/elmo_snli/model.json
@@ -1,5 +1,5 @@
 {
     "id": "elmo-snli",
     "archive_file": "https://storage.googleapis.com/allennlp-public-models/decomposable-attention-elmo-2020.04.09.tar.gz",
-    "predictor_name": "textual_entailment"
+    "predictor_name": "textual-entailment"
 }

--- a/api/allennlp_demo/elmo_snli/test_api.py
+++ b/api/allennlp_demo/elmo_snli/test_api.py
@@ -1,0 +1,10 @@
+from allennlp_demo.common.testing import ModelEndpointTestCase
+from allennlp_demo.elmo_snli.api import ElmoSnliModelEndpoint
+
+
+class TestElmoSnliModelEndpoint(ModelEndpointTestCase):
+    endpoint = ElmoSnliModelEndpoint()
+    predict_input = {
+        "hypothesis": "Two women are sitting on a blanket near some rocks talking about politics.",
+        "premise": "Two women are wandering along the shore drinking iced tea.",
+    }

--- a/api/allennlp_demo/fine_grained_ner/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/fine_grained_ner/.skiff/webapp.jsonnet
@@ -13,5 +13,5 @@ function(image, cause, sha, env, branch, repo, buildId)
     // For more information see:
     // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
     local cpu = '50m';
-    local memory = '1Gi';
+    local memory = '2Gi';
     common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)

--- a/api/allennlp_demo/fine_grained_ner/model.json
+++ b/api/allennlp_demo/fine_grained_ner/model.json
@@ -1,5 +1,5 @@
 {
-    "id": "fine_grained_ner",
+    "id": "fine-grained-ner",
     "archive_file": "https://storage.googleapis.com/allennlp-public-models/fine-grained-ner-model-elmo-2018.12.21.tar.gz",
     "predictor_name": "sentence-tagger"
 }

--- a/api/allennlp_demo/fine_grained_ner/test_api.py
+++ b/api/allennlp_demo/fine_grained_ner/test_api.py
@@ -1,0 +1,9 @@
+from allennlp_demo.common.testing import ModelEndpointTestCase
+from allennlp_demo.fine_grained_ner.api import FineGrainedNerModelEndpoint
+
+
+class TestFineGrainedNerModelEndpoint(ModelEndpointTestCase):
+    endpoint = FineGrainedNerModelEndpoint()
+    predict_input = {
+        "sentence": "Did Uriah honestly think he could beat The Legend of Zelda in under three hours?"
+    }

--- a/api/allennlp_demo/glove_sentiment_analysis/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/glove_sentiment_analysis/.skiff/webapp.jsonnet
@@ -1,0 +1,17 @@
+/**
+ * This file defines the infrastructure we need to run the API endpoint on Kubernetes.
+ *
+ * For more information on the JSONNET language, see:
+ * https://jsonnet.org/learning/getting_started.html
+ */
+
+local common = import '../../common/.skiff/common.libsonnet';
+local model = import '../model.json';
+
+function(image, cause, sha, env, branch, repo, buildId)
+    // This tells Kubernetes what resources we need to run.
+    // For more information see:
+    // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+    local cpu = '50m';
+    local memory = '1Gi';
+    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)

--- a/api/allennlp_demo/glove_sentiment_analysis/api.py
+++ b/api/allennlp_demo/glove_sentiment_analysis/api.py
@@ -1,0 +1,16 @@
+import os
+
+from allennlp_models import sentiment  # noqa: F401
+
+from allennlp_demo.common import config, http
+
+
+class GloveSentimentAnalysisModelEndpoint(http.ModelEndpoint):
+    def __init__(self):
+        c = config.Model.from_file(os.path.join(os.path.dirname(__file__), "model.json"))
+        super().__init__(c)
+
+
+if __name__ == "__main__":
+    endpoint = GloveSentimentAnalysisModelEndpoint()
+    endpoint.run()

--- a/api/allennlp_demo/glove_sentiment_analysis/model.json
+++ b/api/allennlp_demo/glove_sentiment_analysis/model.json
@@ -1,0 +1,5 @@
+{
+    "id": "glove-sentiment-analysis",
+    "archive_file": "https://s3-us-west-2.amazonaws.com/allennlp/models/sst-2-basic-classifier-glove-2019.06.27.tar.gz",
+    "predictor_name": "text_classifier"
+}

--- a/api/allennlp_demo/glove_sentiment_analysis/test_api.py
+++ b/api/allennlp_demo/glove_sentiment_analysis/test_api.py
@@ -1,0 +1,7 @@
+from allennlp_demo.common.testing import ModelEndpointTestCase
+from allennlp_demo.glove_sentiment_analysis.api import GloveSentimentAnalysisModelEndpoint
+
+
+class TestGloveSentimentAnalysisModelEndpoint(ModelEndpointTestCase):
+    endpoint = GloveSentimentAnalysisModelEndpoint()
+    predict_input = {"sentence": "a very well-made, funny and entertaining picture."}

--- a/api/allennlp_demo/masked_lm/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/masked_lm/.skiff/webapp.jsonnet
@@ -1,0 +1,17 @@
+/**
+ * This file defines the infrastructure we need to run the API endpoint on Kubernetes.
+ *
+ * For more information on the JSONNET language, see:
+ * https://jsonnet.org/learning/getting_started.html
+ */
+
+local common = import '../../common/.skiff/common.libsonnet';
+local model = import '../model.json';
+
+function(image, cause, sha, env, branch, repo, buildId)
+    // This tells Kubernetes what resources we need to run.
+    // For more information see:
+    // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+    local cpu = '50m';
+    local memory = '4Gi';
+    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)

--- a/api/allennlp_demo/masked_lm/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/masked_lm/.skiff/webapp.jsonnet
@@ -15,4 +15,4 @@ function(image, cause, sha, env, branch, repo, buildId)
     local cpu = '50m';
     local memory = '4Gi';
     local startupTime = 180;
-    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)
+    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId, startupTime)

--- a/api/allennlp_demo/masked_lm/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/masked_lm/.skiff/webapp.jsonnet
@@ -14,4 +14,5 @@ function(image, cause, sha, env, branch, repo, buildId)
     // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
     local cpu = '50m';
     local memory = '4Gi';
+    local startupTime = 180;
     common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)

--- a/api/allennlp_demo/masked_lm/Dockerfile
+++ b/api/allennlp_demo/masked_lm/Dockerfile
@@ -1,0 +1,17 @@
+FROM allennlp/commit:ff0d44a5e21d5e6256c73b5b9f216a87c5743f91
+
+WORKDIR /app/
+COPY allennlp_demo/masked_lm/requirements.txt allennlp_demo/masked_lm/requirements.txt
+ENV EXCLUDE_ALLENNLP_IN_SETUP true
+RUN pip install -r allennlp_demo/masked_lm/requirements.txt
+
+RUN spacy download en_core_web_sm
+
+COPY allennlp_demo/__init__.py allennlp_demo/__init__.py
+COPY allennlp_demo/common allennlp_demo/common
+COPY allennlp_demo/masked_lm allennlp_demo/masked_lm
+
+ENV PYTHONPATH /app/
+
+ENTRYPOINT [ "python" ]
+CMD [ "allennlp_demo/masked_lm/api.py" ]

--- a/api/allennlp_demo/masked_lm/api.py
+++ b/api/allennlp_demo/masked_lm/api.py
@@ -1,0 +1,14 @@
+import os
+
+from allennlp_demo.common import config, http
+
+
+class MaskedLmModelEndpoint(http.ModelEndpoint):
+    def __init__(self):
+        c = config.Model.from_file(os.path.join(os.path.dirname(__file__), "model.json"))
+        super().__init__(c)
+
+
+if __name__ == "__main__":
+    endpoint = MaskedLmModelEndpoint()
+    endpoint.run()

--- a/api/allennlp_demo/masked_lm/model.json
+++ b/api/allennlp_demo/masked_lm/model.json
@@ -1,0 +1,5 @@
+{
+    "id": "masked-lm",
+    "archive_file": "https://storage.googleapis.com/allennlp-public-models/bert-masked-lm-2019.09.17.tar.gz",
+    "predictor_name": "masked_language_model"
+}

--- a/api/allennlp_demo/masked_lm/requirements.txt
+++ b/api/allennlp_demo/masked_lm/requirements.txt
@@ -1,0 +1,3 @@
+Flask==1.1.2
+pytest==5.4.1
+dataclasses==0.7.0

--- a/api/allennlp_demo/masked_lm/test_api.py
+++ b/api/allennlp_demo/masked_lm/test_api.py
@@ -1,0 +1,7 @@
+from allennlp_demo.common.testing import ModelEndpointTestCase
+from allennlp_demo.masked_lm.api import MaskedLmModelEndpoint
+
+
+class TestMaskedLmModelEndpoint(ModelEndpointTestCase):
+    endpoint = MaskedLmModelEndpoint()
+    predict_input = {"sentence": "The doctor ran to the emergency room to see [MASK] patient."}

--- a/api/allennlp_demo/named_entity_recognition/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/named_entity_recognition/.skiff/webapp.jsonnet
@@ -1,0 +1,17 @@
+/**
+ * This file defines the infrastructure we need to run the API endpoint on Kubernetes.
+ *
+ * For more information on the JSONNET language, see:
+ * https://jsonnet.org/learning/getting_started.html
+ */
+
+local common = import '../../common/.skiff/common.libsonnet';
+local model = import '../model.json';
+
+function(image, cause, sha, env, branch, repo, buildId)
+    // This tells Kubernetes what resources we need to run.
+    // For more information see:
+    // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+    local cpu = '50m';
+    local memory = '1Gi';
+    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)

--- a/api/allennlp_demo/named_entity_recognition/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/named_entity_recognition/.skiff/webapp.jsonnet
@@ -13,5 +13,6 @@ function(image, cause, sha, env, branch, repo, buildId)
     // For more information see:
     // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
     local cpu = '50m';
-    local memory = '1Gi';
-    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)
+    local memory = '4Gi';
+    local startupTime = 180;
+    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId, startupTime)

--- a/api/allennlp_demo/named_entity_recognition/api.py
+++ b/api/allennlp_demo/named_entity_recognition/api.py
@@ -1,0 +1,16 @@
+import os
+
+from allennlp_models import ner  # noqa: F401
+
+from allennlp_demo.common import config, http
+
+
+class NerModelEndpoint(http.ModelEndpoint):
+    def __init__(self):
+        c = config.Model.from_file(os.path.join(os.path.dirname(__file__), "model.json"))
+        super().__init__(c)
+
+
+if __name__ == "__main__":
+    endpoint = NerModelEndpoint()
+    endpoint.run()

--- a/api/allennlp_demo/named_entity_recognition/model.json
+++ b/api/allennlp_demo/named_entity_recognition/model.json
@@ -1,0 +1,5 @@
+{
+    "id": "named-entity-recognition",
+    "archive_file": "https://storage.googleapis.com/allennlp-public-models/ner-model-2020.02.10.tar.gz",
+    "predictor_name": "sentence-tagger"
+}

--- a/api/allennlp_demo/named_entity_recognition/test_api.py
+++ b/api/allennlp_demo/named_entity_recognition/test_api.py
@@ -1,0 +1,9 @@
+from allennlp_demo.common.testing import ModelEndpointTestCase
+from allennlp_demo.named_entity_recognition.api import NerModelEndpoint
+
+
+class TestNerModelEndpoint(ModelEndpointTestCase):
+    endpoint = NerModelEndpoint()
+    predict_input = {
+        "sentence": "Did Uriah honestly think he could beat The Legend of Zelda in under three hours?"
+    }

--- a/api/allennlp_demo/next_token_lm/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/next_token_lm/.skiff/webapp.jsonnet
@@ -1,0 +1,17 @@
+/**
+ * This file defines the infrastructure we need to run the API endpoint on Kubernetes.
+ *
+ * For more information on the JSONNET language, see:
+ * https://jsonnet.org/learning/getting_started.html
+ */
+
+local common = import '../../common/.skiff/common.libsonnet';
+local model = import '../model.json';
+
+function(image, cause, sha, env, branch, repo, buildId)
+    // This tells Kubernetes what resources we need to run.
+    // For more information see:
+    // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+    local cpu = '50m';
+    local memory = '1Gi';
+    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)

--- a/api/allennlp_demo/next_token_lm/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/next_token_lm/.skiff/webapp.jsonnet
@@ -13,5 +13,5 @@ function(image, cause, sha, env, branch, repo, buildId)
     // For more information see:
     // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
     local cpu = '50m';
-    local memory = '1Gi';
+    local memory = '4Gi';
     common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)

--- a/api/allennlp_demo/next_token_lm/api.py
+++ b/api/allennlp_demo/next_token_lm/api.py
@@ -1,0 +1,16 @@
+import os
+
+from allennlp_models import lm  # noqa: F401
+
+from allennlp_demo.common import config, http
+
+
+class NextTokenLmModelEndpoint(http.ModelEndpoint):
+    def __init__(self):
+        c = config.Model.from_file(os.path.join(os.path.dirname(__file__), "model.json"))
+        super().__init__(c)
+
+
+if __name__ == "__main__":
+    endpoint = NextTokenLmModelEndpoint()
+    endpoint.run()

--- a/api/allennlp_demo/next_token_lm/model.json
+++ b/api/allennlp_demo/next_token_lm/model.json
@@ -1,0 +1,5 @@
+{
+    "id": "next-token-lm",
+    "archive_file": "https://storage.googleapis.com/allennlp-public-models/gpt2-next-word-lm-2020.02.19.tar.gz",
+    "predictor_name": "next_token_lm"
+}

--- a/api/allennlp_demo/next_token_lm/test_api.py
+++ b/api/allennlp_demo/next_token_lm/test_api.py
@@ -1,0 +1,7 @@
+from allennlp_demo.common.testing import ModelEndpointTestCase
+from allennlp_demo.next_token_lm.api import NextTokenLmModelEndpoint
+
+
+class TestNextTokenLmModelEndpoint(ModelEndpointTestCase):
+    endpoint = NextTokenLmModelEndpoint()
+    predict_input = {"sentence": "AlleNLP is"}

--- a/api/allennlp_demo/nlvr_parser/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/nlvr_parser/.skiff/webapp.jsonnet
@@ -1,0 +1,17 @@
+/**
+ * This file defines the infrastructure we need to run the API endpoint on Kubernetes.
+ *
+ * For more information on the JSONNET language, see:
+ * https://jsonnet.org/learning/getting_started.html
+ */
+
+local common = import '../../common/.skiff/common.libsonnet';
+local model = import '../model.json';
+
+function(image, cause, sha, env, branch, repo, buildId)
+    // This tells Kubernetes what resources we need to run.
+    // For more information see:
+    // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+    local cpu = '50m';
+    local memory = '1Gi';
+    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)

--- a/api/allennlp_demo/nlvr_parser/Dockerfile
+++ b/api/allennlp_demo/nlvr_parser/Dockerfile
@@ -1,0 +1,17 @@
+FROM allennlp/commit:93024e53c1445cb4630ee5c07926abff8943715f
+
+WORKDIR /app/
+COPY allennlp_demo/nlvr_parser/requirements.txt allennlp_demo/nlvr_parser/requirements.txt
+ENV EXCLUDE_ALLENNLP_IN_SETUP true
+RUN pip install -r allennlp_demo/nlvr_parser/requirements.txt
+
+RUN spacy download en_core_web_sm
+
+COPY allennlp_demo/__init__.py allennlp_demo/__init__.py
+COPY allennlp_demo/common allennlp_demo/common
+COPY allennlp_demo/nlvr_parser allennlp_demo/nlvr_parser
+
+ENV PYTHONPATH /app/
+
+ENTRYPOINT [ "python" ]
+CMD [ "allennlp_demo/nlvr_parser/api.py" ]

--- a/api/allennlp_demo/nlvr_parser/api.py
+++ b/api/allennlp_demo/nlvr_parser/api.py
@@ -1,0 +1,15 @@
+import os
+
+from allennlp_demo.common import config, http
+from allennlp_semparse import predictors, models  # noqa: F401
+
+
+class NlvrParserModelEndpoint(http.ModelEndpoint):
+    def __init__(self):
+        c = config.Model.from_file(os.path.join(os.path.dirname(__file__), "model.json"))
+        super().__init__(c)
+
+
+if __name__ == "__main__":
+    endpoint = NlvrParserModelEndpoint()
+    endpoint.run()

--- a/api/allennlp_demo/nlvr_parser/model.json
+++ b/api/allennlp_demo/nlvr_parser/model.json
@@ -1,0 +1,5 @@
+{
+    "id": "nlvr-parser",
+    "archive_file": "https://allennlp.s3.amazonaws.com/models/nlvr-erm-model-2020.02.10-rule-vocabulary-updated.tar.gz",
+    "predictor_name": "nlvr-parser"
+}

--- a/api/allennlp_demo/nlvr_parser/requirements.txt
+++ b/api/allennlp_demo/nlvr_parser/requirements.txt
@@ -1,0 +1,14 @@
+git+https://github.com/allenai/allennlp-semparse.git@937d5945488a33c61d0047bd74d8106e60340bbd
+Flask==1.1.2
+pytest==5.4.1
+dateparser==0.7.4
+dataclasses==0.7.0
+parsimonious>=0.8.0
+# Used to format and postprocess SQL
+sqlparse>=0.2.4
+# Used to process tables in WikiTableQuestions
+unidecode
+# Used in KnowledgeGraphField
+editdistance
+# Used for the type system for some languages
+nltk

--- a/api/allennlp_demo/nlvr_parser/test_api.py
+++ b/api/allennlp_demo/nlvr_parser/test_api.py
@@ -1,0 +1,26 @@
+from allennlp_demo.nlvr_parser.api import NlvrParserModelEndpoint
+from allennlp_demo.common.testing import ModelEndpointTestCase
+
+
+class TestNlvrParserModelEndpoint(ModelEndpointTestCase):
+    endpoint = NlvrParserModelEndpoint()
+    predict_input = {
+        "sentence": "there is exactly one yellow object touching the edge",
+        "structured_rep": [
+            [
+                {"y_loc": 13, "type": "square", "color": "Yellow", "x_loc": 13, "size": 20},
+                {"y_loc": 20, "type": "triangle", "color": "Yellow", "x_loc": 44, "size": 30},
+                {"y_loc": 90, "type": "circle", "color": "#0099ff", "x_loc": 52, "size": 10},
+            ],
+            [
+                {"y_loc": 57, "type": "square", "color": "Black", "x_loc": 17, "size": 20},
+                {"y_loc": 30, "type": "circle", "color": "#0099ff", "x_loc": 76, "size": 10},
+                {"y_loc": 12, "type": "square", "color": "Black", "x_loc": 35, "size": 10},
+            ],
+            [
+                {"y_loc": 40, "type": "triangle", "color": "#0099ff", "x_loc": 26, "size": 20},
+                {"y_loc": 70, "type": "triangle", "color": "Black", "x_loc": 70, "size": 30},
+                {"y_loc": 19, "type": "square", "color": "Black", "x_loc": 35, "size": 10},
+            ],
+        ],
+    }

--- a/api/allennlp_demo/open_information_extraction/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/open_information_extraction/.skiff/webapp.jsonnet
@@ -1,0 +1,17 @@
+/**
+ * This file defines the infrastructure we need to run the API endpoint on Kubernetes.
+ *
+ * For more information on the JSONNET language, see:
+ * https://jsonnet.org/learning/getting_started.html
+ */
+
+local common = import '../../common/.skiff/common.libsonnet';
+local model = import '../model.json';
+
+function(image, cause, sha, env, branch, repo, buildId)
+    // This tells Kubernetes what resources we need to run.
+    // For more information see:
+    // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+    local cpu = '50m';
+    local memory = '1Gi';
+    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)

--- a/api/allennlp_demo/open_information_extraction/api.py
+++ b/api/allennlp_demo/open_information_extraction/api.py
@@ -1,0 +1,16 @@
+import os
+
+from allennlp_models import syntax  # noqa: F401
+
+from allennlp_demo.common import config, http
+
+
+class OpenInformationExtractionModelEndpoint(http.ModelEndpoint):
+    def __init__(self):
+        c = config.Model.from_file(os.path.join(os.path.dirname(__file__), "model.json"))
+        super().__init__(c)
+
+
+if __name__ == "__main__":
+    endpoint = OpenInformationExtractionModelEndpoint()
+    endpoint.run()

--- a/api/allennlp_demo/open_information_extraction/model.json
+++ b/api/allennlp_demo/open_information_extraction/model.json
@@ -1,0 +1,5 @@
+{
+    "id": "open-information-extraction",
+    "archive_file": "https://storage.googleapis.com/allennlp-public-models/openie-model.2020.03.26.tar.gz",
+    "predictor_name": "open-information-extraction"
+}

--- a/api/allennlp_demo/open_information_extraction/test_api.py
+++ b/api/allennlp_demo/open_information_extraction/test_api.py
@@ -1,0 +1,7 @@
+from allennlp_demo.common.testing import ModelEndpointTestCase
+from allennlp_demo.open_information_extraction.api import OpenInformationExtractionModelEndpoint
+
+
+class TestOpenInformationExtractionModelEndpoint(ModelEndpointTestCase):
+    endpoint = OpenInformationExtractionModelEndpoint()
+    predict_input = {"sentence": "In December, John decided to join the party."}

--- a/api/allennlp_demo/permalinks/models.py
+++ b/api/allennlp_demo/permalinks/models.py
@@ -3,7 +3,15 @@ import binascii
 import logging
 from typing import Optional, NamedTuple, Dict
 
-PermaLink = NamedTuple("PermaLink", [("model_name", str), ("request_data", Dict)])
+PermaLink = NamedTuple(
+    "PermaLink",
+    [
+        ("model_name", Optional[str]),
+        ("request_data", Dict),
+        ("model_id", Optional[str]),
+        ("task_name", Optional[str]),
+    ],
+)
 
 
 def int_to_slug(i: int) -> str:

--- a/api/allennlp_demo/permalinks/schema.sql
+++ b/api/allennlp_demo/permalinks/schema.sql
@@ -17,3 +17,8 @@ ALTER SEQUENCE queries_id_seq OWNED BY queries.id;
 ALTER TABLE ONLY queries ALTER COLUMN id SET DEFAULT nextval('queries_id_seq'::regclass);
 ALTER TABLE ONLY queries
     ADD CONSTRAINT queries_pkey PRIMARY KEY (id);
+
+-- Models served by the new mechanism provide these values, but old ones do not. We allow `NULL`
+-- for backwards compatibility.
+ALTER TABLE queries ADD COLUMN model_id TEXT,
+                    ADD COLUMN task_name TEXT;

--- a/api/allennlp_demo/roberta_mnli/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/roberta_mnli/.skiff/webapp.jsonnet
@@ -1,0 +1,17 @@
+/**
+ * This file defines the infrastructure we need to run the API endpoint on Kubernetes.
+ *
+ * For more information on the JSONNET language, see:
+ * https://jsonnet.org/learning/getting_started.html
+ */
+
+local common = import '../../common/.skiff/common.libsonnet';
+local model = import '../model.json';
+
+function(image, cause, sha, env, branch, repo, buildId)
+    // This tells Kubernetes what resources we need to run.
+    // For more information see:
+    // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+    local cpu = '50m';
+    local memory = '1Gi';
+    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)

--- a/api/allennlp_demo/roberta_mnli/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/roberta_mnli/.skiff/webapp.jsonnet
@@ -13,5 +13,6 @@ function(image, cause, sha, env, branch, repo, buildId)
     // For more information see:
     // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
     local cpu = '50m';
-    local memory = '1Gi';
-    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)
+    local memory = '4Gi';
+    local startupTime = 180
+    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId, startupTime)

--- a/api/allennlp_demo/roberta_mnli/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/roberta_mnli/.skiff/webapp.jsonnet
@@ -14,5 +14,5 @@ function(image, cause, sha, env, branch, repo, buildId)
     // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
     local cpu = '50m';
     local memory = '4Gi';
-    local startupTime = 180
+    local startupTime = 180;
     common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId, startupTime)

--- a/api/allennlp_demo/roberta_mnli/api.py
+++ b/api/allennlp_demo/roberta_mnli/api.py
@@ -1,0 +1,16 @@
+import os
+
+from allennlp_models import nli  # noqa: F401
+
+from allennlp_demo.common import config, http
+
+
+class RobertaMnliModelEndpoint(http.ModelEndpoint):
+    def __init__(self):
+        c = config.Model.from_file(os.path.join(os.path.dirname(__file__), "model.json"))
+        super().__init__(c)
+
+
+if __name__ == "__main__":
+    endpoint = RobertaMnliModelEndpoint()
+    endpoint.run()

--- a/api/allennlp_demo/roberta_mnli/model.json
+++ b/api/allennlp_demo/roberta_mnli/model.json
@@ -1,0 +1,5 @@
+{
+    "id": "roberta-mnli",
+    "archive_file": "https://storage.googleapis.com/allennlp-public-models/mnli-roberta-large-2020.02.27.tar.gz",
+    "predictor_name": "textual-entailment"
+}

--- a/api/allennlp_demo/roberta_mnli/test_api.py
+++ b/api/allennlp_demo/roberta_mnli/test_api.py
@@ -1,0 +1,10 @@
+from allennlp_demo.common.testing import ModelEndpointTestCase
+from allennlp_demo.roberta_mnli.api import RobertaMnliModelEndpoint
+
+
+class TestRobertaMnliModelEndpoint(ModelEndpointTestCase):
+    endpoint = RobertaMnliModelEndpoint()
+    predict_input = {
+        "hypothesis": "Two women are sitting on a blanket near some rocks talking about politics.",
+        "premise": "Two women are wandering along the shore drinking iced tea.",
+    }

--- a/api/allennlp_demo/roberta_sentiment_analysis/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/roberta_sentiment_analysis/.skiff/webapp.jsonnet
@@ -1,0 +1,17 @@
+/**
+ * This file defines the infrastructure we need to run the API endpoint on Kubernetes.
+ *
+ * For more information on the JSONNET language, see:
+ * https://jsonnet.org/learning/getting_started.html
+ */
+
+local common = import '../../common/.skiff/common.libsonnet';
+local model = import '../model.json';
+
+function(image, cause, sha, env, branch, repo, buildId)
+    // This tells Kubernetes what resources we need to run.
+    // For more information see:
+    // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+    local cpu = '50m';
+    local memory = '4Gi';
+    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)

--- a/api/allennlp_demo/roberta_sentiment_analysis/api.py
+++ b/api/allennlp_demo/roberta_sentiment_analysis/api.py
@@ -1,0 +1,16 @@
+import os
+
+from allennlp_models import sentiment  # noqa: F401
+
+from allennlp_demo.common import config, http
+
+
+class RobertaSentimentAnalysisModelEndpoint(http.ModelEndpoint):
+    def __init__(self):
+        c = config.Model.from_file(os.path.join(os.path.dirname(__file__), "model.json"))
+        super().__init__(c)
+
+
+if __name__ == "__main__":
+    endpoint = RobertaSentimentAnalysisModelEndpoint()
+    endpoint.run()

--- a/api/allennlp_demo/roberta_sentiment_analysis/model.json
+++ b/api/allennlp_demo/roberta_sentiment_analysis/model.json
@@ -1,0 +1,5 @@
+{
+    "id": "roberta-sentiment-analysis",
+    "archive_file": "https://storage.googleapis.com/allennlp-public-models/sst-roberta-large-2020.05.05.tar.gz",
+    "predictor_name": "text_classifier"
+}

--- a/api/allennlp_demo/roberta_sentiment_analysis/test_api.py
+++ b/api/allennlp_demo/roberta_sentiment_analysis/test_api.py
@@ -1,0 +1,7 @@
+from allennlp_demo.common.testing import ModelEndpointTestCase
+from allennlp_demo.roberta_sentiment_analysis.api import RobertaSentimentAnalysisModelEndpoint
+
+
+class TestRobertaSentimentAnalysisModelEndpoint(ModelEndpointTestCase):
+    endpoint = RobertaSentimentAnalysisModelEndpoint()
+    predict_input = {"sentence": "a very well-made, funny and entertaining picture."}

--- a/api/allennlp_demo/roberta_snli/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/roberta_snli/.skiff/webapp.jsonnet
@@ -1,0 +1,17 @@
+/**
+ * This file defines the infrastructure we need to run the API endpoint on Kubernetes.
+ *
+ * For more information on the JSONNET language, see:
+ * https://jsonnet.org/learning/getting_started.html
+ */
+
+local common = import '../../common/.skiff/common.libsonnet';
+local model = import '../model.json';
+
+function(image, cause, sha, env, branch, repo, buildId)
+    // This tells Kubernetes what resources we need to run.
+    // For more information see:
+    // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+    local cpu = '50m';
+    local memory = '1Gi';
+    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)

--- a/api/allennlp_demo/roberta_snli/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/roberta_snli/.skiff/webapp.jsonnet
@@ -13,5 +13,5 @@ function(image, cause, sha, env, branch, repo, buildId)
     // For more information see:
     // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
     local cpu = '50m';
-    local memory = '1Gi';
+    local memory = '4Gi';
     common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)

--- a/api/allennlp_demo/roberta_snli/api.py
+++ b/api/allennlp_demo/roberta_snli/api.py
@@ -1,0 +1,16 @@
+import os
+
+from allennlp_models import nli  # noqa: F401
+
+from allennlp_demo.common import config, http
+
+
+class RobertaSnliModelEndpoint(http.ModelEndpoint):
+    def __init__(self):
+        c = config.Model.from_file(os.path.join(os.path.dirname(__file__), "model.json"))
+        super().__init__(c)
+
+
+if __name__ == "__main__":
+    endpoint = RobertaSnliModelEndpoint()
+    endpoint.run()

--- a/api/allennlp_demo/roberta_snli/model.json
+++ b/api/allennlp_demo/roberta_snli/model.json
@@ -1,0 +1,5 @@
+{
+    "id": "roberta-snli",
+    "archive_file": "https://storage.googleapis.com/allennlp-public-models/snli-roberta-large-2020.04.30.tar.gz",
+    "predictor_name": "textual-entailment"
+}

--- a/api/allennlp_demo/roberta_snli/test_api.py
+++ b/api/allennlp_demo/roberta_snli/test_api.py
@@ -1,0 +1,10 @@
+from allennlp_demo.common.testing import ModelEndpointTestCase
+from allennlp_demo.roberta_snli.api import RobertaSnliModelEndpoint
+
+
+class TestRobertaSnliModelEndpoint(ModelEndpointTestCase):
+    endpoint = RobertaSnliModelEndpoint()
+    predict_input = {
+        "hypothesis": "Two women are sitting on a blanket near some rocks talking about politics.",
+        "premise": "Two women are wandering along the shore drinking iced tea.",
+    }

--- a/api/allennlp_demo/semantic_role_labeling/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/semantic_role_labeling/.skiff/webapp.jsonnet
@@ -1,0 +1,17 @@
+/**
+ * This file defines the infrastructure we need to run the API endpoint on Kubernetes.
+ *
+ * For more information on the JSONNET language, see:
+ * https://jsonnet.org/learning/getting_started.html
+ */
+
+local common = import '../../common/.skiff/common.libsonnet';
+local model = import '../model.json';
+
+function(image, cause, sha, env, branch, repo, buildId)
+    // This tells Kubernetes what resources we need to run.
+    // For more information see:
+    // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+    local cpu = '50m';
+    local memory = '1Gi';
+    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)

--- a/api/allennlp_demo/semantic_role_labeling/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/semantic_role_labeling/.skiff/webapp.jsonnet
@@ -13,5 +13,5 @@ function(image, cause, sha, env, branch, repo, buildId)
     // For more information see:
     // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
     local cpu = '50m';
-    local memory = '1Gi';
+    local memory = '4Gi';
     common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)

--- a/api/allennlp_demo/semantic_role_labeling/api.py
+++ b/api/allennlp_demo/semantic_role_labeling/api.py
@@ -1,0 +1,16 @@
+import os
+
+from allennlp_models import syntax  # noqa: F401
+
+from allennlp_demo.common import config, http
+
+
+class SrlModelEndpoint(http.ModelEndpoint):
+    def __init__(self):
+        c = config.Model.from_file(os.path.join(os.path.dirname(__file__), "model.json"))
+        super().__init__(c)
+
+
+if __name__ == "__main__":
+    endpoint = SrlModelEndpoint()
+    endpoint.run()

--- a/api/allennlp_demo/semantic_role_labeling/model.json
+++ b/api/allennlp_demo/semantic_role_labeling/model.json
@@ -1,0 +1,5 @@
+{
+    "id": "semantic-role-labeling",
+    "archive_file": "https://storage.googleapis.com/allennlp-public-models/bert-base-srl-2020.03.24.tar.gz",
+    "predictor_name": "semantic-role-labeling"
+}

--- a/api/allennlp_demo/semantic_role_labeling/test_api.py
+++ b/api/allennlp_demo/semantic_role_labeling/test_api.py
@@ -1,0 +1,9 @@
+from allennlp_demo.common.testing import ModelEndpointTestCase
+from allennlp_demo.semantic_role_labeling.api import SrlModelEndpoint
+
+
+class TestSrlModelEndpoint(ModelEndpointTestCase):
+    endpoint = SrlModelEndpoint()
+    predict_input = {
+        "sentence": "Did Uriah honestly think he could beat the game in under three hours?"
+    }

--- a/api/allennlp_demo/wikitables_parser/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/wikitables_parser/.skiff/webapp.jsonnet
@@ -1,0 +1,17 @@
+/**
+ * This file defines the infrastructure we need to run the API endpoint on Kubernetes.
+ *
+ * For more information on the JSONNET language, see:
+ * https://jsonnet.org/learning/getting_started.html
+ */
+
+local common = import '../../common/.skiff/common.libsonnet';
+local model = import '../model.json';
+
+function(image, cause, sha, env, branch, repo, buildId)
+    // This tells Kubernetes what resources we need to run.
+    // For more information see:
+    // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+    local cpu = '50m';
+    local memory = '1Gi';
+    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)

--- a/api/allennlp_demo/wikitables_parser/Dockerfile
+++ b/api/allennlp_demo/wikitables_parser/Dockerfile
@@ -1,0 +1,17 @@
+FROM allennlp/commit:93024e53c1445cb4630ee5c07926abff8943715f
+
+WORKDIR /app/
+COPY allennlp_demo/wikitables_parser/requirements.txt allennlp_demo/wikitables_parser/requirements.txt
+ENV EXCLUDE_ALLENNLP_IN_SETUP true
+RUN pip install -r allennlp_demo/wikitables_parser/requirements.txt
+
+RUN spacy download en_core_web_sm
+
+COPY allennlp_demo/__init__.py allennlp_demo/__init__.py
+COPY allennlp_demo/common allennlp_demo/common
+COPY allennlp_demo/wikitables_parser allennlp_demo/wikitables_parser
+
+ENV PYTHONPATH /app/
+
+ENTRYPOINT [ "python" ]
+CMD [ "allennlp_demo/wikitables_parser/api.py" ]

--- a/api/allennlp_demo/wikitables_parser/api.py
+++ b/api/allennlp_demo/wikitables_parser/api.py
@@ -1,0 +1,15 @@
+import os
+
+from allennlp_demo.common import config, http
+from allennlp_semparse import predictors, models  # noqa: F401
+
+
+class WikitablesParserModelEndpoint(http.ModelEndpoint):
+    def __init__(self):
+        c = config.Model.from_file(os.path.join(os.path.dirname(__file__), "model.json"))
+        super().__init__(c)
+
+
+if __name__ == "__main__":
+    endpoint = WikitablesParserModelEndpoint()
+    endpoint.run()

--- a/api/allennlp_demo/wikitables_parser/model.json
+++ b/api/allennlp_demo/wikitables_parser/model.json
@@ -1,0 +1,5 @@
+{
+    "id": "wikitables-parser",
+    "archive_file": "https://storage.googleapis.com/allennlp-public-models/wikitables-model-2020.02.10.tar.gz",
+    "predictor_name": "wikitables-parser"
+}

--- a/api/allennlp_demo/wikitables_parser/requirements.txt
+++ b/api/allennlp_demo/wikitables_parser/requirements.txt
@@ -1,0 +1,14 @@
+git+https://github.com/allenai/allennlp-semparse.git@937d5945488a33c61d0047bd74d8106e60340bbd
+Flask==1.1.2
+pytest==5.4.1
+dateparser==0.7.4
+dataclasses==0.7.0
+parsimonious>=0.8.0
+# Used to format and postprocess SQL
+sqlparse>=0.2.4
+# Used to process tables in WikiTableQuestions
+unidecode
+# Used in KnowledgeGraphField
+editdistance
+# Used for the type system for some languages
+nltk

--- a/api/allennlp_demo/wikitables_parser/test_api.py
+++ b/api/allennlp_demo/wikitables_parser/test_api.py
@@ -1,0 +1,29 @@
+from allennlp_demo.wikitables_parser.api import WikitablesParserModelEndpoint
+from allennlp_demo.common.testing import ModelEndpointTestCase
+
+
+class TestWikitablesParserModelEndpoint(ModelEndpointTestCase):
+    endpoint = WikitablesParserModelEndpoint()
+    predict_input = {
+        "table": "\n".join(
+            [
+                "Season	Level	Division	Section	Position	Movements",
+                "1993	Tier 3	Division 2	Östra Svealand	1st	Promoted",
+                "1994	Tier 2	Division 1	Norra	11th	Relegation Playoffs",
+                "1995	Tier 2	Division 1	Norra	4th	",
+                "1996	Tier 2	Division 1	Norra	11th	Relegation Playoffs - Relegated",
+                "1997	Tier 3	Division 2	Östra Svealand	3rd	",
+                "1998	Tier 3	Division 2	Östra Svealand	7th	",
+                "1999	Tier 3	Division 2	Östra Svealand	3rd	",
+                "2000	Tier 3	Division 2	Östra Svealand	9th	",
+                "2001	Tier 3	Division 2	Östra Svealand	7th	",
+                "2002	Tier 3	Division 2	Östra Svealand	2nd	",
+                "2003	Tier 3	Division 2	Östra Svealand	3rd	",
+                "2004	Tier 3	Division 2	Östra Svealand	6th	",
+                "2005	Tier 3	Division 2	Östra Svealand	4th	Promoted",
+                "2006*	Tier 3	Division 1	Norra	5th	",
+                "2007	Tier 3	Division 1	Södra	14th	Relegated",
+            ]
+        ),
+        "question": "What is the only season with the 1st position?",
+    }

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -161,8 +161,8 @@ class SingleTaskDemo extends React.Component {
         .then((response) => {
           return response.json();
         }).then((json) => {
-          const { requestData } = json;
-          this.setState({requestData});
+          const { request_data } = json;
+          this.setState({ requestData: request_data });
         }).catch((error) => {
           // If a permalink doesn't resolve, we don't want to fail. Instead remove the slug from
           // the URL. This lets the user at least prepare a submission.

--- a/ui/src/components/ModelIntro.js
+++ b/ui/src/components/ModelIntro.js
@@ -19,7 +19,7 @@ class ModelIntro extends React.Component {
 
   render() {
 
-    const { title, description, descriptionEllipsed } = this.props;
+    const { title, description } = this.props;
 
     return (
       <div>


### PR DESCRIPTION
- atis parser
- wikitables parser
- nlvr parser
- semantic role labeling
- glove sentiment analysis
- named entity recognition
- next token lm
- open information extraction
- roberta snli
- roberta mnli **(this is broken, but is also broken in the old / currently deployed demo)**
- masked lm

I verified that all of these run and pass their tests locally, except for Roberta MultiNLI, which fails with vocab `KeyError` exception. It appears to be broken on the demo site as well.