### PR TITLE
Reading Comprehension NMN fix

### DIFF
--- a/ui/src/components/demos/ReadingComprehension.js
+++ b/ui/src/components/demos/ReadingComprehension.js
@@ -395,7 +395,7 @@ const AnswerByType = ({ responseData, requestData, interpretData, interpretModel
       }
 
       default: { // old best_span_str path used by BiDAF model
-          const { best_span_str: bestSpanStr } = responseData;
+        const { best_span_str: bestSpanStr } = responseData;
         if(question && passage && bestSpanStr) {
           const start = passage.indexOf(bestSpanStr);
           const head = passage.slice(0, start);
@@ -434,15 +434,15 @@ const Output = (props) => {
     case NMNModel.name:
     case NMNModel.modelId:
       return (
-          <div className="model__content answer">
-            <nmn.Output response={props.responseData}/>
-          </div>
+        <div className="model__content answer">
+          <nmn.Output response={props.responseData}/>
+        </div>
       );
     default:
       return (
-          <div className="model__content answer">
-            <AnswerByType {...props} />
-          </div>
+        <div className="model__content answer">
+          <AnswerByType {...props} />
+        </div>
       )
   }
 }

--- a/ui/src/components/demos/ReadingComprehension.js
+++ b/ui/src/components/demos/ReadingComprehension.js
@@ -394,8 +394,8 @@ const AnswerByType = ({ responseData, requestData, interpretData, interpretModel
         return NoAnswer();
       }
 
-      default: {
-        const { predicted_ans: bestSpanStr } = responseData;
+      default: { // old best_span_str path used by BiDAF model
+          const { best_span_str: bestSpanStr } = responseData;
         if(question && passage && bestSpanStr) {
           const start = passage.indexOf(bestSpanStr);
           const head = passage.slice(0, start);

--- a/ui/src/components/demos/ReadingComprehension.js
+++ b/ui/src/components/demos/ReadingComprehension.js
@@ -394,8 +394,8 @@ const AnswerByType = ({ responseData, requestData, interpretData, interpretModel
         return NoAnswer();
       }
 
-      default: { // old best_span_str path used by BiDAF model
-        const { best_span_str: bestSpanStr } = responseData;
+      default: {
+        const { predicted_ans: bestSpanStr } = responseData;
         if(question && passage && bestSpanStr) {
           const start = passage.indexOf(bestSpanStr);
           const head = passage.slice(0, start);

--- a/ui/src/components/demos/ReadingComprehension.js
+++ b/ui/src/components/demos/ReadingComprehension.js
@@ -435,7 +435,7 @@ const Output = (props) => {
     case NMNModel.modelId:
       return (
         <div className="model__content answer">
-          <nmn.Output response={props.responseData}/>
+          <nmn.Output response={props.responseData} />
         </div>
       );
     default:

--- a/ui/src/components/demos/ReadingComprehension.js
+++ b/ui/src/components/demos/ReadingComprehension.js
@@ -430,19 +430,21 @@ const AnswerByType = ({ responseData, requestData, interpretData, interpretModel
 }
 
 const Output = (props) => {
-    if (props.requestData.model && (props.requestData.model === NMNModel.name || props.requestData.model === "nmn")) {
-        return (
-            <div className="model__content answer">
-                <nmn.Output response={props.responseData}/>
-            </div>
-        );
+    switch (props.requestData.model) {
+        case NMNModel.name:
+        case NMNModel.modelId:
+            return (
+                <div className="model__content answer">
+                    <nmn.Output response={props.responseData}/>
+                </div>
+            );
+        default:
+            return (
+                <div className="model__content answer">
+                    <AnswerByType {...props} />
+                </div>
+            )
     }
-
-    return (
-        <div className="model__content answer">
-            <AnswerByType {...props} />
-        </div>
-    )
 }
 
 const addSnippet = (example) => {

--- a/ui/src/components/demos/ReadingComprehension.js
+++ b/ui/src/components/demos/ReadingComprehension.js
@@ -430,21 +430,21 @@ const AnswerByType = ({ responseData, requestData, interpretData, interpretModel
 }
 
 const Output = (props) => {
-    switch (props.requestData.model) {
-        case NMNModel.name:
-        case NMNModel.modelId:
-            return (
-                <div className="model__content answer">
-                    <nmn.Output response={props.responseData}/>
-                </div>
-            );
-        default:
-            return (
-                <div className="model__content answer">
-                    <AnswerByType {...props} />
-                </div>
-            )
-    }
+  switch (props.requestData.model) {
+    case NMNModel.name:
+    case NMNModel.modelId:
+      return (
+          <div className="model__content answer">
+            <nmn.Output response={props.responseData}/>
+          </div>
+      );
+    default:
+      return (
+          <div className="model__content answer">
+            <AnswerByType {...props} />
+          </div>
+      )
+  }
 }
 
 const addSnippet = (example) => {

--- a/ui/src/components/demos/ReadingComprehension.js
+++ b/ui/src/components/demos/ReadingComprehension.js
@@ -430,21 +430,19 @@ const AnswerByType = ({ responseData, requestData, interpretData, interpretModel
 }
 
 const Output = (props) => {
-  switch (props.requestData.model) {
-    case NMNModel.name: {
-      return (
-        <div className="model__content answer">
-          <nmn.Output response={props.responseData} />
-        </div>
-      );
+    if (props.requestData.model && (props.requestData.model === NMNModel.name || props.requestData.model === "nmn")) {
+        return (
+            <div className="model__content answer">
+                <nmn.Output response={props.responseData}/>
+            </div>
+        );
     }
-    default:
-      return (
+
+    return (
         <div className="model__content answer">
-          <AnswerByType {...props} />
+            <AnswerByType {...props} />
         </div>
-      )
-  }
+    )
 }
 
 const addSnippet = (example) => {


### PR DESCRIPTION
This fixes https://github.com/allenai/allennlp-demo/issues/483.

I can repro by going to /reading-comprehension, choosing the model NMN and the example "Who stars in The Matrix?". The server responds with an answer, but "No answer returned" is shown.

Looks like the "No answer returned." is shown due to the `NoAnswer()` call at the bottom of the default case in `AnswerByType`:

https://github.com/allenai/allennlp-demo/blob/ae62fc3774bf98488745267e8e8aa3ccd29c34f0/ui/src/components/demos/ReadingComprehension.js#L397-L426

In this default case, `responseData` is destructed to extract the field `best_span_str`, which doesn't exist in the response to this example. The response does, however, have a `predicted_ans` field. Here's what `responseData` looks like in this default case:

> <img width="394" alt="image" src="https://user-images.githubusercontent.com/19393950/84532049-6a80fa00-ac9a-11ea-9e4b-b85932a54b34.png">

When I use `predicted_ans` instead of `best_span_str` then the NMN model works for this example:

> <img width="960" alt="image" src="https://user-images.githubusercontent.com/19393950/84532266-c8addd00-ac9a-11ea-90f0-136bbca3cd73.png">

I don't know of this is the right fix; looking for advice from someone closer to the systems involved.