### PR TITLE
Pass the model too.

### DIFF
--- a/ui/src/demos/reading-comprehension/Main.tsx
+++ b/ui/src/demos/reading-comprehension/Main.tsx
@@ -36,8 +36,10 @@ export const Main = () => (
                     <Submit>Run Model</Submit>
                 </Fields>
                 <Output>
-                    {({ output, input }) => (
+                    {({ model, output, input }) => (
                         <>
+                            <h4>Model:</h4>
+                            <p>{model.card.display_name}</p>
                             <h4>Input:</h4>
                             <PrettyPrintedJSON json={input} />
                             <h4>Output:</h4>

--- a/ui/src/demos/reading-comprehension/Main.tsx
+++ b/ui/src/demos/reading-comprehension/Main.tsx
@@ -35,7 +35,7 @@ export const Main = () => (
                     <Question />
                     <Submit>Run Model</Submit>
                 </Fields>
-                <Output>
+                <Output<Input, Prediction>>
                     {({ model, output, input }) => (
                         <>
                             <h4>Model:</h4>

--- a/ui/src/tugboat/components/form/Form.tsx
+++ b/ui/src/tugboat/components/form/Form.tsx
@@ -117,7 +117,13 @@ export const Form = <I, O>(props: Props) => {
             <Divider />
             {input ? (
                 <Promised<I, O> input={input} fetch={fetchPredictions}>
-                    {({ input, output }) => React.cloneElement(secondChild, { output, input })}
+                    {({ input, output }) =>
+                        React.cloneElement(secondChild, {
+                            model: models.selectedModel,
+                            input,
+                            output,
+                        })
+                    }
                 </Promised>
             ) : null}
         </>

--- a/ui/src/tugboat/components/form/Output.tsx
+++ b/ui/src/tugboat/components/form/Output.tsx
@@ -1,7 +1,16 @@
 import React from 'react';
 
-interface Props<O, I> {
-    children: (io: { input: I; output: O }) => React.ReactNode | JSX.Element;
+import { Model } from '../../lib/Model';
+
+interface Result<I, O> {
+    model: Model;
+    input: I;
+    output: O;
+}
+
+interface Props<I, O> {
+    children: (result: Result<I, O>) => React.ReactNode | JSX.Element;
+    model?: Model;
     output?: O;
     input?: I;
 }
@@ -10,15 +19,15 @@ interface Props<O, I> {
  * A component to house the output that's displayed after a user submits a `<Form />`.
  * Your demo's visualizations should be rendered as children of this component.
  *
- * The component expects one child that's a function. The function is provided the output,
- * and the associated input.
+ * The component expects one child that's a function. The function is called with a single
+ * argument which has the selected `model`, the form `input` and the resulting `output`.
  *
  * @example:
- *  <Output>{ (predictions, input) => (
- *      <PredictedAnswer answer={predictions.best_span} />
- *      <LossGraph loss={predictions.loss} />
+ *  <Output>{ ({ model, input, output }) => (
+ *      <PredictedAnswer answer={output.best_span} />
+ *      <LossGraph loss={output.loss} />
  *  )}</Output>
  */
-export const Output = <O, I>({ children, output, input }: Props<O, I>) => (
-    <>{output && input ? children({ input, output }) : null}</>
+export const Output = <I, O>({ children, model, input, output }: Props<I, O>) => (
+    <>{model && input && output ? children({ model, input, output }) : null}</>
 );


### PR DESCRIPTION
This makes the selected model accessible to the `<Output />`'s
render callback. This lets people use it in the top-level
demo to change the output that's displayed.