### PR TITLE
Add Skiff Stats.

### DIFF
--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -115,5 +115,6 @@
         <path d="M30.2,13.7c0.1,0.3,0.1,0.5,0.2,0.8c0,0.1,0,0.1,0.1,0.2c1.2-0.7,2.4-1.3,3.7-1.9c0-0.1,0-0.1,0.1-0.2 c0-0.1,0-0.1,0.1-0.2H30C30,12.8,30.1,13.3,30.2,13.7z" class="st0"></path>
       </symbol>
     </svg>
+    <script src="https://stats.allenai.org/init.min.js" data-app-name="allennlp-demo" async></script>
   </body>
 </html>


### PR DESCRIPTION
This adds support for user metrics provided by Skiff stats.

If this ends up providing the metrics your group needs we can at some point turn off Google Analytics. For now I've left them in place, but let me know if no one is using that (in which case I'd propose we remove them, as it's better for our user's privacy and will make the page a little faster).