### PR TITLE
use large body size for permalinks

### DIFF
--- a/api/allennlp_demo/permalinks/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/permalinks/.skiff/webapp.jsonnet
@@ -16,4 +16,4 @@ function(image, cause, sha, env, branch, repo, buildId)
     local startupTime = 30;
     local useDb = true;
     common.APIEndpoint('permalink', image, cause, sha, cpu, memory, env, branch, repo, buildId,
-                       startupTime, useDb)
+                       startupTime, useDb, '5m')

--- a/api/allennlp_demo/vilbert_vqa/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/vilbert_vqa/.skiff/webapp.jsonnet
@@ -14,4 +14,4 @@ function(image, cause, sha, env, branch, repo, buildId)
     // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
     local cpu = '50m';
     local memory = '2Gi';
-    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId, '5m')
+    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)


### PR DESCRIPTION
In https://github.com/allenai/allennlp-demo/pull/569/files I intended to change the accepted body size of the permalinks service, but actually changed it for vilbert_vqa (which I originally thought was where I'd need to do it).

This PR undoes that unintended change and correctly increases the accepted body size of the permalinks service.

Partially fixes https://github.com/allenai/allennlp-demo/issues/548