### PR TITLE
show nice error when image is too large

### DIFF
--- a/ui/src/components/ImageParamControl.jsx
+++ b/ui/src/components/ImageParamControl.jsx
@@ -90,7 +90,19 @@ export const ImageParamControl = (props) => {
                 );
             }
         } else if (info.file.status === 'error') {
-            message.error(`${info.file.name} file upload failed: ${info.file.error.message}`);
+            // If the image is too large, then info.file.error.message will
+            // look like "cannot post api/permalink/noop 413'"
+            const errorIs413 = info.file.error.message.match("^cannot post .* 413'$");
+
+            const maxFileSize = 5 * 1024 * 1024;
+            if (errorIs413 && info.file.size > maxFileSize) {
+                // Show a friendly "too large" error if it's appropriate to do so
+                message.error(`${info.file.name} file is too large; must be smaller than ${maxFileSize} bytes`);
+            } else {
+                // Otherwise, it's a different error.
+                message.error(`${info.file.name} file upload failed: ${info.file.error.message}`);
+            }
+
             setStateAndSendEvent({
                 imgSrc: undefined,
                 imageName: undefined,


### PR DESCRIPTION
This change makes a nice error appear when the image to be uploaded is too large.

Looks like this:

> ![image](https://user-images.githubusercontent.com/19393950/96915664-5f658400-145b-11eb-9947-1f307c36d8ac.png)

This is another step towards fixing https://github.com/allenai/allennlp-demo/issues/548