### PR TITLE
Add new permalinks fields to support the new serving mechanism.

### DIFF
--- a/api/allennlp_demo/permalinks/api.py
+++ b/api/allennlp_demo/permalinks/api.py
@@ -75,7 +75,7 @@ class PermaLinkService(Flask):
             if link is None:
                 raise NotFound(f"Permalink not found: {slug}")
 
-            return jsonify({"requestData": link.request_data})
+            return jsonify(link._asdict())
 
         @self.route("/", methods=["POST"])
         def create_permalink() -> Response:
@@ -86,19 +86,26 @@ class PermaLinkService(Flask):
             if self.db is None:
                 raise BadRequest("Permalinks are not enabled")
 
-            model_name = request.json.get("model_name")
-            if model_name is None:
-                raise BadRequest("You must provide a model name")
-
             request_data = request.json.get("request_data")
-            if request_data is None:
-                raise BadRequest("You must provide request data")
+            if not request_data:
+                raise BadRequest("Invalid request_data")
+
+            # Old models send this field. New models do not.
+            # TODO: Remove this once all models use the new serving mechanism.
+            model_name = request.json.get("model_name")
+
+            # New models send these fields, but old models do not.
+            # TODO: Once all models are served via the new mechanism these should be required.
+            model_id = request.json.get("model_id")
+            task_name = request.json.get("task_name")
 
             try:
                 id = self.db.insert_request(
                     requester=get_client_ip(request),
                     model_name=model_name,
                     request_data=request_data,
+                    model_id=model_id,
+                    task_name=task_name,
                 )
                 return jsonify(int_to_slug(id))
             except psycopg2.Error as err:

--- a/api/allennlp_demo/permalinks/models.py
+++ b/api/allennlp_demo/permalinks/models.py
@@ -3,7 +3,15 @@ import binascii
 import logging
 from typing import Optional, NamedTuple, Dict
 
-PermaLink = NamedTuple("PermaLink", [("model_name", str), ("request_data", Dict)])
+PermaLink = NamedTuple(
+    "PermaLink",
+    [
+        ("model_name", Optional[str]),
+        ("request_data", Dict),
+        ("model_id", Optional[str]),
+        ("task_name", Optional[str]),
+    ],
+)
 
 
 def int_to_slug(i: int) -> str:

--- a/api/allennlp_demo/permalinks/schema.sql
+++ b/api/allennlp_demo/permalinks/schema.sql
@@ -17,3 +17,8 @@ ALTER SEQUENCE queries_id_seq OWNED BY queries.id;
 ALTER TABLE ONLY queries ALTER COLUMN id SET DEFAULT nextval('queries_id_seq'::regclass);
 ALTER TABLE ONLY queries
     ADD CONSTRAINT queries_pkey PRIMARY KEY (id);
+
+-- Models served by the new mechanism provide these values, but old ones do not. We allow `NULL`
+-- for backwards compatibility.
+ALTER TABLE queries ADD COLUMN model_id TEXT,
+                    ADD COLUMN task_name TEXT;

--- a/api/allennlp_demo/permalinks/test_api.py
+++ b/api/allennlp_demo/permalinks/test_api.py
@@ -86,10 +86,11 @@ def test_new_create_permalink():
     assert get_resp.json["model_id"] == "bidaf"
     assert get_resp.json["task_name"] == "reading-comprehension"
 
+
 def test_create_permalink_no_request_data():
     db = InMemoryDemoDatabase()
     app = PermaLinkService("testpermalinks", db)
     client = app.test_client()
 
-    resp = client.post("/", json={ "model_id": "bidaf", "task_name": "reading-comprehension", })
+    resp = client.post("/", json={"model_id": "bidaf", "task_name": "reading-comprehension"})
     assert resp.status_code == 400

--- a/api/allennlp_demo/permalinks/test_api.py
+++ b/api/allennlp_demo/permalinks/test_api.py
@@ -85,3 +85,11 @@ def test_new_create_permalink():
     assert get_resp.json["model_name"] is None
     assert get_resp.json["model_id"] == "bidaf"
     assert get_resp.json["task_name"] == "reading-comprehension"
+
+def test_create_permalink_no_request_data():
+    db = InMemoryDemoDatabase()
+    app = PermaLinkService("testpermalinks", db)
+    client = app.test_client()
+
+    resp = client.post("/", json={ "model_id": "bidaf", "task_name": "reading-comprehension", })
+    assert resp.status_code == 400

--- a/api/allennlp_demo/permalinks/test_api.py
+++ b/api/allennlp_demo/permalinks/test_api.py
@@ -23,14 +23,15 @@ def test_get_permalink():
     assert resp.status_code == 404
 
     # Add something to the database and make sure it comes back
-    link_id = db.insert_request("1.1.1.1", "reading-comprehension", {"slug": "zilla"})
+    link_id = db.insert_request(
+        requester="1.1.1.1", model_name="reading-comprehension", request_data={"slug": "zilla"}
+    )
     resp = client.get(f"/{int_to_slug(link_id)}")
     assert resp.status_code == 200
-    assert resp.json["requestData"]["slug"] == "zilla"
-    assert len(resp.json.keys()) == 1
+    assert resp.json["request_data"]["slug"] == "zilla"
 
 
-def test_create_permalink():
+def test_old_create_permalink():
     db = InMemoryDemoDatabase()
     app = PermaLinkService("testpermalinks", db)
     client = app.test_client()
@@ -48,5 +49,34 @@ def test_create_permalink():
 
     get_resp = client.get(f"/{slug}")
     assert get_resp.status_code == 200
-    assert get_resp.json["requestData"]["passage"] == "The dog barked."
-    assert get_resp.json["requestData"]["question"] == "Did the dog bark?"
+    assert get_resp.json["request_data"]["passage"] == "The dog barked."
+    assert get_resp.json["request_data"]["question"] == "Did the dog bark?"
+    assert get_resp.json["model_name"] == "bidaf"
+    assert get_resp.json["model_id"] is None
+    assert get_resp.json["task_name"] is None
+
+
+def test_new_create_permalink():
+    db = InMemoryDemoDatabase()
+    app = PermaLinkService("testpermalinks", db)
+    client = app.test_client()
+
+    resp = client.post(
+        "/",
+        json={
+            "model_id": "bidaf",
+            "task_name": "reading-comprehension",
+            "request_data": {"passage": "The dog barked.", "question": "Did the dog bark?"},
+        },
+    )
+    assert resp.status_code == 200
+    slug = resp.json
+    assert len(slug) != 0
+
+    get_resp = client.get(f"/{slug}")
+    assert get_resp.status_code == 200
+    assert get_resp.json["request_data"]["passage"] == "The dog barked."
+    assert get_resp.json["request_data"]["question"] == "Did the dog bark?"
+    assert get_resp.json["model_name"] is None
+    assert get_resp.json["model_id"] == "bidaf"
+    assert get_resp.json["task_name"] == "reading-comprehension"

--- a/api/allennlp_demo/permalinks/test_api.py
+++ b/api/allennlp_demo/permalinks/test_api.py
@@ -39,8 +39,12 @@ def test_old_create_permalink():
     resp = client.post(
         "/",
         json={
-            "model_name": "bidaf",
-            "request_data": {"passage": "The dog barked.", "question": "Did the dog bark?"},
+            "model_name": "reading-comprehension",
+            "request_data": {
+                "model": "BiDAF",
+                "passage": "The dog barked.",
+                "question": "Did the dog bark?",
+            },
         },
     )
     assert resp.status_code == 200
@@ -49,9 +53,10 @@ def test_old_create_permalink():
 
     get_resp = client.get(f"/{slug}")
     assert get_resp.status_code == 200
+    assert get_resp.json["request_data"]["model"] == "BiDAF"
     assert get_resp.json["request_data"]["passage"] == "The dog barked."
     assert get_resp.json["request_data"]["question"] == "Did the dog bark?"
-    assert get_resp.json["model_name"] == "bidaf"
+    assert get_resp.json["model_name"] == "reading-comprehension"
     assert get_resp.json["model_id"] is None
     assert get_resp.json["task_name"] is None
 

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -161,8 +161,8 @@ class SingleTaskDemo extends React.Component {
         .then((response) => {
           return response.json();
         }).then((json) => {
-          const { requestData } = json;
-          this.setState({requestData});
+          const { request_data } = json;
+          this.setState({ requestData: request_data });
         }).catch((error) => {
           // If a permalink doesn't resolve, we don't want to fail. Instead remove the slug from
           // the URL. This lets the user at least prepare a submission.


### PR DESCRIPTION
This adds two new fields to the `queries` database table to support
permalinks for models served by the new mechanism. These fields
are `task_name` and `model_id`.  The `model_id` will tell the UI
which endpoint to invoke, while the `task_name` is purely to be used
by administrators to reverse engineer a full URL from the database. 
Right now that's possible by introspecting the `request_data`, but
this isn't terribly easy to do.

The new fields are optional for backwards compatibility. This way the
old models can continue creating permalinks as they did before, and 
we can transition new models to the new mechanism on a case by case
basis.

The new fields aren't yet used, but I added a test to make sure they
work. In the next PR I'll transition a the Reading Comprehension demo
to use the new endpoints and make use of this functionality.  Part of this
will involve migrating the old permalinks to the new format -- I haven't quite
thought through how to do that yet.

I'll need to execute the `ALTER TABLE` command that I added to `schema.sql`
manually as there's no mechanism for executing migrations. This will 
accordingly involve a small window of downtime (the site will still work, 
permalinks will just be broken which the UI and API handle gracefully).