### PR TITLE
Rework the way we resolve the list of demos a bit.

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -18,6 +18,7 @@
     "@types/react-router-dom": "^5.1.6",
     "@types/slug": "^0.9.1",
     "@types/styled-components": "^5.1.4",
+    "@types/webpack-env": "^1.15.3",
     "@typescript-eslint/eslint-plugin": "^4.5.0",
     "@typescript-eslint/parser": "^4.7.0",
     "antd": "^4.7.2",
@@ -61,5 +62,6 @@
     "build": "webpack --mode production",
     "lint": "eslint '**/*.{js,jsx,ts,tsx,json}' && echo '💫  Lint complete.'",
     "lint:fix": "eslint '**/*.{js,jsx,ts,tsx,json}' --fix && echo '🛠  Lint --fix complete'"
-  }
+  },
+  "devDependencies": {}
 }

--- a/ui/src/components/Menu.js
+++ b/ui/src/components/Menu.js
@@ -3,81 +3,14 @@ import styled from 'styled-components';
 import { Menu as AntdMenu } from 'antd';
 import { textStyles, LeftSider } from '@allenai/varnish/components';
 import { Link } from '@allenai/varnish-react-router';
-import slug from 'slug';
 
 import { ImgIcon } from './ImgIcon';
-import annotateIcon from '../icons/annotate-14px.svg';
-import otherIcon from '../icons/other-14px.svg';
-import parseIcon from '../icons/parse-14px.svg';
-import passageIcon from '../icons/passage-14px.svg';
-import questionIcon from '../icons/question-14px.svg';
-import addIcon from '../icons/add-14px.svg';
 
 const { Item, SubMenu } = AntdMenu;
 
 /*******************************************************************************
   <Menu /> Component
 *******************************************************************************/
-
-// find all demo pages to show in menu
-const demoCtxs = require.context('../demos', true, /Main\.tsx$/);
-const demos = demoCtxs.keys().map(demoCtxs);
-
-// predefined order of known types
-const demoGroups = [
-    {
-        label: 'Answer a question',
-        iconSrc: questionIcon,
-    },
-    {
-        label: 'Annotate a sentence',
-        iconSrc: annotateIcon,
-    },
-    {
-        label: 'Annotate a passage',
-        iconSrc: passageIcon,
-    },
-    {
-        label: 'Semantic parsing',
-        iconSrc: parseIcon,
-    },
-    {
-        label: 'Other',
-        iconSrc: otherIcon,
-    },
-    {
-        label: 'Contributing',
-        iconSrc: addIcon,
-    },
-];
-
-export const demoMenuGroups = demoGroups
-    .map((g) => {
-        return {
-            label: g.label,
-            iconSrc: g.iconSrc,
-            routes: demos
-                .filter(
-                    (demo) =>
-                        !demo.demoConfig.status !== 'disabled' &&
-                        ((!g.label && demo.demoConfig.group === 'Other') ||
-                            demo.demoConfig.group === g.label)
-                )
-                .sort((a, b) => a.demoConfig.order - b.demoConfig.order)
-                .map((demo) => {
-                    return {
-                        path: demo.demoConfig.path
-                            ? demo.demoConfig.path
-                            : `${slug(demo.demoConfig.title, '-')}`,
-                        title: demo.demoConfig.title,
-                        component: demo.default,
-                        status: demo.demoConfig.status,
-                    };
-                }),
-        };
-    })
-    // remove groups with no demos
-    .filter((g) => g.routes.length);
 
 export default class Menu extends React.Component {
     siderWidthExpanded = '300px';
@@ -104,9 +37,9 @@ export default class Menu extends React.Component {
                 onCollapse={this.handleMenuCollapse}>
                 <AntdMenu
                     defaultSelectedKeys={[this.props.redirectedModel]}
-                    defaultOpenKeys={demoMenuGroups.map((g) => g.label)}
+                    defaultOpenKeys={this.props.items.map((g) => g.label)}
                     mode="inline">
-                    {demoMenuGroups.map((g) => (
+                    {this.props.items.map((g) => (
                         <SubMenu
                             key={g.label}
                             title={
@@ -115,13 +48,20 @@ export default class Menu extends React.Component {
                                     <textStyles.Small>{g.label}</textStyles.Small>
                                 </IconMenuItemColumns>
                             }>
-                            {g.routes.map((m) => (
-                                <Item key={m.title}>
-                                    <Link to={`/${m.path}`} onClick={() => {}}>
-                                        <textStyles.Small>{m.title}</textStyles.Small>
-                                    </Link>
-                                </Item>
-                            ))}
+                            {g.demos.map((m) => {
+                                // TODO: Remove this, as it's an artifact of the incremental
+                                // transition. All demos are currently marked as hidden as
+                                // a mechanism for using the old code. Once we've fully
+                                // transition we won't need to do this anymore.
+                                const path = m.config.path.replace(/^\/hidden/, '');
+                                return (
+                                    <Item key={m.config.title}>
+                                        <Link to={`${path}`}>
+                                            <textStyles.Small>{m.config.title}</textStyles.Small>
+                                        </Link>
+                                    </Item>
+                                );
+                            })}
                         </SubMenu>
                     ))}
                 </AntdMenu>

--- a/ui/src/demos/constituency-parsing/Main.tsx
+++ b/ui/src/demos/constituency-parsing/Main.tsx
@@ -17,5 +17,4 @@ const Main = () => {
     );
 };
 
-export { demoConfig };
 export default Main;

--- a/ui/src/demos/constituency-parsing/Main.tsx
+++ b/ui/src/demos/constituency-parsing/Main.tsx
@@ -6,15 +6,13 @@ import React from 'react';
 import { Content } from '@allenai/varnish/components';
 
 import { Title } from '../../tugboat';
-import { demoConfig } from './config';
+import { config } from './config';
 
-const Main = () => {
+export const Main = () => {
     return (
         <Content>
-            <Title>{demoConfig.title}</Title>
+            <Title>{config.title}</Title>
             NOTE: This task is under development
         </Content>
     );
 };
-
-export default Main;

--- a/ui/src/demos/constituency-parsing/config.ts
+++ b/ui/src/demos/constituency-parsing/config.ts
@@ -1,6 +1,6 @@
 import { DemoConfig } from '../../tugboat';
 
-export const demoConfig: DemoConfig = {
+export const config: DemoConfig = {
     group: 'Annotate a sentence',
     title: 'Constituency Parsing',
     order: 5,

--- a/ui/src/demos/constituency-parsing/index.ts
+++ b/ui/src/demos/constituency-parsing/index.ts
@@ -1,0 +1,15 @@
+/**
+ * TODO: If we like the pattern proposed I'll:
+ *
+ *  1. Modify each `./config` instance to just export a symbol named `config` instead of
+ *     `demoConfig`, so we don't have to do this.
+ *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
+ *
+ * Making those changes means we could just `export *` below, instead of remapping the imports
+ * to the names the `Demos.load()` API expects.
+ */
+import { demoConfig as config } from './config';
+
+import Main from './Main';
+export { config };
+export { Main };

--- a/ui/src/demos/constituency-parsing/index.ts
+++ b/ui/src/demos/constituency-parsing/index.ts
@@ -1,15 +1,2 @@
-/**
- * TODO: If we like the pattern proposed I'll:
- *
- *  1. Modify each `./config` instance to just export a symbol named `config` instead of
- *     `demoConfig`, so we don't have to do this.
- *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
- *
- * Making those changes means we could just `export *` below, instead of remapping the imports
- * to the names the `Demos.load()` API expects.
- */
-import { demoConfig as config } from './config';
-
-import Main from './Main';
-export { config };
-export { Main };
+export * from './Main';
+export * from './config';

--- a/ui/src/demos/coreference-resolution/Main.tsx
+++ b/ui/src/demos/coreference-resolution/Main.tsx
@@ -17,5 +17,4 @@ const Main = () => {
     );
 };
 
-export { demoConfig };
 export default Main;

--- a/ui/src/demos/coreference-resolution/Main.tsx
+++ b/ui/src/demos/coreference-resolution/Main.tsx
@@ -6,15 +6,13 @@ import React from 'react';
 import { Content } from '@allenai/varnish/components';
 
 import { Title } from '../../tugboat';
-import { demoConfig } from './config';
+import { config } from './config';
 
-const Main = () => {
+export const Main = () => {
     return (
         <Content>
-            <Title>{demoConfig.title}</Title>
+            <Title>{config.title}</Title>
             NOTE: This task is under development
         </Content>
     );
 };
-
-export default Main;

--- a/ui/src/demos/coreference-resolution/config.ts
+++ b/ui/src/demos/coreference-resolution/config.ts
@@ -1,6 +1,6 @@
 import { DemoConfig } from '../../tugboat';
 
-export const demoConfig: DemoConfig = {
+export const config: DemoConfig = {
     group: 'Annotate a passage',
     title: 'Coreference Resolution',
     order: 1,

--- a/ui/src/demos/coreference-resolution/index.ts
+++ b/ui/src/demos/coreference-resolution/index.ts
@@ -1,0 +1,15 @@
+/**
+ * TODO: If we like the pattern proposed I'll:
+ *
+ *  1. Modify each `./config` instance to just export a symbol named `config` instead of
+ *     `demoConfig`, so we don't have to do this.
+ *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
+ *
+ * Making those changes means we could just `export *` below, instead of remapping the imports
+ * to the names the `Demos.load()` API expects.
+ */
+import { demoConfig as config } from './config';
+
+import Main from './Main';
+export { config };
+export { Main };

--- a/ui/src/demos/coreference-resolution/index.ts
+++ b/ui/src/demos/coreference-resolution/index.ts
@@ -1,15 +1,2 @@
-/**
- * TODO: If we like the pattern proposed I'll:
- *
- *  1. Modify each `./config` instance to just export a symbol named `config` instead of
- *     `demoConfig`, so we don't have to do this.
- *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
- *
- * Making those changes means we could just `export *` below, instead of remapping the imports
- * to the names the `Demos.load()` API expects.
- */
-import { demoConfig as config } from './config';
-
-import Main from './Main';
-export { config };
-export { Main };
+export * from './Main';
+export * from './config';

--- a/ui/src/demos/cornell-nvlr-semantic-parsing/Main.tsx
+++ b/ui/src/demos/cornell-nvlr-semantic-parsing/Main.tsx
@@ -17,5 +17,4 @@ const Main = () => {
     );
 };
 
-export { demoConfig };
 export default Main;

--- a/ui/src/demos/cornell-nvlr-semantic-parsing/Main.tsx
+++ b/ui/src/demos/cornell-nvlr-semantic-parsing/Main.tsx
@@ -6,15 +6,13 @@ import React from 'react';
 import { Content } from '@allenai/varnish/components';
 
 import { Title } from '../../tugboat';
-import { demoConfig } from './config';
+import { config } from './config';
 
-const Main = () => {
+export const Main = () => {
     return (
         <Content>
-            <Title>{demoConfig.title}</Title>
+            <Title>{config.title}</Title>
             NOTE: This task is under development
         </Content>
     );
 };
-
-export default Main;

--- a/ui/src/demos/cornell-nvlr-semantic-parsing/config.ts
+++ b/ui/src/demos/cornell-nvlr-semantic-parsing/config.ts
@@ -3,7 +3,7 @@ import { DemoConfig } from '../../tugboat';
 export const demoConfig: DemoConfig = {
     group: 'Semantic parsing',
     title: 'Cornell NLVR Semantic Parsing',
-    path: 'nlvr-parser',
+    path: '/nlvr-parser',
     order: 2,
     status: 'hidden',
 };

--- a/ui/src/demos/cornell-nvlr-semantic-parsing/config.ts
+++ b/ui/src/demos/cornell-nvlr-semantic-parsing/config.ts
@@ -1,6 +1,6 @@
 import { DemoConfig } from '../../tugboat';
 
-export const demoConfig: DemoConfig = {
+export const config: DemoConfig = {
     group: 'Semantic parsing',
     title: 'Cornell NLVR Semantic Parsing',
     path: '/nlvr-parser',

--- a/ui/src/demos/cornell-nvlr-semantic-parsing/index.ts
+++ b/ui/src/demos/cornell-nvlr-semantic-parsing/index.ts
@@ -1,0 +1,15 @@
+/**
+ * TODO: If we like the pattern proposed I'll:
+ *
+ *  1. Modify each `./config` instance to just export a symbol named `config` instead of
+ *     `demoConfig`, so we don't have to do this.
+ *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
+ *
+ * Making those changes means we could just `export *` below, instead of remapping the imports
+ * to the names the `Demos.load()` API expects.
+ */
+import { demoConfig as config } from './config';
+
+import Main from './Main';
+export { config };
+export { Main };

--- a/ui/src/demos/cornell-nvlr-semantic-parsing/index.ts
+++ b/ui/src/demos/cornell-nvlr-semantic-parsing/index.ts
@@ -1,15 +1,2 @@
-/**
- * TODO: If we like the pattern proposed I'll:
- *
- *  1. Modify each `./config` instance to just export a symbol named `config` instead of
- *     `demoConfig`, so we don't have to do this.
- *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
- *
- * Making those changes means we could just `export *` below, instead of remapping the imports
- * to the names the `Demos.load()` API expects.
- */
-import { demoConfig as config } from './config';
-
-import Main from './Main';
-export { config };
-export { Main };
+export * from './Main';
+export * from './config';

--- a/ui/src/demos/dependency-parsing/Main.tsx
+++ b/ui/src/demos/dependency-parsing/Main.tsx
@@ -17,5 +17,4 @@ const Main = () => {
     );
 };
 
-export { demoConfig };
 export default Main;

--- a/ui/src/demos/dependency-parsing/Main.tsx
+++ b/ui/src/demos/dependency-parsing/Main.tsx
@@ -6,15 +6,13 @@ import React from 'react';
 import { Content } from '@allenai/varnish/components';
 
 import { Title } from '../../tugboat';
-import { demoConfig } from './config';
+import { config } from './config';
 
-const Main = () => {
+export const Main = () => {
     return (
         <Content>
-            <Title>{demoConfig.title}</Title>
+            <Title>{config.title}</Title>
             NOTE: This task is under development
         </Content>
     );
 };
-
-export default Main;

--- a/ui/src/demos/dependency-parsing/config.ts
+++ b/ui/src/demos/dependency-parsing/config.ts
@@ -1,6 +1,6 @@
 import { DemoConfig } from '../../tugboat';
 
-export const demoConfig: DemoConfig = {
+export const config: DemoConfig = {
     group: 'Annotate a sentence',
     title: 'Dependency Parsing',
     order: 4,

--- a/ui/src/demos/dependency-parsing/index.ts
+++ b/ui/src/demos/dependency-parsing/index.ts
@@ -1,0 +1,15 @@
+/**
+ * TODO: If we like the pattern proposed I'll:
+ *
+ *  1. Modify each `./config` instance to just export a symbol named `config` instead of
+ *     `demoConfig`, so we don't have to do this.
+ *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
+ *
+ * Making those changes means we could just `export *` below, instead of remapping the imports
+ * to the names the `Demos.load()` API expects.
+ */
+import { demoConfig as config } from './config';
+
+import Main from './Main';
+export { config };
+export { Main };

--- a/ui/src/demos/dependency-parsing/index.ts
+++ b/ui/src/demos/dependency-parsing/index.ts
@@ -1,15 +1,2 @@
-/**
- * TODO: If we like the pattern proposed I'll:
- *
- *  1. Modify each `./config` instance to just export a symbol named `config` instead of
- *     `demoConfig`, so we don't have to do this.
- *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
- *
- * Making those changes means we could just `export *` below, instead of remapping the imports
- * to the names the `Demos.load()` API expects.
- */
-import { demoConfig as config } from './config';
-
-import Main from './Main';
-export { config };
-export { Main };
+export * from './Main';
+export * from './config';

--- a/ui/src/demos/language-modeling/Main.tsx
+++ b/ui/src/demos/language-modeling/Main.tsx
@@ -17,5 +17,4 @@ const Main = () => {
     );
 };
 
-export { demoConfig };
 export default Main;

--- a/ui/src/demos/language-modeling/Main.tsx
+++ b/ui/src/demos/language-modeling/Main.tsx
@@ -6,15 +6,13 @@ import React from 'react';
 import { Content } from '@allenai/varnish/components';
 
 import { Title } from '../../tugboat';
-import { demoConfig } from './config';
+import { config } from './config';
 
-const Main = () => {
+export const Main = () => {
     return (
         <Content>
-            <Title>{demoConfig.title}</Title>
+            <Title>{config.title}</Title>
             NOTE: This task is under development
         </Content>
     );
 };
-
-export default Main;

--- a/ui/src/demos/language-modeling/config.ts
+++ b/ui/src/demos/language-modeling/config.ts
@@ -3,7 +3,7 @@ import { DemoConfig } from '../../tugboat';
 export const demoConfig: DemoConfig = {
     group: 'Other',
     title: 'Language Modeling',
-    path: 'next-token-lm?text=AllenNLP%20is',
+    path: '/next-token-lm',
     order: 2,
     status: 'hidden',
 };

--- a/ui/src/demos/language-modeling/config.ts
+++ b/ui/src/demos/language-modeling/config.ts
@@ -1,6 +1,6 @@
 import { DemoConfig } from '../../tugboat';
 
-export const demoConfig: DemoConfig = {
+export const config: DemoConfig = {
     group: 'Other',
     title: 'Language Modeling',
     path: '/next-token-lm',

--- a/ui/src/demos/language-modeling/index.ts
+++ b/ui/src/demos/language-modeling/index.ts
@@ -1,0 +1,15 @@
+/**
+ * TODO: If we like the pattern proposed I'll:
+ *
+ *  1. Modify each `./config` instance to just export a symbol named `config` instead of
+ *     `demoConfig`, so we don't have to do this.
+ *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
+ *
+ * Making those changes means we could just `export *` below, instead of remapping the imports
+ * to the names the `Demos.load()` API expects.
+ */
+import { demoConfig as config } from './config';
+
+import Main from './Main';
+export { config };
+export { Main };

--- a/ui/src/demos/language-modeling/index.ts
+++ b/ui/src/demos/language-modeling/index.ts
@@ -1,15 +1,2 @@
-/**
- * TODO: If we like the pattern proposed I'll:
- *
- *  1. Modify each `./config` instance to just export a symbol named `config` instead of
- *     `demoConfig`, so we don't have to do this.
- *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
- *
- * Making those changes means we could just `export *` below, instead of remapping the imports
- * to the names the `Demos.load()` API expects.
- */
-import { demoConfig as config } from './config';
-
-import Main from './Main';
-export { config };
-export { Main };
+export * from './Main';
+export * from './config';

--- a/ui/src/demos/masked-language-modeling/Main.tsx
+++ b/ui/src/demos/masked-language-modeling/Main.tsx
@@ -17,5 +17,4 @@ const Main = () => {
     );
 };
 
-export { demoConfig };
 export default Main;

--- a/ui/src/demos/masked-language-modeling/Main.tsx
+++ b/ui/src/demos/masked-language-modeling/Main.tsx
@@ -6,15 +6,13 @@ import React from 'react';
 import { Content } from '@allenai/varnish/components';
 
 import { Title } from '../../tugboat';
-import { demoConfig } from './config';
+import { config } from './config';
 
-const Main = () => {
+export const Main = () => {
     return (
         <Content>
-            <Title>{demoConfig.title}</Title>
+            <Title>{config.title}</Title>
             NOTE: This task is under development
         </Content>
     );
 };
-
-export default Main;

--- a/ui/src/demos/masked-language-modeling/config.ts
+++ b/ui/src/demos/masked-language-modeling/config.ts
@@ -3,8 +3,7 @@ import { DemoConfig } from '../../tugboat';
 export const demoConfig: DemoConfig = {
     group: 'Other',
     title: 'Masked Language Modeling',
-    path:
-        'masked-lm?text=The%20doctor%20ran%20to%20the%20emergency%20room%20to%20see%20%5BMASK%5D%20patient.',
+    path: '/masked-lm',
     order: 3,
     status: 'hidden',
 };

--- a/ui/src/demos/masked-language-modeling/config.ts
+++ b/ui/src/demos/masked-language-modeling/config.ts
@@ -1,6 +1,6 @@
 import { DemoConfig } from '../../tugboat';
 
-export const demoConfig: DemoConfig = {
+export const config: DemoConfig = {
     group: 'Other',
     title: 'Masked Language Modeling',
     path: '/masked-lm',

--- a/ui/src/demos/masked-language-modeling/index.ts
+++ b/ui/src/demos/masked-language-modeling/index.ts
@@ -1,0 +1,15 @@
+/**
+ * TODO: If we like the pattern proposed I'll:
+ *
+ *  1. Modify each `./config` instance to just export a symbol named `config` instead of
+ *     `demoConfig`, so we don't have to do this.
+ *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
+ *
+ * Making those changes means we could just `export *` below, instead of remapping the imports
+ * to the names the `Demos.load()` API expects.
+ */
+import { demoConfig as config } from './config';
+
+import Main from './Main';
+export { config };
+export { Main };

--- a/ui/src/demos/masked-language-modeling/index.ts
+++ b/ui/src/demos/masked-language-modeling/index.ts
@@ -1,15 +1,2 @@
-/**
- * TODO: If we like the pattern proposed I'll:
- *
- *  1. Modify each `./config` instance to just export a symbol named `config` instead of
- *     `demoConfig`, so we don't have to do this.
- *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
- *
- * Making those changes means we could just `export *` below, instead of remapping the imports
- * to the names the `Demos.load()` API expects.
- */
-import { demoConfig as config } from './config';
-
-import Main from './Main';
-export { config };
-export { Main };
+export * from './Main';
+export * from './config';

--- a/ui/src/demos/named-entity-recognition/Main.tsx
+++ b/ui/src/demos/named-entity-recognition/Main.tsx
@@ -17,5 +17,4 @@ const Main = () => {
     );
 };
 
-export { demoConfig };
 export default Main;

--- a/ui/src/demos/named-entity-recognition/Main.tsx
+++ b/ui/src/demos/named-entity-recognition/Main.tsx
@@ -6,15 +6,13 @@ import React from 'react';
 import { Content } from '@allenai/varnish/components';
 
 import { Title } from '../../tugboat';
-import { demoConfig } from './config';
+import { config } from './config';
 
-const Main = () => {
+export const Main = () => {
     return (
         <Content>
-            <Title>{demoConfig.title}</Title>
+            <Title>{config.title}</Title>
             NOTE: This task is under development
         </Content>
     );
 };
-
-export default Main;

--- a/ui/src/demos/named-entity-recognition/config.ts
+++ b/ui/src/demos/named-entity-recognition/config.ts
@@ -1,6 +1,6 @@
 import { DemoConfig } from '../../tugboat';
 
-export const demoConfig: DemoConfig = {
+export const config: DemoConfig = {
     group: 'Annotate a sentence',
     title: 'Named Entity Recognition',
     order: 1,

--- a/ui/src/demos/named-entity-recognition/index.ts
+++ b/ui/src/demos/named-entity-recognition/index.ts
@@ -1,0 +1,15 @@
+/**
+ * TODO: If we like the pattern proposed I'll:
+ *
+ *  1. Modify each `./config` instance to just export a symbol named `config` instead of
+ *     `demoConfig`, so we don't have to do this.
+ *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
+ *
+ * Making those changes means we could just `export *` below, instead of remapping the imports
+ * to the names the `Demos.load()` API expects.
+ */
+import { demoConfig as config } from './config';
+
+import Main from './Main';
+export { config };
+export { Main };

--- a/ui/src/demos/named-entity-recognition/index.ts
+++ b/ui/src/demos/named-entity-recognition/index.ts
@@ -1,15 +1,2 @@
-/**
- * TODO: If we like the pattern proposed I'll:
- *
- *  1. Modify each `./config` instance to just export a symbol named `config` instead of
- *     `demoConfig`, so we don't have to do this.
- *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
- *
- * Making those changes means we could just `export *` below, instead of remapping the imports
- * to the names the `Demos.load()` API expects.
- */
-import { demoConfig as config } from './config';
-
-import Main from './Main';
-export { config };
-export { Main };
+export * from './Main';
+export * from './config';

--- a/ui/src/demos/open-information-extraction/Main.tsx
+++ b/ui/src/demos/open-information-extraction/Main.tsx
@@ -17,5 +17,4 @@ const Main = () => {
     );
 };
 
-export { demoConfig };
 export default Main;

--- a/ui/src/demos/open-information-extraction/Main.tsx
+++ b/ui/src/demos/open-information-extraction/Main.tsx
@@ -6,15 +6,13 @@ import React from 'react';
 import { Content } from '@allenai/varnish/components';
 
 import { Title } from '../../tugboat';
-import { demoConfig } from './config';
+import { config } from './config';
 
-const Main = () => {
+export const Main = () => {
     return (
         <Content>
-            <Title>{demoConfig.title}</Title>
+            <Title>{config.title}</Title>
             NOTE: This task is under development
         </Content>
     );
 };
-
-export default Main;

--- a/ui/src/demos/open-information-extraction/config.ts
+++ b/ui/src/demos/open-information-extraction/config.ts
@@ -1,6 +1,6 @@
 import { DemoConfig } from '../../tugboat';
 
-export const demoConfig: DemoConfig = {
+export const config: DemoConfig = {
     group: 'Annotate a sentence',
     title: 'Open Information Extraction',
     order: 2,

--- a/ui/src/demos/open-information-extraction/index.ts
+++ b/ui/src/demos/open-information-extraction/index.ts
@@ -1,0 +1,15 @@
+/**
+ * TODO: If we like the pattern proposed I'll:
+ *
+ *  1. Modify each `./config` instance to just export a symbol named `config` instead of
+ *     `demoConfig`, so we don't have to do this.
+ *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
+ *
+ * Making those changes means we could just `export *` below, instead of remapping the imports
+ * to the names the `Demos.load()` API expects.
+ */
+import { demoConfig as config } from './config';
+
+import Main from './Main';
+export { config };
+export { Main };

--- a/ui/src/demos/open-information-extraction/index.ts
+++ b/ui/src/demos/open-information-extraction/index.ts
@@ -1,15 +1,2 @@
-/**
- * TODO: If we like the pattern proposed I'll:
- *
- *  1. Modify each `./config` instance to just export a symbol named `config` instead of
- *     `demoConfig`, so we don't have to do this.
- *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
- *
- * Making those changes means we could just `export *` below, instead of remapping the imports
- * to the names the `Demos.load()` API expects.
- */
-import { demoConfig as config } from './config';
-
-import Main from './Main';
-export { config };
-export { Main };
+export * from './Main';
+export * from './config';

--- a/ui/src/demos/reading-comprehension/Main.tsx
+++ b/ui/src/demos/reading-comprehension/Main.tsx
@@ -3,8 +3,7 @@
 */
 
 import React from 'react';
-import { Divider, Select, Spin } from 'antd';
-import { LoadingOutlined } from '@ant-design/icons';
+import { Divider, Select } from 'antd';
 import { Content } from '@allenai/varnish/components';
 
 import {
@@ -13,14 +12,15 @@ import {
     Description,
     Markdown,
     RunButton,
+    Loading,
     ModelInfo,
     ModelUsageModal,
     ModelCardModal,
     useModels,
 } from '../../tugboat';
-import { demoConfig } from './config';
+import { config } from './config';
 
-const Main = () => {
+export const Main = () => {
     const models = useModels('bidaf-elmo', 'bidaf', 'nmn', 'transformer-qa', 'naqanet');
     const [selectedModel, setSelectedModel] = React.useState<ModelInfo>();
 
@@ -33,14 +33,14 @@ const Main = () => {
     if (!models) {
         return (
             <Content>
-                <Spin indicator={<LoadingOutlined style={{ fontSize: '2rem' }} spin />} />
+                <Loading />
             </Content>
         );
     }
 
     return (
         <Content>
-            <Title>{demoConfig.title}</Title>
+            <Title>{config.title}</Title>
             <Description>
                 <Markdown>
                     Reading comprehension is the task of answering questions about a passage of text
@@ -102,5 +102,3 @@ const Main = () => {
         </Content>
     );
 };
-
-export default Main;

--- a/ui/src/demos/reading-comprehension/config.ts
+++ b/ui/src/demos/reading-comprehension/config.ts
@@ -1,6 +1,6 @@
 import { DemoConfig } from '../../tugboat';
 
-export const demoConfig: DemoConfig = {
+export const config: DemoConfig = {
     group: 'Answer a question',
     title: 'Reading Comprehension',
     order: 1,

--- a/ui/src/demos/reading-comprehension/index.ts
+++ b/ui/src/demos/reading-comprehension/index.ts
@@ -1,0 +1,15 @@
+/**
+ * TODO: If we like the pattern proposed I'll:
+ *
+ *  1. Modify each `./config` instance to just export a symbol named `config` instead of
+ *     `demoConfig`, so we don't have to do this.
+ *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
+ *
+ * Making those changes means we could just `export *` below, instead of remapping the imports
+ * to the names the `Demos.load()` API expects.
+ */
+import { demoConfig as config } from './config';
+
+import Main from './Main';
+export { config };
+export { Main };

--- a/ui/src/demos/reading-comprehension/index.ts
+++ b/ui/src/demos/reading-comprehension/index.ts
@@ -1,15 +1,2 @@
-/**
- * TODO: If we like the pattern proposed I'll:
- *
- *  1. Modify each `./config` instance to just export a symbol named `config` instead of
- *     `demoConfig`, so we don't have to do this.
- *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
- *
- * Making those changes means we could just `export *` below, instead of remapping the imports
- * to the names the `Demos.load()` API expects.
- */
-import { demoConfig as config } from './config';
-
-import Main from './Main';
-export { config };
-export { Main };
+export * from './Main';
+export * from './config';

--- a/ui/src/demos/semantic-role-labeling/Main.tsx
+++ b/ui/src/demos/semantic-role-labeling/Main.tsx
@@ -17,5 +17,4 @@ const Main = () => {
     );
 };
 
-export { demoConfig };
 export default Main;

--- a/ui/src/demos/semantic-role-labeling/Main.tsx
+++ b/ui/src/demos/semantic-role-labeling/Main.tsx
@@ -6,15 +6,13 @@ import React from 'react';
 import { Content } from '@allenai/varnish/components';
 
 import { Title } from '../../tugboat';
-import { demoConfig } from './config';
+import { config } from './config';
 
-const Main = () => {
+export const Main = () => {
     return (
         <Content>
-            <Title>{demoConfig.title}</Title>
+            <Title>{config.title}</Title>
             NOTE: This task is under development
         </Content>
     );
 };
-
-export default Main;

--- a/ui/src/demos/semantic-role-labeling/config.ts
+++ b/ui/src/demos/semantic-role-labeling/config.ts
@@ -1,6 +1,6 @@
 import { DemoConfig } from '../../tugboat';
 
-export const demoConfig: DemoConfig = {
+export const config: DemoConfig = {
     group: 'Annotate a sentence',
     title: 'Semantic Role Labeling',
     order: 6,

--- a/ui/src/demos/semantic-role-labeling/index.ts
+++ b/ui/src/demos/semantic-role-labeling/index.ts
@@ -1,0 +1,15 @@
+/**
+ * TODO: If we like the pattern proposed I'll:
+ *
+ *  1. Modify each `./config` instance to just export a symbol named `config` instead of
+ *     `demoConfig`, so we don't have to do this.
+ *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
+ *
+ * Making those changes means we could just `export *` below, instead of remapping the imports
+ * to the names the `Demos.load()` API expects.
+ */
+import { demoConfig as config } from './config';
+
+import Main from './Main';
+export { config };
+export { Main };

--- a/ui/src/demos/semantic-role-labeling/index.ts
+++ b/ui/src/demos/semantic-role-labeling/index.ts
@@ -1,15 +1,2 @@
-/**
- * TODO: If we like the pattern proposed I'll:
- *
- *  1. Modify each `./config` instance to just export a symbol named `config` instead of
- *     `demoConfig`, so we don't have to do this.
- *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
- *
- * Making those changes means we could just `export *` below, instead of remapping the imports
- * to the names the `Demos.load()` API expects.
- */
-import { demoConfig as config } from './config';
-
-import Main from './Main';
-export { config };
-export { Main };
+export * from './Main';
+export * from './config';

--- a/ui/src/demos/sentiment-analysis/Main.tsx
+++ b/ui/src/demos/sentiment-analysis/Main.tsx
@@ -17,5 +17,4 @@ const Main = () => {
     );
 };
 
-export { demoConfig };
 export default Main;

--- a/ui/src/demos/sentiment-analysis/Main.tsx
+++ b/ui/src/demos/sentiment-analysis/Main.tsx
@@ -6,15 +6,13 @@ import React from 'react';
 import { Content } from '@allenai/varnish/components';
 
 import { Title } from '../../tugboat';
-import { demoConfig } from './config';
+import { config } from './config';
 
-const Main = () => {
+export const Main = () => {
     return (
         <Content>
-            <Title>{demoConfig.title}</Title>
+            <Title>{config.title}</Title>
             NOTE: This task is under development
         </Content>
     );
 };
-
-export default Main;

--- a/ui/src/demos/sentiment-analysis/config.ts
+++ b/ui/src/demos/sentiment-analysis/config.ts
@@ -1,6 +1,6 @@
 import { DemoConfig } from '../../tugboat';
 
-export const demoConfig: DemoConfig = {
+export const config: DemoConfig = {
     group: 'Annotate a sentence',
     title: 'Sentiment Analysis',
     order: 3,

--- a/ui/src/demos/sentiment-analysis/index.ts
+++ b/ui/src/demos/sentiment-analysis/index.ts
@@ -1,0 +1,15 @@
+/**
+ * TODO: If we like the pattern proposed I'll:
+ *
+ *  1. Modify each `./config` instance to just export a symbol named `config` instead of
+ *     `demoConfig`, so we don't have to do this.
+ *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
+ *
+ * Making those changes means we could just `export *` below, instead of remapping the imports
+ * to the names the `Demos.load()` API expects.
+ */
+import { demoConfig as config } from './config';
+
+import Main from './Main';
+export { config };
+export { Main };

--- a/ui/src/demos/sentiment-analysis/index.ts
+++ b/ui/src/demos/sentiment-analysis/index.ts
@@ -1,15 +1,2 @@
-/**
- * TODO: If we like the pattern proposed I'll:
- *
- *  1. Modify each `./config` instance to just export a symbol named `config` instead of
- *     `demoConfig`, so we don't have to do this.
- *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
- *
- * Making those changes means we could just `export *` below, instead of remapping the imports
- * to the names the `Demos.load()` API expects.
- */
-import { demoConfig as config } from './config';
-
-import Main from './Main';
-export { config };
-export { Main };
+export * from './Main';
+export * from './config';

--- a/ui/src/demos/text-to-sql-atis/Main.tsx
+++ b/ui/src/demos/text-to-sql-atis/Main.tsx
@@ -17,5 +17,4 @@ const Main = () => {
     );
 };
 
-export { demoConfig };
 export default Main;

--- a/ui/src/demos/text-to-sql-atis/Main.tsx
+++ b/ui/src/demos/text-to-sql-atis/Main.tsx
@@ -6,15 +6,13 @@ import React from 'react';
 import { Content } from '@allenai/varnish/components';
 
 import { Title } from '../../tugboat';
-import { demoConfig } from './config';
+import { config } from './config';
 
-const Main = () => {
+export const Main = () => {
     return (
         <Content>
-            <Title>{demoConfig.title}</Title>
+            <Title>{config.title}</Title>
             NOTE: This task is under development
         </Content>
     );
 };
-
-export default Main;

--- a/ui/src/demos/text-to-sql-atis/config.ts
+++ b/ui/src/demos/text-to-sql-atis/config.ts
@@ -3,7 +3,7 @@ import { DemoConfig } from '../../tugboat';
 export const demoConfig: DemoConfig = {
     group: 'Semantic parsing',
     title: 'Text to SQL (ATIS)',
-    path: 'atis-parser',
+    path: '/atis-parser',
     order: 3,
     status: 'hidden',
 };

--- a/ui/src/demos/text-to-sql-atis/config.ts
+++ b/ui/src/demos/text-to-sql-atis/config.ts
@@ -1,6 +1,6 @@
 import { DemoConfig } from '../../tugboat';
 
-export const demoConfig: DemoConfig = {
+export const config: DemoConfig = {
     group: 'Semantic parsing',
     title: 'Text to SQL (ATIS)',
     path: '/atis-parser',

--- a/ui/src/demos/text-to-sql-atis/index.ts
+++ b/ui/src/demos/text-to-sql-atis/index.ts
@@ -1,0 +1,15 @@
+/**
+ * TODO: If we like the pattern proposed I'll:
+ *
+ *  1. Modify each `./config` instance to just export a symbol named `config` instead of
+ *     `demoConfig`, so we don't have to do this.
+ *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
+ *
+ * Making those changes means we could just `export *` below, instead of remapping the imports
+ * to the names the `Demos.load()` API expects.
+ */
+import { demoConfig as config } from './config';
+
+import Main from './Main';
+export { config };
+export { Main };

--- a/ui/src/demos/text-to-sql-atis/index.ts
+++ b/ui/src/demos/text-to-sql-atis/index.ts
@@ -1,15 +1,2 @@
-/**
- * TODO: If we like the pattern proposed I'll:
- *
- *  1. Modify each `./config` instance to just export a symbol named `config` instead of
- *     `demoConfig`, so we don't have to do this.
- *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
- *
- * Making those changes means we could just `export *` below, instead of remapping the imports
- * to the names the `Demos.load()` API expects.
- */
-import { demoConfig as config } from './config';
-
-import Main from './Main';
-export { config };
-export { Main };
+export * from './Main';
+export * from './config';

--- a/ui/src/demos/textual-entailment/Main.tsx
+++ b/ui/src/demos/textual-entailment/Main.tsx
@@ -17,5 +17,4 @@ const Main = () => {
     );
 };
 
-export { demoConfig };
 export default Main;

--- a/ui/src/demos/textual-entailment/Main.tsx
+++ b/ui/src/demos/textual-entailment/Main.tsx
@@ -6,15 +6,13 @@ import React from 'react';
 import { Content } from '@allenai/varnish/components';
 
 import { Title } from '../../tugboat';
-import { demoConfig } from './config';
+import { config } from './config';
 
-const Main = () => {
+export const Main = () => {
     return (
         <Content>
-            <Title>{demoConfig.title}</Title>
+            <Title>{config.title}</Title>
             NOTE: This task is under development
         </Content>
     );
 };
-
-export default Main;

--- a/ui/src/demos/textual-entailment/config.ts
+++ b/ui/src/demos/textual-entailment/config.ts
@@ -1,6 +1,6 @@
 import { DemoConfig } from '../../tugboat';
 
-export const demoConfig: DemoConfig = {
+export const config: DemoConfig = {
     group: 'Other',
     title: 'Textual Entailment',
     order: 1,

--- a/ui/src/demos/textual-entailment/index.ts
+++ b/ui/src/demos/textual-entailment/index.ts
@@ -1,0 +1,15 @@
+/**
+ * TODO: If we like the pattern proposed I'll:
+ *
+ *  1. Modify each `./config` instance to just export a symbol named `config` instead of
+ *     `demoConfig`, so we don't have to do this.
+ *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
+ *
+ * Making those changes means we could just `export *` below, instead of remapping the imports
+ * to the names the `Demos.load()` API expects.
+ */
+import { demoConfig as config } from './config';
+
+import Main from './Main';
+export { config };
+export { Main };

--- a/ui/src/demos/textual-entailment/index.ts
+++ b/ui/src/demos/textual-entailment/index.ts
@@ -1,15 +1,2 @@
-/**
- * TODO: If we like the pattern proposed I'll:
- *
- *  1. Modify each `./config` instance to just export a symbol named `config` instead of
- *     `demoConfig`, so we don't have to do this.
- *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
- *
- * Making those changes means we could just `export *` below, instead of remapping the imports
- * to the names the `Demos.load()` API expects.
- */
-import { demoConfig as config } from './config';
-
-import Main from './Main';
-export { config };
-export { Main };
+export * from './Main';
+export * from './config';

--- a/ui/src/demos/user-contributed-models/Main.tsx
+++ b/ui/src/demos/user-contributed-models/Main.tsx
@@ -17,5 +17,4 @@ const Main = () => {
     );
 };
 
-export { demoConfig };
 export default Main;

--- a/ui/src/demos/user-contributed-models/Main.tsx
+++ b/ui/src/demos/user-contributed-models/Main.tsx
@@ -6,15 +6,13 @@ import React from 'react';
 import { Content } from '@allenai/varnish/components';
 
 import { Title } from '../../tugboat';
-import { demoConfig } from './config';
+import { config } from './config';
 
-const Main = () => {
+export const Main = () => {
     return (
         <Content>
-            <Title>{demoConfig.title}</Title>
+            <Title>{config.title}</Title>
             NOTE: This task is under development
         </Content>
     );
 };
-
-export default Main;

--- a/ui/src/demos/user-contributed-models/config.ts
+++ b/ui/src/demos/user-contributed-models/config.ts
@@ -3,7 +3,7 @@ import { DemoConfig } from '../../tugboat';
 export const demoConfig: DemoConfig = {
     group: 'Contributing',
     title: 'User Contributed Models',
-    path: 'user-models',
+    path: '/user-models',
     order: 1,
     status: 'hidden',
 };

--- a/ui/src/demos/user-contributed-models/config.ts
+++ b/ui/src/demos/user-contributed-models/config.ts
@@ -1,6 +1,6 @@
 import { DemoConfig } from '../../tugboat';
 
-export const demoConfig: DemoConfig = {
+export const config: DemoConfig = {
     group: 'Contributing',
     title: 'User Contributed Models',
     path: '/user-models',

--- a/ui/src/demos/user-contributed-models/index.ts
+++ b/ui/src/demos/user-contributed-models/index.ts
@@ -1,0 +1,15 @@
+/**
+ * TODO: If we like the pattern proposed I'll:
+ *
+ *  1. Modify each `./config` instance to just export a symbol named `config` instead of
+ *     `demoConfig`, so we don't have to do this.
+ *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
+ *
+ * Making those changes means we could just `export *` below, instead of remapping the imports
+ * to the names the `Demos.load()` API expects.
+ */
+import { demoConfig as config } from './config';
+
+import Main from './Main';
+export { config };
+export { Main };

--- a/ui/src/demos/user-contributed-models/index.ts
+++ b/ui/src/demos/user-contributed-models/index.ts
@@ -1,15 +1,2 @@
-/**
- * TODO: If we like the pattern proposed I'll:
- *
- *  1. Modify each `./config` instance to just export a symbol named `config` instead of
- *     `demoConfig`, so we don't have to do this.
- *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
- *
- * Making those changes means we could just `export *` below, instead of remapping the imports
- * to the names the `Demos.load()` API expects.
- */
-import { demoConfig as config } from './config';
-
-import Main from './Main';
-export { config };
-export { Main };
+export * from './Main';
+export * from './config';

--- a/ui/src/demos/visual-question-answering/Main.tsx
+++ b/ui/src/demos/visual-question-answering/Main.tsx
@@ -17,5 +17,4 @@ const Main = () => {
     );
 };
 
-export { demoConfig };
 export default Main;

--- a/ui/src/demos/visual-question-answering/Main.tsx
+++ b/ui/src/demos/visual-question-answering/Main.tsx
@@ -6,15 +6,13 @@ import React from 'react';
 import { Content } from '@allenai/varnish/components';
 
 import { Title } from '../../tugboat';
-import { demoConfig } from './config';
+import { config } from './config';
 
-const Main = () => {
+export const Main = () => {
     return (
         <Content>
-            <Title>{demoConfig.title}</Title>
+            <Title>{config.title}</Title>
             NOTE: This task is under development
         </Content>
     );
 };
-
-export default Main;

--- a/ui/src/demos/visual-question-answering/config.ts
+++ b/ui/src/demos/visual-question-answering/config.ts
@@ -1,6 +1,6 @@
 import { DemoConfig } from '../../tugboat';
 
-export const demoConfig: DemoConfig = {
+export const config: DemoConfig = {
     group: 'Answer a question',
     title: 'Visual Question Answering',
     order: 2,

--- a/ui/src/demos/visual-question-answering/index.ts
+++ b/ui/src/demos/visual-question-answering/index.ts
@@ -1,0 +1,15 @@
+/**
+ * TODO: If we like the pattern proposed I'll:
+ *
+ *  1. Modify each `./config` instance to just export a symbol named `config` instead of
+ *     `demoConfig`, so we don't have to do this.
+ *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
+ *
+ * Making those changes means we could just `export *` below, instead of remapping the imports
+ * to the names the `Demos.load()` API expects.
+ */
+import { demoConfig as config } from './config';
+
+import Main from './Main';
+export { config };
+export { Main };

--- a/ui/src/demos/visual-question-answering/index.ts
+++ b/ui/src/demos/visual-question-answering/index.ts
@@ -1,15 +1,2 @@
-/**
- * TODO: If we like the pattern proposed I'll:
- *
- *  1. Modify each `./config` instance to just export a symbol named `config` instead of
- *     `demoConfig`, so we don't have to do this.
- *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
- *
- * Making those changes means we could just `export *` below, instead of remapping the imports
- * to the names the `Demos.load()` API expects.
- */
-import { demoConfig as config } from './config';
-
-import Main from './Main';
-export { config };
-export { Main };
+export * from './Main';
+export * from './config';

--- a/ui/src/demos/wiki-tables-semantic-parsing/Main.tsx
+++ b/ui/src/demos/wiki-tables-semantic-parsing/Main.tsx
@@ -17,5 +17,4 @@ const Main = () => {
     );
 };
 
-export { demoConfig };
 export default Main;

--- a/ui/src/demos/wiki-tables-semantic-parsing/Main.tsx
+++ b/ui/src/demos/wiki-tables-semantic-parsing/Main.tsx
@@ -6,15 +6,13 @@ import React from 'react';
 import { Content } from '@allenai/varnish/components';
 
 import { Title } from '../../tugboat';
-import { demoConfig } from './config';
+import { config } from './config';
 
-const Main = () => {
+export const Main = () => {
     return (
         <Content>
-            <Title>{demoConfig.title}</Title>
+            <Title>{config.title}</Title>
             NOTE: This task is under development
         </Content>
     );
 };
-
-export default Main;

--- a/ui/src/demos/wiki-tables-semantic-parsing/config.ts
+++ b/ui/src/demos/wiki-tables-semantic-parsing/config.ts
@@ -3,7 +3,7 @@ import { DemoConfig } from '../../tugboat';
 export const demoConfig: DemoConfig = {
     group: 'Semantic parsing',
     title: 'WikiTables Semantic Parsing',
-    path: 'wikitables-parser',
+    path: '/wikitables-parser',
     order: 1,
     status: 'hidden',
 };

--- a/ui/src/demos/wiki-tables-semantic-parsing/config.ts
+++ b/ui/src/demos/wiki-tables-semantic-parsing/config.ts
@@ -1,6 +1,6 @@
 import { DemoConfig } from '../../tugboat';
 
-export const demoConfig: DemoConfig = {
+export const config: DemoConfig = {
     group: 'Semantic parsing',
     title: 'WikiTables Semantic Parsing',
     path: '/wikitables-parser',

--- a/ui/src/demos/wiki-tables-semantic-parsing/index.ts
+++ b/ui/src/demos/wiki-tables-semantic-parsing/index.ts
@@ -1,0 +1,15 @@
+/**
+ * TODO: If we like the pattern proposed I'll:
+ *
+ *  1. Modify each `./config` instance to just export a symbol named `config` instead of
+ *     `demoConfig`, so we don't have to do this.
+ *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
+ *
+ * Making those changes means we could just `export *` below, instead of remapping the imports
+ * to the names the `Demos.load()` API expects.
+ */
+import { demoConfig as config } from './config';
+
+import Main from './Main';
+export { config };
+export { Main };

--- a/ui/src/demos/wiki-tables-semantic-parsing/index.ts
+++ b/ui/src/demos/wiki-tables-semantic-parsing/index.ts
@@ -1,15 +1,2 @@
-/**
- * TODO: If we like the pattern proposed I'll:
- *
- *  1. Modify each `./config` instance to just export a symbol named `config` instead of
- *     `demoConfig`, so we don't have to do this.
- *  2. Modify each `./Main` instance to just `export Main` instead of using `export.default`.
- *
- * Making those changes means we could just `export *` below, instead of remapping the imports
- * to the names the `Demos.load()` API expects.
- */
-import { demoConfig as config } from './config';
-
-import Main from './Main';
-export { config };
-export { Main };
+export * from './Main';
+export * from './config';

--- a/ui/src/groups.ts
+++ b/ui/src/groups.ts
@@ -1,0 +1,40 @@
+import { DemoGroup } from './tugboat';
+
+/**
+ * TODO: These are SVGs, so we should just convert them into React.Components that are output
+ * as part of the DOM. They'll be faster, look better and we can change colors n' such via
+ * CSS.
+ */
+import annotateIcon from './icons/annotate-14px.svg';
+import otherIcon from './icons/other-14px.svg';
+import parseIcon from './icons/parse-14px.svg';
+import passageIcon from './icons/passage-14px.svg';
+import questionIcon from './icons/question-14px.svg';
+import addIcon from './icons/add-14px.svg';
+
+export const groups: DemoGroup[] = [
+    {
+        label: 'Answer a question',
+        iconSrc: questionIcon,
+    },
+    {
+        label: 'Annotate a sentence',
+        iconSrc: annotateIcon,
+    },
+    {
+        label: 'Annotate a passage',
+        iconSrc: passageIcon,
+    },
+    {
+        label: 'Semantic parsing',
+        iconSrc: parseIcon,
+    },
+    {
+        label: 'Other',
+        iconSrc: otherIcon,
+    },
+    {
+        label: 'Contributing',
+        iconSrc: addIcon,
+    },
+];

--- a/ui/src/tugboat/Demo.ts
+++ b/ui/src/tugboat/Demo.ts
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { DemoConfig } from './DemoConfig';
+
+export interface Demo {
+    config: DemoConfig;
+    /**
+     * The `<Component />` to render when your demo is active.
+     */
+    Component: React.Component;
+}

--- a/ui/src/tugboat/DemoConfig.ts
+++ b/ui/src/tugboat/DemoConfig.ts
@@ -1,0 +1,12 @@
+export interface DemoConfig {
+    group: string;
+    title: string;
+    order: number;
+    status: 'active' | 'hidden' | 'disabled';
+    /**
+     * The path used to access the demo. If it's not set we make a URL safe version of your
+     * title and use that instead.  For instance a title of "My Cool Demo" would be accessible
+     * at "/my-cool-demo".
+     */
+    path?: string;
+}

--- a/ui/src/tugboat/DemoGroup.ts
+++ b/ui/src/tugboat/DemoGroup.ts
@@ -1,0 +1,4 @@
+export interface DemoGroup {
+    label: string;
+    iconSrc: string;
+}

--- a/ui/src/tugboat/Demos.ts
+++ b/ui/src/tugboat/Demos.ts
@@ -1,0 +1,92 @@
+import slug from 'slug';
+
+import { Demo } from './Demo';
+import { DemoConfig } from './DemoConfig';
+
+/**
+ * TODO: Figure out how the mechanism will work when this code is distributed as it's own module.
+ *
+ * The code below uses a webpack specific extension of NodeJS's `require()`.
+ * See: https://webpack.js.org/api/module-methods/#requirecontext
+ *
+ * The `require.context()` function cannot be called in a nested function. It must be executed as
+ * the file is imported, since at build time it's mapped to the actual files on disk that it
+ * points to.
+ *
+ * It also appears that the path *must* be a hard-coded string, as an attempt to use an
+ * environment variable caused runtime errors.
+ *
+ * This means that if we use this approach users won't be able to override the location of
+ * their demos. They'll be forced to place them where this code is hard-coded to look.
+ *
+ * When we package this up as a separate NPM module we'd probably change `'../demos'`
+ * below to `'../../../src/demos'`, assuming the module is published as `@allenai/varnish`, which
+ * means it'll be installed at `node_modules/allenai/varnish` and that `node_modules` lives
+ * at the root of their application.
+ *
+ * It's worth noting that npm and yarn tolerate moving where `node_modules` is, in which case
+ * the above mentioned mechanism will stop working. Maybe that's ok, given it's *very* unlikely
+ * one of our users will do this.
+ *
+ */
+const ctx = require.context('../demos', true, /\/index\.ts$/);
+
+class ConfigError extends Error {
+    constructor(message: string) {
+        super(`Configuration Error: ${message}`);
+    }
+}
+
+class DemoList {
+    constructor(readonly demos: Demo[]) {}
+    all() {
+        return this.demos;
+    }
+
+    forGroup(label: string) {
+        return this.demos.filter((d) => d.config.group === label);
+    }
+}
+
+export const Demos = {
+    /**
+     * Returns a list of demos from `src/demos`. Each demo is defined by a directory there that
+     * contains an `index.ts` file which exports two things:
+     *
+     * 1. A symbol named `Main` that is a `React.Component` that's responsible for rendering the
+     *    user-interface.
+     *
+     * 2. A symbol named `config` that is an instance of `tugboat.DemoConfig`.
+     *
+     * If an `index.ts` file exists and doesn't export both of these symbols, a `ConfigError`
+     * is thrown.
+     */
+    load(): DemoList {
+        const demos: Demo[] = [];
+        for (const path of ctx.keys()) {
+            const d = ctx(path);
+            if (!('Main' in d)) {
+                throw new ConfigError(`${path}/Main.tsx doesn't exist.`);
+            }
+            if (!('config' in d)) {
+                throw new ConfigError(`${path}/config.ts doesn't exist`);
+            }
+
+            const config: DemoConfig = d.config;
+
+            // If there isn't a path, we generate a URL safe version of the title and use that.
+            if (!config.path) {
+                config.path = `/${slug(config.title, '-')}`;
+            }
+
+            // We prefix demos that are hidden from view with a prefix that makes them harder to
+            // find. Someone can still access them, they're just less likely to.
+            if (config.status === 'hidden') {
+                config.path = `/hidden${config.path}`;
+            }
+
+            demos.push({ Component: d.Main, config });
+        }
+        return new DemoList(demos.sort((a, b) => a.config.order - b.config.order));
+    },
+};

--- a/ui/src/tugboat/ModelCard.tsx
+++ b/ui/src/tugboat/ModelCard.tsx
@@ -1,3 +1,17 @@
+/**
+ * TODO: This code is tightly coupled to the AllenNLP Demo and should be moved out of
+ * `tugboat`:
+ *
+ *  1. The API endpoints we query are AllenNLP specific. We can't assert that `/api/info` or
+ *     `/api/:model` exists in the backend we're talking to. We only know this to be true
+ *     in this example.
+ *
+ *  2. The `ModelCard` includes all sorts of properties that are domain specific -- AllenNLP
+ *     models have properties like `registered_predictor_name` that won't exist in Vision,
+ *     Mosaic, etc. I like the idea of asserting some general set of properties that models
+ *     need to have to be featured via `tugboat`, but that's probably a pretty small, generic
+ *     set.
+ */
 import React from 'react';
 
 export interface ModelCard {

--- a/ui/src/tugboat/ModelCard.tsx
+++ b/ui/src/tugboat/ModelCard.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+export interface ModelCard {
+    id: string;
+    archive_file?: string;
+    citation?: string;
+    contact?: string;
+    contributed_by?: string;
+    date?: string;
+    description: string;
+    developed_by?: string;
+    display_name: string;
+    evaluation_dataset?: string;
+    model_type?: string;
+    paper?: string;
+    registered_model_name?: string;
+    registered_predictor_name?: string;
+    task_id?: string;
+    training_dataset?: string;
+    training_motivation?: string;
+    training_preprocessing?: string;
+    version?: string;
+}
+
+export interface ModelInfo {
+    id: string;
+    model_card_data?: ModelCard;
+}
+
+export function fetchModelInfo(id: string): Promise<ModelInfo> {
+    return fetch(`/api/${id}`).then((r) => r.json() as Promise<ModelInfo>);
+}
+
+export function useModels(...ids: string[]): ModelInfo[] | undefined {
+    const [models, setModels] = React.useState<ModelInfo[]>();
+    React.useEffect(() => {
+        Promise.all(ids.map(fetchModelInfo)).then(setModels);
+    }, ids);
+    return models;
+}

--- a/ui/src/tugboat/ModelCardModal.tsx
+++ b/ui/src/tugboat/ModelCardModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button, Modal } from 'antd';
 
-import { ModelCard } from './shared';
+import { ModelCard } from './ModelCard';
 import { Markdown } from './Markdown';
 
 interface Props {

--- a/ui/src/tugboat/ModelUsageModal.tsx
+++ b/ui/src/tugboat/ModelUsageModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button, Modal } from 'antd';
 
-import { ModelCard } from './shared';
+import { ModelCard } from './ModelCard';
 
 interface Props {
     model: ModelCard;

--- a/ui/src/tugboat/index.ts
+++ b/ui/src/tugboat/index.ts
@@ -18,3 +18,8 @@ export * from './shared';
 export * from './Markdown';
 export * from './ModelUsageModal';
 export * from './ModelCardModal';
+export * from './ModelCard';
+export * from './DemoConfig';
+export * from './Demos';
+export * from './Demo';
+export * from './DemoGroup';

--- a/ui/src/tugboat/shared.tsx
+++ b/ui/src/tugboat/shared.tsx
@@ -1,53 +1,6 @@
 import styled from 'styled-components';
 import { Button } from 'antd';
 
-export interface DemoConfig {
-    group: string;
-    title: string;
-    order: number;
-    status: 'active' | 'hidden' | 'disabled';
-    /* The path used to access your demo. If it's not set we make a URL safe version of your title and use that instead.
-    For instance a title of "My Cool Demo" would be accessible at "/my-cool-demo". */
-    path?: string;
-}
-
-export interface ModelCard {
-    id: string;
-    archive_file?: string;
-    citation?: string;
-    contact?: string;
-    contributed_by?: string;
-    date?: string;
-    description: string;
-    developed_by?: string;
-    display_name: string;
-    evaluation_dataset?: string;
-    model_type?: string;
-    paper?: string;
-    registered_model_name?: string;
-    registered_predictor_name?: string;
-    task_id?: string;
-    training_dataset?: string;
-    training_motivation?: string;
-    training_preprocessing?: string;
-    version?: string;
-}
-
-export interface ModelInfo {
-    id: string;
-    info: { model_card_data: ModelCard };
-}
-
-export const getModelCards = (data: ModelInfo[] | undefined, ids: string[]): ModelCard[] => {
-    const ret = (data || [])
-        .filter((m) => m.id && m.info && m.info.model_card_data && ids.includes(m.id))
-        .map((m) => {
-            m.info.model_card_data.id = m.id; // todo: remove this once we have real data
-            return m.info.model_card_data;
-        });
-    return ret;
-};
-
 export const Title = styled.h3`
     margin-bottom: ${({ theme }) => theme.spacing.xxs};
 `;

--- a/ui/src/tugboat/shared.tsx
+++ b/ui/src/tugboat/shared.tsx
@@ -1,5 +1,7 @@
+import React from 'react';
 import styled from 'styled-components';
-import { Button } from 'antd';
+import { Button, Spin } from 'antd';
+import { LoadingOutlined } from '@ant-design/icons';
 
 export const Title = styled.h3`
     margin-bottom: ${({ theme }) => theme.spacing.xxs};
@@ -15,3 +17,9 @@ export const RunButton = styled(Button).attrs({
     margin-top: ${({ theme }) => theme.spacing.sm};
     margin-right: ${({ theme }) => theme.spacing.md};
 `;
+
+const LoadingIcon = styled(LoadingOutlined).attrs(() => ({ spin: true }))`
+    font-size: 2rem;
+`;
+
+export const Loading = () => <Spin indicator={<LoadingIcon />} />;

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1194,6 +1194,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
+"@types/webpack-env@^1.15.3":
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.15.3.tgz#fb602cd4c2f0b7c0fb857e922075fdf677d25d84"
+  integrity sha512-5oiXqR7kwDGZ6+gmzIO2lTC+QsriNuQXZDWNYRV3l2XRN/zmPgnC21DLSx2D05zvD8vnXW6qUg7JnXZ4I6qLVQ==
+
 "@types/webpack-sources@*":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-2.0.0.tgz#08216ab9be2be2e1499beaebc4d469cec81e82a7"


### PR DESCRIPTION
This reworks the way we resolve the list of demos in a few ways:

1. Rather than importing the component and it's config from `Main.tsx`,
   we use the `index.ts` file for this. This is a pattern that's already
   well established in the community to it feels right to do. Note, if
   this PR is accepted I can rename all instances of `demoConfig`
   to `config`. I'll do this before merging if we like the direction.

2. Factor the code for loading demos into code that's clearly separated
   from the AllenNLP code. This way we have more of an idea of how
   an individual demo might use it.

3. Clearly document how things work and where the warts are. Knowledge
   is power.

4. Moved a few things out of `shared.tsx` into their own files. I like
   keeping the UI specific code and the models separate. In this case
   it felt like we were combining a few too many concerns into one
   file. Let me know what you think.

5. Wrote a hook for the model card info bit, and refactored the approach
   so it queries the info for the specific models that are requested
   rather than querying them all. In this case this reduces the size of
   the response from 32k to 7k, which seems worth it. There's of course
   overhead for additional connections, though the requests can and
   are processed in parallel -- my gut intuition is this will be faster,
   but I could be wrong. That said I like that it gives us a little
   flexibility, in that if we only need one model we only request it's
   data, rather than fetching them all.
