### PR TITLE
Add a new endpoint for listing taskcards.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,10 @@ jobs:
           "roberta_snli",
           "semantic_role_labeling",
           "transformer_qa",
-          "vilbert_vqa",
+          # See: https://github.com/allenai/allennlp-demo/pull/645
+          # "vilbert_vqa",
           "wikitables_parser",
+          "tasks"
         ]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,7 @@ jobs:
           "roberta_snli",
           "semantic_role_labeling",
           "transformer_qa",
-          # See: https://github.com/allenai/allennlp-demo/pull/645
-          # "vilbert_vqa",
+          "vilbert_vqa",
           "wikitables_parser",
           "tasks"
         ]

--- a/api/allennlp_demo/info/api.py
+++ b/api/allennlp_demo/info/api.py
@@ -114,8 +114,7 @@ class InfoService(flask.Flask):
 
             # Now join the info HTTP requests concurrently.
             for endpoint, info_resp in zip(
-                endpoints,
-                grequests.map(info_requests, exception_handler=self.exception_handler),
+                endpoints, grequests.map(info_requests, exception_handler=self.exception_handler),
             ):
                 if not info_resp:
                     continue

--- a/api/allennlp_demo/info/api.py
+++ b/api/allennlp_demo/info/api.py
@@ -114,7 +114,8 @@ class InfoService(flask.Flask):
 
             # Now join the info HTTP requests concurrently.
             for endpoint, info_resp in zip(
-                endpoints, grequests.map(info_requests, exception_handler=self.exception_handler),
+                endpoints,
+                grequests.map(info_requests, exception_handler=self.exception_handler),
             ):
                 if not info_resp:
                     continue

--- a/api/allennlp_demo/next_token_lm/test_api.py
+++ b/api/allennlp_demo/next_token_lm/test_api.py
@@ -11,10 +11,7 @@ class TestNextTokenLmModelEndpoint(ModelEndpointTestCase):
     @pytest.mark.parametrize(
         "input_text, result",
         [
-            (
-                "AllenNLP is one  of  the  most  popular ",
-                "AllenNLP is one of the most popular",
-            ),
+            ("AllenNLP is one  of  the  most  popular ", "AllenNLP is one of the most popular",),
             ("AllenNLP is a framework.\n", "AllenNLP is a framework.\n"),
             ("AllenNLP is a framework.\t", "AllenNLP is a framework."),
         ],

--- a/api/allennlp_demo/next_token_lm/test_api.py
+++ b/api/allennlp_demo/next_token_lm/test_api.py
@@ -11,7 +11,10 @@ class TestNextTokenLmModelEndpoint(ModelEndpointTestCase):
     @pytest.mark.parametrize(
         "input_text, result",
         [
-            ("AllenNLP is one  of  the  most  popular ", "AllenNLP is one of the most popular",),
+            (
+                "AllenNLP is one  of  the  most  popular ",
+                "AllenNLP is one of the most popular",
+            ),
             ("AllenNLP is a framework.\n", "AllenNLP is a framework.\n"),
             ("AllenNLP is a framework.\t", "AllenNLP is a framework."),
         ],

--- a/api/allennlp_demo/tasks/api.py
+++ b/api/allennlp_demo/tasks/api.py
@@ -21,7 +21,7 @@ class TasksService(flask.Flask):
         def info():
             return flask.jsonify({"id": "tasks", "allennlp_models": VERSION})
 
-        @self.route("/tasks", methods=["GET"])
+        @self.route("/all", methods=["GET"])
         def tasks():
             tasks = get_tasks()
             return flask.jsonify(tasks)

--- a/api/allennlp_demo/tasks/api.py
+++ b/api/allennlp_demo/tasks/api.py
@@ -1,12 +1,12 @@
 """
 The tasks endpoint lists all demo tasks and some info about them.
 """
-import logging  # noqa: E402
-import flask  # noqa: E402
+import logging
+import flask
 from werkzeug.exceptions import NotFound
 
-from allennlp_demo.common.logs import configure_logging  # noqa: E402
-from allennlp_models.pretrained import get_tasks  # noqa: E402
+from allennlp_demo.common.logs import configure_logging
+from allennlp_models.pretrained import get_tasks
 from allennlp_models.version import VERSION
 
 logger = logging.getLogger(__name__)

--- a/api/allennlp_demo/tasks/api.py
+++ b/api/allennlp_demo/tasks/api.py
@@ -1,0 +1,30 @@
+"""
+The tasks endpoint lists all demo tasks and some info about them.
+"""
+import logging  # noqa: E402
+import flask  # noqa: E402
+
+from allennlp_demo.common.logs import configure_logging  # noqa: E402
+from allennlp_models.pretrained import get_tasks # noqa: E402
+from allennlp_models.version import VERSION
+
+logger = logging.getLogger(__name__)
+
+class TasksService(flask.Flask):
+    def __init__(self, name: str = "info"):
+        super().__init__(name)
+        configure_logging(self)
+
+        @self.route("/", methods=["GET"])
+        def info():
+            return flask.jsonify({ "id": "tasks", "allennlp_models": VERSION })
+
+        @self.route("/tasks", methods=["GET"])
+        def tasks():
+            tasks = get_tasks()
+            print(tasks)
+            return flask.jsonify(tasks)
+
+if __name__ == "__main__":
+    app = TasksService()
+    app.run(host="0.0.0.0", port=8000)

--- a/api/allennlp_demo/tasks/api.py
+++ b/api/allennlp_demo/tasks/api.py
@@ -5,10 +5,8 @@ import logging  # noqa: E402
 import flask  # noqa: E402
 from werkzeug.exceptions import NotFound
 
-from typing import List, Dict  # noqa: E402
 from allennlp_demo.common.logs import configure_logging  # noqa: E402
 from allennlp_models.pretrained import get_tasks  # noqa: E402
-from allennlp_models.common.task_card import TaskCard
 from allennlp_models.version import VERSION
 
 logger = logging.getLogger(__name__)

--- a/api/allennlp_demo/tasks/api.py
+++ b/api/allennlp_demo/tasks/api.py
@@ -5,13 +5,14 @@ import logging  # noqa: E402
 import flask  # noqa: E402
 from werkzeug.exceptions import NotFound
 
-from typing import List, Dict # noqa: E402
+from typing import List, Dict  # noqa: E402
 from allennlp_demo.common.logs import configure_logging  # noqa: E402
-from allennlp_models.pretrained import get_tasks # noqa: E402
+from allennlp_models.pretrained import get_tasks  # noqa: E402
 from allennlp_models.common.task_card import TaskCard
 from allennlp_models.version import VERSION
 
 logger = logging.getLogger(__name__)
+
 
 class TasksService(flask.Flask):
     def __init__(self, name: str = "info"):
@@ -20,7 +21,7 @@ class TasksService(flask.Flask):
 
         @self.route("/", methods=["GET"])
         def info():
-            return flask.jsonify({ "id": "tasks", "allennlp_models": VERSION })
+            return flask.jsonify({"id": "tasks", "allennlp_models": VERSION})
 
         @self.route("/tasks", methods=["GET"])
         def tasks():
@@ -33,6 +34,7 @@ class TasksService(flask.Flask):
                 if tid == task_id:
                     return flask.jsonify(task)
             raise NotFound(f"No task card with {task_id} found.")
+
 
 if __name__ == "__main__":
     app = TasksService()

--- a/api/allennlp_demo/tasks/api.py
+++ b/api/allennlp_demo/tasks/api.py
@@ -3,9 +3,12 @@ The tasks endpoint lists all demo tasks and some info about them.
 """
 import logging  # noqa: E402
 import flask  # noqa: E402
+from werkzeug.exceptions import NotFound
 
+from typing import List, Dict # noqa: E402
 from allennlp_demo.common.logs import configure_logging  # noqa: E402
 from allennlp_models.pretrained import get_tasks # noqa: E402
+from allennlp_models.common.task_card import TaskCard
 from allennlp_models.version import VERSION
 
 logger = logging.getLogger(__name__)
@@ -22,8 +25,14 @@ class TasksService(flask.Flask):
         @self.route("/tasks", methods=["GET"])
         def tasks():
             tasks = get_tasks()
-            print(tasks)
             return flask.jsonify(tasks)
+
+        @self.route("/task/<string:task_id>", methods=["GET"])
+        def task(task_id: str):
+            for (tid, task) in get_tasks().items():
+                if tid == task_id:
+                    return flask.jsonify(task)
+            raise NotFound(f"No task card with {task_id} found.")
 
 if __name__ == "__main__":
     app = TasksService()

--- a/api/allennlp_demo/tasks/test_api.py
+++ b/api/allennlp_demo/tasks/test_api.py
@@ -1,0 +1,25 @@
+from .api import TasksService
+
+def test_tasks():
+    app = TasksService()
+    client = app.test_client()
+    response = client.get("/tasks")
+    assert response.status_code == 200
+    assert len(response.json.items()) > 0
+
+def test_task():
+    app = TasksService()
+    client = app.test_client()
+    response = client.get("/task/rc")
+    assert response.status_code == 200
+    assert len(response.json.items()) > 0
+    assert response.json["name" ] == "Reading Comprehension"
+    assert response.json["id"] == "rc"
+    assert len(response.json["examples"].items()) > 0
+
+def task_not_found():
+    app = TasksService()
+    client = app.test_client()
+    response = client.get("/task/✨")
+    assert response.status_code == 404
+

--- a/api/allennlp_demo/tasks/test_api.py
+++ b/api/allennlp_demo/tasks/test_api.py
@@ -4,7 +4,7 @@ from .api import TasksService
 def test_tasks():
     app = TasksService()
     client = app.test_client()
-    response = client.get("/tasks")
+    response = client.get("/all")
     assert response.status_code == 200
     assert len(response.json.items()) > 0
 

--- a/api/allennlp_demo/tasks/test_api.py
+++ b/api/allennlp_demo/tasks/test_api.py
@@ -1,5 +1,6 @@
 from .api import TasksService
 
+
 def test_tasks():
     app = TasksService()
     client = app.test_client()
@@ -7,19 +8,20 @@ def test_tasks():
     assert response.status_code == 200
     assert len(response.json.items()) > 0
 
+
 def test_task():
     app = TasksService()
     client = app.test_client()
     response = client.get("/task/rc")
     assert response.status_code == 200
     assert len(response.json.items()) > 0
-    assert response.json["name" ] == "Reading Comprehension"
+    assert response.json["name"] == "Reading Comprehension"
     assert response.json["id"] == "rc"
     assert len(response.json["examples"].items()) > 0
+
 
 def task_not_found():
     app = TasksService()
     client = app.test_client()
     response = client.get("/task/✨")
     assert response.status_code == 404
-

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,5 +1,5 @@
-allennlp==1.2.2
-allennlp-models==1.2.2
+allennlp==1.3.0
+allennlp-models==1.3.0
 allennlp-semparse==0.0.2
 Flask==1.1.2
 pytest==6.1.2

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,5 +1,5 @@
-allennlp==1.2.1
-allennlp-models==1.2.1
+allennlp==1.2.2
+allennlp-models==1.2.2
 allennlp-semparse==0.0.2
 Flask==1.1.2
 pytest==6.1.2

--- a/dev/check_models_ci.py
+++ b/dev/check_models_ci.py
@@ -10,6 +10,7 @@ from typing import Iterable
 WORKFLOW_FILE_PATH = ".github/workflows/ci.yml"
 logging.basicConfig()
 
+# Sometimes models are broken, so we allow their tests to be temporarily omitted.
 SKIPPED = set([ "vilbert_vqa" ])
 
 # These are endpoints we have tests for that aren't models. This script skips these.

--- a/dev/check_models_ci.py
+++ b/dev/check_models_ci.py
@@ -10,9 +10,6 @@ from typing import Iterable
 WORKFLOW_FILE_PATH = ".github/workflows/ci.yml"
 logging.basicConfig()
 
-# Sometimes models are broken, so we allow their tests to be temporarily omitted.
-SKIPPED = set([ "vilbert_vqa" ])
-
 # These are endpoints we have tests for that aren't models. This script skips these.
 NON_MODEL_ENDPOINTS = set([ "tasks" ])
 
@@ -25,12 +22,6 @@ def find_models() -> Iterable[str]:
             continue
         config_path = os.path.join(path, "model.json")
         if not os.path.isfile(config_path):
-            continue
-        if name in SKIPPED:
-            logging.getLogger().warning(
-                f"{name} is being skipped, probably because it's non-functional for one reason"
-                f"or another. If you think it's being skipped and shouldn't be, edit {__file__}."
-            )
             continue
         yield name
 


### PR DESCRIPTION
This adds two new endpoints:
- `/api/tasks ~> Dict[str, TaskCard]`. This is effectively a HTTP wrapper for `get_tasks()`.
- `/api/task/:task_id ~> Optional[TaskCard]`. This fetches a single task card by it's id.

We plan on using this in TugBoat (the new demo UI architecture) for powering the examples
that we display in the UI.