### PR TITLE
Add the info service.

### DIFF
--- a/api/allennlp_demo/info/.skiff/role.json
+++ b/api/allennlp_demo/info/.skiff/role.json
@@ -1,0 +1,41 @@
+---
+{
+    "apiVersion": "rbac.authorization.k8s.io/v1",
+    "kind": "ClusterRole",
+    "metadata": {
+        "name": "allennlp-demo-api-info"
+    },
+    "rules": [
+        {
+            "apiGroups": [ "" ],
+            "resources": [ "namespaces" ],
+            "verbs": [ "get", "list" ]
+        },
+        {
+            "apiGroups": [ "extensions" ],
+            "resources": [ "ingresses" ],
+            "verbs": [ "list" ]
+        }
+    ]
+}
+---
+{
+    "apiVersion": "rbac.authorization.k8s.io/v1",
+    "kind": "ClusterRoleBinding",
+    "metadata": {
+        "name": "allennlp-demo-api-info"
+    },
+    "subjects": [
+        {
+            "kind": "ServiceAccount",
+            "name": "default",
+            "namespace": "allennlp-demo-api-info"
+        }
+    ],
+    "roleRef": {
+        "kind": "ClusterRole",
+        "name": "allennlp-demo-api-info",
+        "apiGroup": "rbac.authorization.k8s.io"
+    }
+}
+...

--- a/api/allennlp_demo/info/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/info/.skiff/webapp.jsonnet
@@ -1,0 +1,18 @@
+/**
+ * This file defines the infrastructure we need to run the API endpoint on Kubernetes.
+ *
+ * For more information on the JSONNET language, see:
+ * https://jsonnet.org/learning/getting_started.html
+ */
+
+local common = import '../../common/.skiff/common.libsonnet';
+
+function(image, cause, sha, env, branch, repo, buildId)
+    // This tells Kubernetes what resources we need to run.
+    // For more information see:
+    // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+    local cpu = '50m';
+    local memory = '200Mi';
+    local startupTime = 30;
+    common.APIEndpoint('info', image, cause, sha, cpu, memory, env, branch, repo, buildId,
+                       startupTime)

--- a/api/allennlp_demo/info/Dockerfile
+++ b/api/allennlp_demo/info/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.7
+
+WORKDIR /app/
+
+COPY allennlp_demo/info/requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
+COPY allennlp_demo/__init__.py allennlp_demo/__init__.py
+COPY allennlp_demo/common allennlp_demo/common
+COPY allennlp_demo/info allennlp_demo/info
+
+# Ensure allennlp_demo module can be found by Python.
+ENV PYTHONPATH /app/
+
+# Ensure log messages written immediately instead of being buffered, which is
+# useful if the app crashes so the logs won't get swallowed.
+ENV PYTHONUNBUFFERED 1
+
+ENTRYPOINT [ "python" ]
+CMD [ "allennlp_demo/info/prod_api.py" ]

--- a/api/allennlp_demo/info/README.md
+++ b/api/allennlp_demo/info/README.md
@@ -1,0 +1,19 @@
+# Info Service
+
+This service lists all endpoints on the cluster and some information about them.
+
+## Running this Locally
+
+To run this locally you'll need to install `kubectl` and the
+[Google Cloud SDK](https://cloud.google.com/sdk).
+
+After both are installed you'll need to authenticate your local `kubectl` client against the
+Skiff cluster. To do so ask someone from [reviz@allenai.org](mailto:reviz@allenai.org).
+
+## One Time Setup
+
+To run the service on a Kubernetes cluster, have an administrator run this command once:
+
+```bash
+kubectl create -f .skiff/role.json
+```

--- a/api/allennlp_demo/info/api.py
+++ b/api/allennlp_demo/info/api.py
@@ -1,0 +1,83 @@
+"""
+The info service is an endpoint that lists all API endpoints and some additional information
+about each. It's purely for discovery, and intended for use primarily by administrators (but is
+ok to be public.
+"""
+from typing import Optional, Mapping, Any
+from dataclasses import dataclass
+
+import flask
+import kubernetes
+import requests
+import logging
+
+from allennlp_demo.common.logs import configure_logging
+
+
+@dataclass(frozen=True)
+class Endpoint:
+    """
+    An individual API endpoint.
+    """
+
+    id: str
+    url: str
+    info: Optional[Mapping[str, Any]]
+
+    @staticmethod
+    def from_ingress(ingress: kubernetes.client.ExtensionsV1beta1Ingress) -> Optional["Endpoint"]:
+        logger = logging.getLogger(__name__)
+
+        id = ingress.metadata.labels.get("endpoint")
+        if id is None:
+            return None
+
+        # We expect an ingres with a single rule that has a single path. If the ingress doesn't
+        # match that expectation log an error and return nothing.
+        num_rules = len(ingress.spec.rules)
+        if num_rules != 1:
+            logger.exception(f"Unexpected Ingress with {num_rules} rules")
+            return None
+        rule = ingress.spec.rules[0]
+
+        paths = rule.http.paths
+        num_paths = len(paths)
+        if num_paths != 1:
+            logger.exception(f"Unexpected Ingress with {num_paths} paths")
+            return None
+        # The path includes a regular expression that we remove.
+        path = paths[0].path.rstrip("(/.*))?$")
+        url = f"https://{rule.host}{path}"
+
+        # The root of each endpoint should include some additional information.
+        # NOTE: Python is quite slow at this, since this is an I/O bound action. In theory
+        # gevent should resolve that, but in practice it doesn't seem to. We could consider
+        # using a Thread here, or just rewrite this in language that's better suited for the task.
+        resp = requests.get(url)
+        if not resp.ok:
+            return Endpoint(id, url, None)
+
+        return Endpoint(id, url, resp.json())
+
+
+class InfoService(flask.Flask):
+    def __init__(self, name: str = "info"):
+        super().__init__(name)
+        configure_logging(self)
+
+        @self.route("/", methods=["GET"])
+        def info():
+            client = kubernetes.client.ExtensionsV1beta1Api()
+            resp = client.list_ingress_for_all_namespaces(label_selector="app=allennlp-demo")
+            endpoints = []
+            for ingress in resp.items:
+                endpoint = Endpoint.from_ingress(ingress)
+                if endpoint is not None:
+                    endpoints.append(endpoint)
+            return flask.jsonify(endpoints)
+
+
+if __name__ == "__main__":
+    kubernetes.config.load_kube_config()
+    app = InfoService()
+    app.run(host="0.0.0.0", port=8000)

--- a/api/allennlp_demo/info/prod_api.py
+++ b/api/allennlp_demo/info/prod_api.py
@@ -1,0 +1,29 @@
+"""
+Production entry point that launches the gevent WSGI server in place of Flask's
+default one.
+
+The workload for this service is entirely I/O bound, so should improve the
+service's ability to handle more concurrent connections without using a
+multi-process WSGI server like `gunicorn`.
+"""
+from gevent import monkey, pywsgi
+
+# This ensures third party libs use the non-blocking socket, so that we actually
+# benefit from using `gevent`. They recommend that it be one of the first
+# lines executed in your program, which is why we import it and immediately
+# execute the command.
+#
+# See: http://www.gevent.org/intro.html#monkey-patching
+monkey.patch_all()
+
+import kubernetes  # noqa: E402
+
+from allennlp_demo.info.api import InfoService  # noqa: E402
+
+if __name__ == "__main__":
+    kubernetes.config.load_incluster_config()
+    app = InfoService()
+    # Note, we set `log=None` to disable the `gevent` request log in favor
+    # of ours which includes the info we want.
+    server = pywsgi.WSGIServer(("0.0.0.0", 8000), app, log=None, error_log=app.logger)
+    server.serve_forever()

--- a/api/allennlp_demo/info/prod_api.py
+++ b/api/allennlp_demo/info/prod_api.py
@@ -6,19 +6,11 @@ The workload for this service is entirely I/O bound, so should improve the
 service's ability to handle more concurrent connections without using a
 multi-process WSGI server like `gunicorn`.
 """
-from gevent import monkey, pywsgi
+from gevent import pywsgi
+import kubernetes
 
-# This ensures third party libs use the non-blocking socket, so that we actually
-# benefit from using `gevent`. They recommend that it be one of the first
-# lines executed in your program, which is why we import it and immediately
-# execute the command.
-#
-# See: http://www.gevent.org/intro.html#monkey-patching
-monkey.patch_all()
+from allennlp_demo.info.api import InfoService
 
-import kubernetes  # noqa: E402
-
-from allennlp_demo.info.api import InfoService  # noqa: E402
 
 if __name__ == "__main__":
     kubernetes.config.load_incluster_config()

--- a/api/allennlp_demo/info/requirements.txt
+++ b/api/allennlp_demo/info/requirements.txt
@@ -1,0 +1,5 @@
+Flask==1.1.2
+pytest==5.4.1
+gevent==20.5.0
+kubernetes==11.0.0
+requests==2.23.0

--- a/api/allennlp_demo/info/requirements.txt
+++ b/api/allennlp_demo/info/requirements.txt
@@ -3,3 +3,5 @@ pytest==5.4.1
 gevent==20.5.0
 kubernetes==11.0.0
 requests==2.23.0
+grequests==0.6.0
+Flask-Caching==1.8.0


### PR DESCRIPTION
This adds a simple service that lists all endpoints and some
information we know about each.

The endpoint is a little slow, it takes about 3 or 4 seconds to
collect all of the information. I imagine this is because of the
blocking requests we make to each endpoint. We could either
accept the latency or use concurrency to make it faster. I imagine
making the requests concurrently would greatly speed things up
since they're all I/O bound.

Here's what the output looks like:

```
  {
    "id": "semantic-role-labeling",
    "info": {
      "allennlp": "1.0.0rc3",
      "archive_file": "https://storage.googleapis.com/allennlp-public-models/bert-base-srl-2020.03.24.tar.gz",
      "id": "semantic-role-labeling",
      "overrides": null,
      "predictor_name": "semantic-role-labeling"
    },
    "url": "https://demo.allennlp.org/api/semantic-role-labeling"
  },
  {
    "id": "wikitables-parser",
    "info": {
      "allennlp": "0.9.1-unreleased",
      "archive_file": "https://storage.googleapis.com/allennlp-public-models/wikitables-model-2020.02.10.tar.gz",
      "id": "wikitables-parser",
      "overrides": null,
      "predictor_name": "wikitables-parser"
    },
    "url": "https://demo.allennlp.org/api/wikitables-parser"
  }
```

This can provide some nifty things, like:

```
[I] ~/h/a/api ❯❯❯ curl -s http://localhost:8000 | jq -r '.[].info.allennlp' | sort | uniq
0.9.0-unreleased
0.9.1-unreleased
1.0.0rc3
null
```

The `null` is from the permalinks service. It'd be easy to filter out with a `grep -v`, or something.

If this looks good I'll need to create a trigger after deploying and get this out the door.