### PR TITLE
Re-use the root certificate.

### DIFF
--- a/api/allennlp_demo/common/.skiff/common.libsonnet
+++ b/api/allennlp_demo/common/.skiff/common.libsonnet
@@ -240,7 +240,6 @@ local db = import 'db.libsonnet';
                 namespace: namespace.metadata.name,
                 labels: labels,
                 annotations: annotations + {
-                    'cert-manager.io/cluster-issuer': 'letsencrypt-prod',
                     'kubernetes.io/ingress.class': 'nginx',
                     'nginx.ingress.kubernetes.io/ssl-redirect': 'true',
                     'nginx.ingress.kubernetes.io/proxy-body-size': '0.5m',
@@ -251,8 +250,9 @@ local db = import 'db.libsonnet';
             },
             spec: {
                 tls: [
+                    // We explicitly omit secretName here, which is optional, so that the root
+                    // certificate that's managed by the UI is used instead.
                     {
-                        secretName: fullyQualifiedName,
                         hosts: hosts
                     }
                 ],


### PR DESCRIPTION
Prior to this change every endpoint got it's own certificate.
This revises things so that the certificate will be resolved using
the hostname of the request -- which will map to the certificate that's
issued by the UI. This way we're less likely to trigger LetsEncrypt's
rate limits.

This fixes https://github.com/allenai/skiff/issues/843.