### PR TITLE
make endpoint info requests concurrently

### DIFF
--- a/api/allennlp_demo/info/api.py
+++ b/api/allennlp_demo/info/api.py
@@ -3,18 +3,29 @@ The info service is an endpoint that lists all API endpoints and some additional
 about each. It's purely for discovery, and intended for use primarily by administrators (but is
 ok to be public.
 """
-from typing import Optional, Mapping, Any
-from dataclasses import dataclass
 
-import flask
-import kubernetes
-import requests
-import logging
+# This needs to be imported first, since it calls gevent.monkey.patch_all(),
+# which ensures third party libs (like requests) use the non-blocking socket, so that we actually
+# benefit from using `gevent`. They recommend that it be one of the first
+# lines executed in your program, which is why we import it first.
+#
+# See: http://www.gevent.org/intro.html#monkey-patching
+import grequests
 
-from allennlp_demo.common.logs import configure_logging
+from dataclasses import dataclass  # noqa: E402
+import logging  # noqa: E402
+from typing import Optional, Mapping, Any, List  # noqa: E402
+
+import flask  # noqa: E402
+import kubernetes  # noqa: E402
+
+from allennlp_demo.common.logs import configure_logging  # noqa: E402
 
 
-@dataclass(frozen=True)
+logger = logging.getLogger(__name__)
+
+
+@dataclass
 class Endpoint:
     """
     An individual API endpoint.
@@ -26,8 +37,6 @@ class Endpoint:
 
     @staticmethod
     def from_ingress(ingress: kubernetes.client.ExtensionsV1beta1Ingress) -> Optional["Endpoint"]:
-        logger = logging.getLogger(__name__)
-
         id = ingress.metadata.labels.get("endpoint")
         if id is None:
             return None
@@ -49,15 +58,7 @@ class Endpoint:
         path = paths[0].path.rstrip("(/.*))?$")
         url = f"https://{rule.host}{path}"
 
-        # The root of each endpoint should include some additional information.
-        # NOTE: Python is quite slow at this, since this is an I/O bound action. In theory
-        # gevent should resolve that, but in practice it doesn't seem to. We could consider
-        # using a Thread here, or just rewrite this in language that's better suited for the task.
-        resp = requests.get(url)
-        if not resp.ok:
-            return Endpoint(id, url, None)
-
-        return Endpoint(id, url, resp.json())
+        return Endpoint(id, url, None)
 
 
 class InfoService(flask.Flask):
@@ -69,11 +70,19 @@ class InfoService(flask.Flask):
         def info():
             client = kubernetes.client.ExtensionsV1beta1Api()
             resp = client.list_ingress_for_all_namespaces(label_selector="app=allennlp-demo")
-            endpoints = []
+            # Gather endpoints.
+            endpoints: List[Endpoint] = []
+            info_requests: List[grequests.AsyncRequest] = []
             for ingress in resp.items:
                 endpoint = Endpoint.from_ingress(ingress)
                 if endpoint is not None:
                     endpoints.append(endpoint)
+                    info_requests.append(grequests.get(endpoint.url))
+            # Now concurrently get the info for each endpoint.
+            for endpoint, info_resp in zip(endpoints, grequests.map(info_requests)):
+                if not info_resp.ok:
+                    continue
+                endpoint.info = info_resp.json()
             return flask.jsonify(endpoints)
 
 

--- a/api/allennlp_demo/info/api.py
+++ b/api/allennlp_demo/info/api.py
@@ -75,6 +75,11 @@ class InfoService(flask.Flask):
         cache = Cache(config={"CACHE_TYPE": "simple"})
         cache.init_app(self)
 
+        # We'll re-use a single HTTP Session to make all of the info requests to our
+        # our model endpoints.
+        # We set `pool_maxsize` to 100 so that the pool can handle all of the model
+        # requests concurrently, potentially from several different incoming requests
+        # at once.
         self.session = Session()
         adapter = adapters.HTTPAdapter(pool_maxsize=100)
         self.session.mount("https://", adapter)

--- a/api/allennlp_demo/info/prod_api.py
+++ b/api/allennlp_demo/info/prod_api.py
@@ -6,19 +6,11 @@ The workload for this service is entirely I/O bound, so should improve the
 service's ability to handle more concurrent connections without using a
 multi-process WSGI server like `gunicorn`.
 """
-from gevent import monkey, pywsgi
+from gevent import pywsgi
+import kubernetes
 
-# This ensures third party libs use the non-blocking socket, so that we actually
-# benefit from using `gevent`. They recommend that it be one of the first
-# lines executed in your program, which is why we import it and immediately
-# execute the command.
-#
-# See: http://www.gevent.org/intro.html#monkey-patching
-monkey.patch_all()
+from allennlp_demo.info.api import InfoService
 
-import kubernetes  # noqa: E402
-
-from allennlp_demo.info.api import InfoService  # noqa: E402
 
 if __name__ == "__main__":
     kubernetes.config.load_incluster_config()

--- a/api/allennlp_demo/info/requirements.txt
+++ b/api/allennlp_demo/info/requirements.txt
@@ -4,3 +4,4 @@ gevent==20.5.0
 kubernetes==11.0.0
 requests==2.23.0
 grequests==0.6.0
+Flask-Caching==1.8.0

--- a/api/allennlp_demo/info/requirements.txt
+++ b/api/allennlp_demo/info/requirements.txt
@@ -3,3 +3,4 @@ pytest==5.4.1
 gevent==20.5.0
 kubernetes==11.0.0
 requests==2.23.0
+grequests==0.6.0


### PR DESCRIPTION
This does a couple things.

1. It uses a helper module `grequests` to do the endpoint info requests concurrently.
2. It uses a single `requests.Session` for all of the HTTP requests to reduce overhead.

On my computer this reduces the time to serve a single request from ~1.6 seconds to ~150 milliseconds.