### PR TITLE
Migrate the RC demo to use the new endpoint.

### DIFF
--- a/api/allennlp_demo/common/http.py
+++ b/api/allennlp_demo/common/http.py
@@ -115,9 +115,9 @@ class ModelEndpoint:
         to add or remove interpreters.
         """
         return {
-            "simple": SimpleGradient(self.predictor),
-            "smooth": SmoothGradient(self.predictor),
-            "integrated": IntegratedGradient(self.predictor),
+            "simple_gradient": SimpleGradient(self.predictor),
+            "smooth_gradient": SmoothGradient(self.predictor),
+            "integrated_gradient": IntegratedGradient(self.predictor),
         }
 
     def load_attackers(self) -> Mapping[str, Attacker]:
@@ -128,7 +128,7 @@ class ModelEndpoint:
         """
         hotflip = Hotflip(self.predictor)
         hotflip.initialize()
-        return {"hotflip": hotflip, "input-reduction": InputReduction(self.predictor)}
+        return {"hotflip": hotflip, "input_reduction": InputReduction(self.predictor)}
 
     def info(self) -> str:
         """

--- a/api/allennlp_demo/common/testing/rc.py
+++ b/api/allennlp_demo/common/testing/rc.py
@@ -34,10 +34,10 @@ class RcModelEndpointTestCase(ModelEndpointTestCase):
         assert len(result["best_span_str"].strip()) > 0
 
     def interpreter_ids(self) -> List[str]:
-        return ["simple", "smooth", "integrated"]
+        return ["simple_gradient", "smooth_gradient", "integrated_gradient"]
 
     def attacker_ids(self) -> List[str]:
-        return ["hotflip", "input-reduction"]
+        return ["hotflip", "input_reduction"]
 
     def test_interpret(self):
         for interpreter_id in self.interpreter_ids():

--- a/dev/local_models.conf
+++ b/dev/local_models.conf
@@ -28,7 +28,7 @@ server {
     # only support one model at a time (with this setup), so we strip the `/api/:model` prefix
     # before shipping the request to the endpoint. Production works in a similar fashion.
     location /api {
-        rewrite /api/(.+)(/(.*))? /$3 break;
+        rewrite /api/[^/]+(/(.*))? /$2 break;
         proxy_pass http://model:8000;
         proxy_set_header X-Forwarded-For $remote_addr;
     }

--- a/old/models.json
+++ b/old/models.json
@@ -1,27 +1,4 @@
 {
-    "reading-comprehension": {
-        "archive_file": "https://storage.googleapis.com/allennlp-public-models/bidaf-model-2020.03.19.tar.gz",
-        "predictor_name": "reading-comprehension",
-        "max_request_length": 311108
-    },
-    "elmo-reading-comprehension": {
-        "archive_file": "https://storage.googleapis.com/allennlp-public-models/bidaf-elmo-model-2020.03.19.tar.gz",
-        "predictor_name": "reading-comprehension",
-        "max_request_length": 311108
-    },
-    "naqanet-reading-comprehension": {
-        "archive_file": "https://storage.googleapis.com/allennlp-public-models/naqanet-2020.02.19.tar.gz",
-        "predictor_name": "reading-comprehension",
-        "max_request_length": 25819
-    },
-    "nmn-drop": {
-        "archive_file": "https://storage.googleapis.com/allennlp-public-models/drop-nmn-2020.04.04.tar.gz",
-        "predictor_name": "drop_demo_predictor",
-        "max_request_length": 25819,
-        "overrides": "{\"model\": {\"debug\":true, \"beam_size\":1}}",
-        "memory": "4Gi",
-        "image": "gcr.io/ai2-reviz/allennlp-demo-nmn-drop:34cfc7e1122c6ca4a8cd0d7f23cd2fb12c64a057"
-    },
     "semantic-role-labeling": {
         "archive_file": "https://storage.googleapis.com/allennlp-public-models/bert-base-srl-2020.03.24.tar.gz",
         "predictor_name": "semantic-role-labeling",

--- a/ui/src/components/demos/ReadingComprehension.js
+++ b/ui/src/components/demos/ReadingComprehension.js
@@ -9,7 +9,6 @@ import {
 } from 'react-accessible-accordion';
 import Model from '../Model'
 import OutputField from '../OutputField'
-import { API_ROOT } from '../../api-config';
 import { truncateText } from '../DemoInput'
 import { UsageSection } from '../UsageSection';
 import { UsageCode } from '../UsageCode';
@@ -40,31 +39,28 @@ const description = (
 
 const NMNModel = {
   name: "NMN (trained on DROP)",
-  desc: "A neural module network trained on DROP."
+  desc: "A neural module network trained on DROP.",
+  modelId: "nmn"
 };
 
 const taskModels = [
   {
     name: "ELMo-BiDAF (trained on SQuAD)",
-    desc: "Same as the BiDAF model except it uses ELMo embeddings instead of GloVe."
+    desc: "Same as the BiDAF model except it uses ELMo embeddings instead of GloVe.",
+    modelId: "bidaf-elmo"
   },
   {
     name: "BiDAF (trained on SQuAD)",
-    desc: "Reimplementation of BiDAF (Seo et al, 2017), or Bi-Directional Attention Flow,<br/>a widely used MC baseline that achieved state-of-the-art accuracies on<br/>the SQuAD dataset (Wikipedia sentences) in early 2017."
+    desc: "Reimplementation of BiDAF (Seo et al, 2017), or Bi-Directional Attention Flow,<br/>a widely used MC baseline that achieved state-of-the-art accuracies on<br/>the SQuAD dataset (Wikipedia sentences) in early 2017.",
+    modelId: "bidaf"
   },
   {
     name: "NAQANet (trained on DROP)",
-    desc: "An augmented version of QANet that adds rudimentary numerical reasoning ability,<br/>trained on DROP (Dua et al., 2019), as published in the original DROP paper."
+    desc: "An augmented version of QANet that adds rudimentary numerical reasoning ability,<br/>trained on DROP (Dua et al., 2019), as published in the original DROP paper.",
+    modelId: "naqanet"
   },
   NMNModel
 ]
-
-const taskEndpoints = {
-  "ELMo-BiDAF (trained on SQuAD)": "elmo-reading-comprehension",
-  "BiDAF (trained on SQuAD)": "reading-comprehension",
-  "NAQANet (trained on DROP)": "naqanet-reading-comprehension",
-  "NMN (trained on DROP)": "nmn-drop"
-};
 
 const fields = [
   {name: "passage", label: "Passage", type: "TEXT_AREA",
@@ -554,22 +550,21 @@ const examples = [
 ]
 
 
-const getUrl = (model, apiCall) => {
-    const selectedModel = model || (taskModels[0] && taskModels[0].name);
-    const endpoint = taskEndpoints[selectedModel]
-    return `${API_ROOT}/${apiCall}/${endpoint}`
+const getUrl = (model, ...paths) => {
+  const selectedModel = taskModels.find(t => t.name === model) || taskModels[0];
+  return `/${['api', selectedModel.modelId, ...paths ].join('/')}`;
 }
 
-const apiUrl = ({model}) => {
-    return getUrl(model, "predict")
+const apiUrl = ({ model }) => {
+  return getUrl(model, "predict")
 }
 
-const apiUrlInterpret = ({model}) => {
-    return getUrl(model, "interpret")
+const apiUrlInterpret = ({ model }, interpreter) => {
+  return getUrl(model, "interpret", interpreter)
 }
 
-const apiUrlAttack = ({model}) => {
-    return getUrl(model, "attack")
+const apiUrlAttack = ({ model }, attacker) => {
+  return getUrl(model, "attack", attacker)
 }
 
 const usage = (


### PR DESCRIPTION
This change modifies the RC demo to use the new endpoints. It should
be representative of the work we do demo-by-demo.

I redacted a few identifiers that I changed in the interest of
cleanliness to reduce the amount of work. I also fixed an issue
with routing in the local environment.

After this I plan on adding a local config that proxies all
API requests to production for working on the UI only. This
should make it easier to test changes that don't require working
on the API.