### PR TITLE
update build timeout

### DIFF
--- a/api/allennlp_demo/common/.skiff/cloudbuild-deploy.yaml
+++ b/api/allennlp_demo/common/.skiff/cloudbuild-deploy.yaml
@@ -58,4 +58,4 @@ artifacts:
     location: gs://skiff-archive/$REPO_NAME/$_SUBMODULE_PATH/$_ENV/$BUILD_ID/$COMMIT_SHA
     paths:
     -  api/allennlp_demo/$_SUBMODULE_PATH/.skiff/webapp.yaml
-timeout: 900s
+timeout: 1200s


### PR DESCRIPTION
I think it's fairly rare for a cloud build to last longer than 15 minutes, but one did on the last master commit. So this just ups the timeout to 20 minutes to be safe.