### PR TITLE
make hotflip ui work for naqanet in rc

### DIFF
--- a/ui/src/components/demos/ReadingComprehension.js
+++ b/ui/src/components/demos/ReadingComprehension.js
@@ -239,7 +239,7 @@ const Attacks = ({attackData, attackModel, requestData}) => {
   // NAQANet needs some fixing in allennlp.attackers.utils.get_fields_to_compare in order to work,
   // so we're disabling it for now (see TODO in that function).
   const inputReduction = model && model.toLowerCase().includes('naqanet') ?
-    " "
+    null
   : (
     <InputReductionPanel>
       <InputReductionComponent reducedInput={reducedInput} reduceFunction={attackModel(requestData, INPUT_REDUCTION_ATTACKER, NAME_OF_INPUT_TO_ATTACK, NAME_OF_GRAD_INPUT)} />


### PR DESCRIPTION
Fixes https://github.com/allenai/allennlp-demo/issues/482

The value `" "` for inputReduction was causing problems; by setting it to null, JSX will not treat it as a node and the `Collapse` component won't receive a string as the first child.

After this change, I see a HotFlip Attack pannel when I select and run the NAQANet model in Reading Comprehension:

> <img width="789" alt="image" src="https://user-images.githubusercontent.com/19393950/84549118-0ff89580-acbc-11ea-8a95-a4e85e0f4281.png">

