### PR TITLE
Fix permalinks.

### DIFF
--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <link rel="stylesheet" type="text/css" href="https://unpkg.com/hierplane@0.0.9/dist/static/hierplane.min.css">
-    <link rel="manifest" href="https://demo.allennlp.org/manifest.json">
     <link rel="shortcut icon" href="https://demo.allennlp.org/favicon.ico">
     <title>AllenNLP - Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -65,6 +65,7 @@ module.exports = {
     output: {
         filename: 'main.[hash:6].js',
         path: path.resolve(__dirname, 'build'),
+        publicPath: '/'
     },
     devServer: {
         hot: true,


### PR DESCRIPTION
Permalinks have been broken since this change:
https://github.com/allenai/allennlp-demo/commit/bf3b1e989637e44c8236613ae7037a58c256579c

In that change I ported the UI to our newer build tools, but failed to
test permalinks (oops!). Permalinks were broken because the `<script />`
tag that's injected by `webpack` at build time was using a relative
path instead of an absolute one. This caused permalinks to fail
because instead of downloading `/main.[hash].js` the browser would
attempt to download `/[task-name]/main.[hash].js`, which doesn't
exist and actually causes `/index.html` to be served instead (which
clearly isn't a JavaScript document).

Don't worry, this time I actually tested with permalinks. They work
now :).

Oof. SPAs. So many footguns!

This fixes this issue:
https://github.com/allenai/reviz/issues/152