### PR TITLE
parametrize body size, use large body size for permalinks

### DIFF
--- a/api/allennlp_demo/common/.skiff/common.libsonnet
+++ b/api/allennlp_demo/common/.skiff/common.libsonnet
@@ -28,11 +28,17 @@ local db = import 'db.libsonnet';
      * @param startupTime   {number}    The amount of time in seconds the container should take to
      *                                  start. If this is set too low your container will get into
      *                                  a restart loop when it's started. Defaults to 120 seconds.
-     * @param useDb          {boolean}  If true the required resources will provision to provide
+     * @param useDb         {boolean}   If true the required resources will provision to provide
      *                                  a secure connection to the database. The required secrets
      *                                  must be manually provisioned by system administrator.
+     * @param maxBodySize   {string}    Maximum size of allowed HTTP body payload. For example,
+     *                                  '10M'. See NGINX docs for syntax:
+     *                                      Sizes can be specified in bytes, kilobytes (suffixes k
+     *                                      and K) or megabytes (suffixes m and M), for example,
+     *                                      "1024”, "8k”, "1m”.
+     *                                  NGINX docs: http://nginx.org/en/docs/syntax.html
      */
-    APIEndpoint(id, image, cause, sha, cpu, memory, env, branch, repo, buildId, startupTime=120, useDb=false):
+    APIEndpoint(id, image, cause, sha, cpu, memory, env, branch, repo, buildId, startupTime=120, useDb=false, maxBodySize = '0.5m'):
         // Different environments are deployed to the same namespace. This serves to prevent
         // collissions.
         local fullyQualifiedName = config.appName + '-api-' + id + '-' + env;
@@ -242,7 +248,7 @@ local db = import 'db.libsonnet';
                 annotations: annotations + {
                     'kubernetes.io/ingress.class': 'nginx',
                     'nginx.ingress.kubernetes.io/ssl-redirect': 'true',
-                    'nginx.ingress.kubernetes.io/proxy-body-size': '0.5m',
+                    'nginx.ingress.kubernetes.io/proxy-body-size': maxBodySize,
                     // We trim the prefix before sending requests to the container, so a request for
                     // /api/$path_prefix/foo becomes /foo.
                     'nginx.ingress.kubernetes.io/rewrite-target': '/$2'

--- a/api/allennlp_demo/vilbert_vqa/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/vilbert_vqa/.skiff/webapp.jsonnet
@@ -14,4 +14,4 @@ function(image, cause, sha, env, branch, repo, buildId)
     // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
     local cpu = '50m';
     local memory = '2Gi';
-    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)
+    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId, '5m')


### PR DESCRIPTION
Large images are rejected (with HTTP 413 - "Payload Too Large") when when uploading them on the form at https://demo.allennlp.org/visual-question-answering. The rejection is happening on a POST to https://demo.allennlp.org/api/permalink/noop which is the permalink service

So this change makes that service accept uploads of 5MB (5242880 bytes).

I set this value manually on the ingress and confirmed that a 5,214,629 byte file is accepted, but a 5,315,752 file is rejected.

(This partially addresses https://github.com/allenai/allennlp-demo/issues/548)