### PR TITLE
Use a larger image for building.

### DIFF
--- a/api/allennlp_demo/common/.skiff/cloudbuild-deploy.yaml
+++ b/api/allennlp_demo/common/.skiff/cloudbuild-deploy.yaml
@@ -52,3 +52,4 @@ artifacts:
     paths:
     -  api/allennlp_demo/$_SUBMODULE_PATH/.skiff/webapp.yaml
 timeout: 1200s
+machineType: 'N1_HIGHCPU_8'


### PR DESCRIPTION
Since the Vilbert VQA model won't build with only 2 GB of RAM.