### PR TITLE
update next-token-lm demo

### DIFF
--- a/api/allennlp_demo/common/http.py
+++ b/api/allennlp_demo/common/http.py
@@ -82,10 +82,10 @@ class ModelEndpoint:
     This class can be extended to implement custom functionality.
     """
 
-    def __init__(self, model: config.Model):
+    def __init__(self, model: config.Model, log_payloads: bool = False):
         self.model = model
         self.app = Flask(model.id)
-        self.configure_logging()
+        self.configure_logging(log_payloads)
         self.predictor = model.load_predictor()
         self.interpreters = self.load_interpreters()
         self.attackers = self.load_attackers()
@@ -187,8 +187,8 @@ class ModelEndpoint:
             raise InvalidAttackerError(attacker_id)
         return attacker.attack_from_json(**attack)
 
-    def configure_logging(self) -> None:
-        configure_logging(self.app)
+    def configure_logging(self, log_payloads: bool = False) -> None:
+        configure_logging(self.app, log_payloads=log_payloads)
 
     def configure_error_handling(self) -> None:
         def handle_invalid_json(err: json.JSONDecodeError):

--- a/api/allennlp_demo/common/logs.py
+++ b/api/allennlp_demo/common/logs.py
@@ -55,7 +55,7 @@ class JsonLogFormatter(logging.Formatter):
             return json.dumps({"logname": r.name, "severity": r.levelname, "message": m})
 
 
-def configure_logging(app: Flask):
+def configure_logging(app: Flask, log_payloads: bool = False):
     """
     Setup logging in a way that makes sense for demo API endpoints.
     """
@@ -85,8 +85,8 @@ def configure_logging(app: Flask):
             request.method,
             request.path,
             request.args,
-            request.get_json(silent=True),
-            r.get_json(silent=True),
+            None if not log_payloads else request.get_json(silent=True),
+            None if not log_payloads else r.get_json(silent=True),
             request.remote_addr,
             request.headers.get("X-Forwarded-For"),
             latency_ms,

--- a/api/allennlp_demo/elmo_snli/model.json
+++ b/api/allennlp_demo/elmo_snli/model.json
@@ -1,4 +1,4 @@
 {
     "id": "elmo-snli",
-    "pretrained_model_id": "pair-classification-esim"
+    "archive_file": "https://storage.googleapis.com/allennlp-public-models/esim-elmo-2020.11.11.tar.gz"
 }

--- a/api/allennlp_demo/next_token_lm/model.json
+++ b/api/allennlp_demo/next_token_lm/model.json
@@ -1,7 +1,8 @@
 {
     "id": "next-token-lm",
     "pretrained_model_id": "lm-next-token-lm-gpt2",
-    "attackers": ["hotflip"],
+    "attackers": [],
+    "interpreters": [],
     "overrides": {
         "dataset_reader.max_tokens": 512,
         "model.beam_search_generator": {
@@ -9,7 +10,11 @@
             "beam_search": {
                 "end_index": 50256,
                 "max_steps": 5,
-                "beam_size": 5
+                "beam_size": 5,
+                "sampler": {
+                    "type": "gumbel",
+                    "temperature": 0.7
+                }
             }
         }
     }

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,5 +1,5 @@
-allennlp==1.2.0
-allennlp-models==1.2.0
+allennlp==1.2.1
+allennlp-models==1.2.1
 allennlp-semparse==0.0.2
 Flask==1.1.2
 pytest==6.1.1

--- a/ui/src/components/demos/LanguageModel.js
+++ b/ui/src/components/demos/LanguageModel.js
@@ -427,7 +427,7 @@ class App extends React.Component {
           </InputOutput>
           <p><span>{probabilitiesNote}</span></p>
         </ModelArea>
-        <div className="model__content">
+        <div hidden className="model__content">
           <MySaliencyMaps interpretData={interpretData} tokens={tokens} interpretModel={this.interpretModel} requestData={requestData}/>
           <Attacks attackData={attackData} attackModel={this.attackModel} requestData={requestData}/>
         </div>

--- a/ui/src/components/demos/LanguageModel.js
+++ b/ui/src/components/demos/LanguageModel.js
@@ -164,8 +164,9 @@ const description = (
 <p>Language modeling is the task of determining the probability of a given sequence of words occurring in a sentence. </p>
 <p>This demonstration uses the public 345M parameter <a href="https://github.com/openai/gpt-2" target="_blank" rel="noopener noreferrer">OpenAI GPT-2</a> language model
 to generate sentences.<br /><br />
-Provide some initial text, and the model will generate a list of the most-likely next words.
-You can click on one of those candidate words to choose it and continue, or you can keep typing.
+Provide some initial text, and the model will generate a list of candidates for the next few words
+using <a href="https://api.semanticscholar.org/CorpusID:76662039" target="_blank" rel="noopener noreferrer">Stochastic Beam Search</a>.
+You can click on one of those candidate to choose it and continue, or you can keep typing.
 Click the left arrow at the bottom to undo your last choice.</p>
   </span>
 )


### PR DESCRIPTION
Fixes #601, adds Stochastic Beam Search to next-token-lm demo instead of deterministic beam search, makes logging JSON payloads optional (default is `False`), hides attack/interpret functionality for next-token-lm.