### PR TITLE
Don't just format the exception, include the error too.

### DIFF
--- a/api/allennlp_demo/common/logs.py
+++ b/api/allennlp_demo/common/logs.py
@@ -3,6 +3,7 @@ import sys
 import json
 import logging
 import time
+from typing import Mapping
 
 from flask import Flask, request, Response, g
 from dataclasses import dataclass, asdict
@@ -32,7 +33,7 @@ class JsonLogFormatter(logging.Formatter):
             # In development we just return the exception with the default formatting, as this
             # is easiest for the end user.
             if os.getenv("FLASK_ENV") == "development":
-                return self.formatException(r.exc_info)
+                return super().format(r)
 
             # Otherwise we still output them as JSON
             m = r.getMessage() % r.__dict__
@@ -45,7 +46,7 @@ class JsonLogFormatter(logging.Formatter):
                     "stack": self.formatStack(r.stack_info),
                 }
             )
-        if not isinstance(r.msg, str):
+        if isinstance(r.msg, Mapping):
             return json.dumps({"logname": r.name, "severity": r.levelname, **r.msg})
         else:
             m = r.getMessage() % r.__dict__


### PR DESCRIPTION
This fixes a few small issues in the logging formatter we use in the new API endpoints:

- Output the message and exception when in development. The prior code was outputting the only exception. This specifically makes calls to `logger.exception()` easier to track down.
- Only try to use the spread operator on mappings, otherwise we'll get errors.