### PR TITLE
Make sure the model info includes the loaded attackers and interpreters.

### DIFF
--- a/api/allennlp_demo/common/config.py
+++ b/api/allennlp_demo/common/config.py
@@ -1,5 +1,5 @@
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, Any, Optional, List
 
 from allennlp.predictors import Predictor
@@ -44,12 +44,12 @@ class Model:
     This is ignored if `pretrained_model_id` is given.
     """
 
-    attackers: Optional[List[str]] = None
+    attackers: List[str] = field(default_factory=lambda: VALID_ATTACKERS)
     """
     List of valid attackers to use.
     """
 
-    interpreters: Optional[List[str]] = None
+    interpreters: List[str] = field(default_factory=lambda: VALID_INTERPRETERS)
     """
     List of valid interpreters to use.
     """
@@ -78,9 +78,9 @@ class Model:
             out = cls(**raw)
 
         # Do some validation.
-        for attacker in out.attackers or []:
+        for attacker in out.attackers:
             assert attacker in VALID_ATTACKERS, f"invalid attacker {attacker}"
-        for interpreter in out.interpreters or []:
+        for interpreter in out.interpreters:
             assert interpreter in VALID_INTERPRETERS, f"invalid interpreter {interpreter}"
         if out.use_old_load_method:
             assert out.pretrained_model_id is None

--- a/api/allennlp_demo/common/config.py
+++ b/api/allennlp_demo/common/config.py
@@ -5,8 +5,8 @@ from typing import Dict, Any, Optional, List
 from allennlp.predictors import Predictor
 
 
-VALID_ATTACKERS = ("hotflip", "input_reduction")
-VALID_INTERPRETERS = ("simple_gradient", "smooth_gradient", "integrated_gradient")
+VALID_ATTACKERS = ["hotflip", "input_reduction"]
+VALID_INTERPRETERS = ["simple_gradient", "smooth_gradient", "integrated_gradient"]
 
 
 @dataclass(frozen=True)

--- a/api/allennlp_demo/common/http.py
+++ b/api/allennlp_demo/common/http.py
@@ -119,17 +119,12 @@ class ModelEndpoint:
         `/interpret/:id` will invoke the interpreter with the provided `:id`. Override this method
         to add or remove interpreters.
         """
-        interpreter_names = (
-            config.VALID_INTERPRETERS
-            if self.model.interpreters is None
-            else self.model.interpreters
-        )
         interpreters: Dict[str, SaliencyInterpreter] = {}
-        if "simple_gradient" in interpreter_names:
+        if "simple_gradient" in self.model.interpreters:
             interpreters["simple_gradient"] = SimpleGradient(self.predictor)
-        if "smooth_gradient" in interpreter_names:
+        if "smooth_gradient" in self.model.interpreters:
             interpreters["smooth_gradient"] = SmoothGradient(self.predictor)
-        if "integrated_gradient" in interpreter_names:
+        if "integrated_gradient" in self.model.interpreters:
             interpreters["integrated_gradient"] = IntegratedGradient(self.predictor)
         return interpreters
 
@@ -139,15 +134,12 @@ class ModelEndpoint:
         will invoke the attacker with the provided `:id`. Override this method to add or remove
         attackers.
         """
-        attacker_names = (
-            config.VALID_ATTACKERS if self.model.attackers is None else self.model.attackers
-        )
         attackers: Dict[str, Attacker] = {}
-        if "hotflip" in attacker_names:
+        if "hotflip" in self.model.attackers:
             hotflip = Hotflip(self.predictor)
             hotflip.initialize()
             attackers["hotflip"] = hotflip
-        if "input_reduction" in attacker_names:
+        if "input_reduction" in self.model.attackers:
             attackers["input_reduction"] = InputReduction(self.predictor)
         return attackers
 


### PR DESCRIPTION
Right now the `/info` route for each model returns `null` for the
`attackers` and `interpreters` if they're not specified. For
instance:

```
❯ curl -s https://demo.allennlp.org/api/bidaf | jq 'del(.model_card_data)'
{
  "allennlp": "1.3.0",
  "archive_file": "https://storage.googleapis.com/allennlp-public-models/bidaf-model-2020.03.19.tar.gz",
  "attackers": null,
  "id": "bidaf",
  "interpreters": null,
  "overrides": null,
  "predictor_name": "reading_comprehension",
  "pretrained_model_id": "rc-bidaf",
  "use_old_load_method": false
}
```

This is incorrect, as when they're not specified, the default
interpreters and attackers are loaded instead. This PR fixes that
by assigning these fields default values.

```
❯ curl -s http://localhost:8080/api/bidaf/ | jq 'del(.model_card_data)'
{
  "allennlp": "1.3.0",
  "archive_file": "https://storage.googleapis.com/allennlp-public-models/bidaf-model-2020.03.19.tar.gz",
  "attackers": [
    "hotflip",
    "input_reduction"
  ],
  "id": "bidaf",
  "interpreters": [
    "simple_gradient",
    "smooth_gradient",
    "integrated_gradient"
  ],
  "overrides": null,
  "predictor_name": "reading_comprehension",
  "pretrained_model_id": "rc-bidaf",
  "use_old_load_method": false
}
```

I also tested a model that overrides the field by assigning both
fields to an empty list:

```
❯ curl -s http://localhost:8080/api/transformer_qa/ | jq 'del(.model_card_data)'
{
  "allennlp": "1.3.0",
  "archive_file": "https://storage.googleapis.com/allennlp-public-models/transformer-qa-2020-10-03.tar.gz",
  "attackers": [],
  "id": "transformer-qa",
  "interpreters": [],
  "overrides": null,
  "predictor_name": "transformer_qa",
  "pretrained_model_id": "rc-transformer-qa",
  "use_old_load_method": false
}
```

This change will allow us to use this in the front-end to toggle
attackers on and off on a model basis. This will allow us to
resolve issues like [this one](https://github.com/allenai/allennlp-demo/issues/679)
in a dyanmic way, rather than hard-coding things to be on or off
on a per-demo basis.