### PR TITLE
Add support for model attacks.

### DIFF
--- a/ui/src/components/Attack.tsx
+++ b/ui/src/components/Attack.tsx
@@ -25,9 +25,10 @@ interface Props<I, O> {
     target: keyof I & string;
     gradient: GradientInputField;
     children: (io: { input: AttackRequest<I>; output: O }) => React.ReactNode | JSX.Element;
+    action: string;
 }
 
-export const Attack = <I, O>({ type, input, children, target, gradient }: Props<I, O>) => {
+export const Attack = <I, O>({ type, input, children, target, gradient, action }: Props<I, O>) => {
     const [submitted, setSubmitted] = React.useState(false);
 
     const ctx = React.useContext(Models);
@@ -53,7 +54,7 @@ export const Attack = <I, O>({ type, input, children, target, gradient }: Props<
     return (
         <>
             <Button type="primary" onClick={() => setSubmitted(true)}>
-                Submit Attack
+                {action}
             </Button>
             {submitted ? (
                 <Promised input={attackInput} fetch={fetchAttackOutput}>

--- a/ui/src/components/Attack.tsx
+++ b/ui/src/components/Attack.tsx
@@ -41,13 +41,13 @@ export const Attack = <I, O>({ type, input, children, target, gradient, action }
         grad_input_field: gradient,
         inputs: input,
     };
-    const fetchAttackOutput = (i?: AttackRequest<I>) => {
-        if (!i) {
+    const fetchAttackOutput = (attack?: AttackRequest<I>) => {
+        if (!attack) {
             throw new EmptyAttackRequestError();
         }
         return fetch(`/api/${model.id}/attack/${type}`, {
             method: 'POST',
-            body: JSON.stringify(i),
+            body: JSON.stringify(attack),
         }).then((r) => r.json());
     };
 

--- a/ui/src/components/Attack.tsx
+++ b/ui/src/components/Attack.tsx
@@ -25,10 +25,10 @@ interface Props<I, O> {
     target: keyof I & string;
     gradient: GradientInputField;
     children: (io: { input: AttackRequest<I>; output: O }) => React.ReactNode | JSX.Element;
-    action: string;
+    label: string;
 }
 
-export const Attack = <I, O>({ type, input, children, target, gradient, action }: Props<I, O>) => {
+export const Attack = <I, O>({ type, input, children, target, gradient, label }: Props<I, O>) => {
     const [submitted, setSubmitted] = React.useState(false);
 
     const ctx = React.useContext(Models);
@@ -54,7 +54,7 @@ export const Attack = <I, O>({ type, input, children, target, gradient, action }
     return (
         <>
             <Button type="primary" onClick={() => setSubmitted(true)}>
-                {action}
+                {label}
             </Button>
             {submitted ? (
                 <Promised input={attackInput} fetch={fetchAttackOutput}>

--- a/ui/src/components/Attack.tsx
+++ b/ui/src/components/Attack.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Button } from 'antd';
+
+import { Promised } from '../tugboat/components';
+import { Models } from '../tugboat/context';
+import { NoSelectedModelError } from '../tugboat/error';
+
+import { AttackType, GradientInputField } from '../lib';
+
+class EmptyAttackRequestError extends Error {
+    constructor() {
+        super('An attack request cannot be empty.');
+    }
+}
+
+interface AttackRequest<I> {
+    input_field_to_attack: keyof I & string;
+    grad_input_field: GradientInputField;
+    inputs: I;
+}
+
+interface Props<I, O> {
+    input: I;
+    type: AttackType;
+    target: keyof I & string;
+    gradient: GradientInputField;
+    children: (io: { input: AttackRequest<I>; output: O }) => React.ReactNode | JSX.Element;
+}
+
+export const Attack = <I, O>({ type, input, children, target, gradient }: Props<I, O>) => {
+    const [submitted, setSubmitted] = React.useState(false);
+
+    const ctx = React.useContext(Models);
+    if (!ctx.selectedModel) {
+        throw new NoSelectedModelError();
+    }
+    const model = ctx.selectedModel;
+    const attackInput: AttackRequest<I> = {
+        input_field_to_attack: target,
+        grad_input_field: gradient,
+        inputs: input,
+    };
+    const fetchAttackOutput = (i?: AttackRequest<I>) => {
+        if (!i) {
+            throw new EmptyAttackRequestError();
+        }
+        return fetch(`/api/${model.id}/attack/${type}`, {
+            method: 'POST',
+            body: JSON.stringify(i),
+        }).then((r) => r.json());
+    };
+
+    return (
+        <>
+            <Button type="primary" onClick={() => setSubmitted(true)}>
+                Submit Attack
+            </Button>
+            {submitted ? (
+                <Promised input={attackInput} fetch={fetchAttackOutput}>
+                    {children}
+                </Promised>
+            ) : null}
+        </>
+    );
+};

--- a/ui/src/components/Attacks.tsx
+++ b/ui/src/components/Attacks.tsx
@@ -14,7 +14,7 @@ interface Props<I> {
     target: keyof I & string;
 }
 
-export const Attacks = <I,>({ model, input, target }: Props<I>) => {
+export const Attacks = <I, O>({ model, input, target }: Props<I>) => {
     const modelInfoList = React.useContext(ModelInfoList);
 
     const info = modelInfoList.find((i) => i.id === model.id);
@@ -29,26 +29,24 @@ export const Attacks = <I,>({ model, input, target }: Props<I>) => {
             <Collapse>
                 {supportedAttackTypes.has(AttackType.InputReduction) ? (
                     <Collapse.Panel key={AttackType.InputReduction} header="Input Reduction">
-                        {/* TODO: Replace `any` with a better type once we know what it is. */}
-                        <Attack<I, any>
+                        <Attack<I, O>
                             type={AttackType.InputReduction}
                             target={target}
                             gradient={GradientInputField.Input2}
                             input={input}
-                            action="Reduce Input">
+                            label="Reduce Input">
                             {({ output }) => <PrettyPrintedJSON json={output} />}
                         </Attack>
                     </Collapse.Panel>
                 ) : null}
                 {supportedAttackTypes.has(AttackType.HotFlip) ? (
                     <Collapse.Panel key={AttackType.HotFlip} header="HotFlip">
-                        {/* TODO: Replace `any` with a better type once we know what it is. */}
-                        <Attack<I, any>
+                        <Attack<I, O>
                             type={AttackType.HotFlip}
                             target={target}
                             gradient={GradientInputField.Input2}
                             input={input}
-                            action="Flip Words">
+                            label="Flip Words">
                             {({ output }) => <PrettyPrintedJSON json={output} />}
                         </Attack>
                     </Collapse.Panel>

--- a/ui/src/components/Attacks.tsx
+++ b/ui/src/components/Attacks.tsx
@@ -1,25 +1,20 @@
 import React from 'react';
 import { Collapse } from 'antd';
 
-import { Output, PrettyPrintedJSON } from '../../tugboat/components';
-import { Model } from '../../tugboat/lib';
+import { Output, PrettyPrintedJSON } from '../tugboat/components';
+import { Model } from '../tugboat/lib';
 
-import { Attack } from '../../components';
-import { ModelInfoList } from '../../context';
-import { AttackType, GradientInputField } from '../../lib';
-import { Input } from './types';
+import { Attack } from './Attack';
+import { ModelInfoList } from '../context';
+import { AttackType, GradientInputField } from '../lib';
 
-interface Props {
+interface Props<I> {
     model: Model;
-    input: Input;
+    input: I;
+    target: keyof I & string;
 }
 
-/**
- * TODO: Bits and pieces of this can and should move into `../../components` so that other demos
- * that support attacks can use this code. The bit we need to figure out before doing so it
- * what the output looks like, and how generic it actually is.
- */
-export const Attacks = ({ model, input }: Props) => {
+export const Attacks = <I,>({ model, input, target }: Props<I>) => {
     const modelInfoList = React.useContext(ModelInfoList);
 
     const info = modelInfoList.find((i) => i.id === model.id);
@@ -35,11 +30,12 @@ export const Attacks = ({ model, input }: Props) => {
                 {supportedAttackTypes.has(AttackType.InputReduction) ? (
                     <Collapse.Panel key={AttackType.InputReduction} header="Input Reduction">
                         {/* TODO: Replace `any` with a better type once we know what it is. */}
-                        <Attack<Input, any>
+                        <Attack<I, any>
                             type={AttackType.InputReduction}
-                            target="question"
+                            target={target}
                             gradient={GradientInputField.Input2}
-                            input={input}>
+                            input={input}
+                            action="Reduce Input">
                             {({ output }) => <PrettyPrintedJSON json={output} />}
                         </Attack>
                     </Collapse.Panel>
@@ -47,11 +43,12 @@ export const Attacks = ({ model, input }: Props) => {
                 {supportedAttackTypes.has(AttackType.HotFlip) ? (
                     <Collapse.Panel key={AttackType.HotFlip} header="HotFlip">
                         {/* TODO: Replace `any` with a better type once we know what it is. */}
-                        <Attack<Input, any>
+                        <Attack<I, any>
                             type={AttackType.HotFlip}
-                            target="question"
+                            target={target}
                             gradient={GradientInputField.Input2}
-                            input={input}>
+                            input={input}
+                            action="Flip Words">
                             {({ output }) => <PrettyPrintedJSON json={output} />}
                         </Attack>
                     </Collapse.Panel>

--- a/ui/src/components/Interpret.tsx
+++ b/ui/src/components/Interpret.tsx
@@ -1,13 +1,23 @@
 import React from 'react';
-import { Input } from 'antd';
+import { Button } from 'antd';
 
-import { Form, Field, Fields, Output, Result, Submit } from '../tugboat/components';
+import { Promised } from '../tugboat/components';
+import { Models } from '../tugboat/context';
+import { NoSelectedModelError } from '../tugboat/error';
+
+import { InterpreterId } from '../lib';
+
+class EmptyInterpretRequestError extends Error {
+    constructor() {
+        super('An interpret request cannot be empty.');
+    }
+}
 
 interface Props<I, O> {
+    interpreter: InterpreterId;
     input: I;
     description?: React.ReactNode;
-    interpreter: string;
-    children: (interpretation: Result<I, O>) => React.ReactNode | JSX.Element;
+    children: (io: { input: I; output: O }) => React.ReactNode | JSX.Element;
 }
 
 export const Interpret = <I extends { [k: string]: any }, O>({
@@ -15,19 +25,35 @@ export const Interpret = <I extends { [k: string]: any }, O>({
     input,
     description,
     children,
-}: Props<I, O>) => (
-    <>
-        {description}
-        <Form<I, O> action={(modelId) => `/api/${modelId}/interpret/${interpreter}`}>
-            <Fields>
-                {Object.keys(input).map((fieldName) => (
-                    <Field key={fieldName} name={fieldName} hidden>
-                        <Input value={input[fieldName]} />
-                    </Field>
-                ))}
-                <Submit>Interpret Prediction</Submit>
-            </Fields>
-            <Output>{children}</Output>
-        </Form>
-    </>
-);
+}: Props<I, O>) => {
+    const [submitted, setSubmitted] = React.useState(false);
+
+    const ctx = React.useContext(Models);
+    if (!ctx.selectedModel) {
+        throw new NoSelectedModelError();
+    }
+    const model = ctx.selectedModel;
+    const fetchInterpretOutput = (body?: I) => {
+        if (!body) {
+            throw new EmptyInterpretRequestError();
+        }
+        return fetch(`/api/${model.id}/interpret/${interpreter}`, {
+            method: 'POST',
+            body: JSON.stringify(body),
+        }).then((r) => r.json());
+    };
+
+    return (
+        <>
+            {description}
+            <Button type="primary" onClick={() => setSubmitted(true)}>
+                Interpret Prediction
+            </Button>
+            {submitted ? (
+                <Promised input={input} fetch={fetchInterpretOutput}>
+                    {children}
+                </Promised>
+            ) : null}
+        </>
+    );
+};

--- a/ui/src/components/ModelUsage.tsx
+++ b/ui/src/components/ModelUsage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { Models } from '../tugboat/context';
-import { NoSelectedModel } from '../tugboat/error';
+import { NoSelectedModelError } from '../tugboat/error';
 import { SyntaxHighlight } from '../tugboat/components/SyntaxHighlight';
 
 interface Props {
@@ -21,7 +21,7 @@ interface Props {
 export const ModelUsage = (props: Props) => {
     const models = React.useContext(Models);
     if (!models.selectedModel) {
-        throw new NoSelectedModel();
+        throw new NoSelectedModelError();
     }
 
     return (

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -5,3 +5,4 @@ export * from './Interpret';
 export * from './Interpreters';
 export * from './TaskCards';
 export * from './Attack';
+export * from './Attacks';

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -4,3 +4,4 @@ export * from './Predict';
 export * from './Interpret';
 export * from './Interpreters';
 export * from './TaskCards';
+export * from './Attack';

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -5,4 +5,3 @@ export * from './Interpret';
 export * from './Interpreters';
 export * from './TaskCards';
 export * from './Attack';
-export * from './Attacks';

--- a/ui/src/demos/reading-comprehension/Attacks.tsx
+++ b/ui/src/demos/reading-comprehension/Attacks.tsx
@@ -1,20 +1,24 @@
 import React from 'react';
 import { Collapse } from 'antd';
 
-import { Output, PrettyPrintedJSON } from '../tugboat/components';
-import { Model } from '../tugboat/lib';
+import { Output, PrettyPrintedJSON } from '../../tugboat/components';
+import { Model } from '../../tugboat/lib';
 
-import { Attack } from './Attack';
-import { ModelInfoList } from '../context';
-import { AttackType, GradientInputField } from '../lib';
+import { Attack } from '../../components/Attack';
+import { ModelInfoList } from '../../context';
+import { AttackType, GradientInputField } from '../../lib';
+import { Input } from './types';
 
-interface Props<I> {
+type InputReductionAttackOutput = any;
+type HotflipAttackOutput = any;
+
+interface Props {
     model: Model;
-    input: I;
-    target: keyof I & string;
+    input: Input;
+    target: keyof Input & string;
 }
 
-export const Attacks = <I, O>({ model, input, target }: Props<I>) => {
+export const Attacks = ({ model, input, target }: Props) => {
     const modelInfoList = React.useContext(ModelInfoList);
 
     const info = modelInfoList.find((i) => i.id === model.id);
@@ -29,7 +33,7 @@ export const Attacks = <I, O>({ model, input, target }: Props<I>) => {
             <Collapse>
                 {supportedAttackTypes.has(AttackType.InputReduction) ? (
                     <Collapse.Panel key={AttackType.InputReduction} header="Input Reduction">
-                        <Attack<I, O>
+                        <Attack<Input, InputReductionAttackOutput>
                             type={AttackType.InputReduction}
                             target={target}
                             gradient={GradientInputField.Input2}
@@ -41,7 +45,7 @@ export const Attacks = <I, O>({ model, input, target }: Props<I>) => {
                 ) : null}
                 {supportedAttackTypes.has(AttackType.HotFlip) ? (
                     <Collapse.Panel key={AttackType.HotFlip} header="HotFlip">
-                        <Attack<I, O>
+                        <Attack<Input, HotflipAttackOutput>
                             type={AttackType.HotFlip}
                             target={target}
                             gradient={GradientInputField.Input2}

--- a/ui/src/demos/reading-comprehension/Attacks.tsx
+++ b/ui/src/demos/reading-comprehension/Attacks.tsx
@@ -34,6 +34,7 @@ export const Attacks = ({ model, input }: Props) => {
             <Collapse>
                 {supportedAttackTypes.has(AttackType.InputReduction) ? (
                     <Collapse.Panel key={AttackType.InputReduction} header="Input Reduction">
+                        {/* TODO: Replace `any` with a better type once we know what it is. */}
                         <Attack<Input, any>
                             type={AttackType.InputReduction}
                             target="question"
@@ -45,6 +46,7 @@ export const Attacks = ({ model, input }: Props) => {
                 ) : null}
                 {supportedAttackTypes.has(AttackType.HotFlip) ? (
                     <Collapse.Panel key={AttackType.HotFlip} header="HotFlip">
+                        {/* TODO: Replace `any` with a better type once we know what it is. */}
                         <Attack<Input, any>
                             type={AttackType.HotFlip}
                             target="question"

--- a/ui/src/demos/reading-comprehension/Attacks.tsx
+++ b/ui/src/demos/reading-comprehension/Attacks.tsx
@@ -9,6 +9,7 @@ import { ModelInfoList } from '../../context';
 import { AttackType, GradientInputField } from '../../lib';
 import { Input } from './types';
 
+// TODO: Add actual types.
 type InputReductionAttackOutput = any;
 type HotflipAttackOutput = any;
 

--- a/ui/src/demos/reading-comprehension/Attacks.tsx
+++ b/ui/src/demos/reading-comprehension/Attacks.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Collapse } from 'antd';
+
+import { Output, PrettyPrintedJSON } from '../../tugboat/components';
+import { Model } from '../../tugboat/lib';
+
+import { Attack } from '../../components';
+import { ModelInfoList } from '../../context';
+import { AttackType, GradientInputField } from '../../lib';
+import { Input } from './types';
+
+interface Props {
+    model: Model;
+    input: Input;
+}
+
+/**
+ * TODO: Bits and pieces of this can and should move into `../../components` so that other demos
+ * that support attacks can use this code. The bit we need to figure out before doing so it
+ * what the output looks like, and how generic it actually is.
+ */
+export const Attacks = ({ model, input }: Props) => {
+    const modelInfoList = React.useContext(ModelInfoList);
+
+    const info = modelInfoList.find((i) => i.id === model.id);
+    if (!info || info.attackers.length === 0) {
+        return null;
+    }
+
+    const supportedAttackTypes = new Set(info.attackers);
+
+    return (
+        <Output.Section title="Model Attacks">
+            <Collapse>
+                {supportedAttackTypes.has(AttackType.InputReduction) ? (
+                    <Collapse.Panel key={AttackType.InputReduction} header="Input Reduction">
+                        <Attack<Input, any>
+                            type={AttackType.InputReduction}
+                            target="question"
+                            gradient={GradientInputField.Input2}
+                            input={input}>
+                            {({ output }) => <PrettyPrintedJSON json={output} />}
+                        </Attack>
+                    </Collapse.Panel>
+                ) : null}
+                {supportedAttackTypes.has(AttackType.HotFlip) ? (
+                    <Collapse.Panel key={AttackType.HotFlip} header="HotFlip">
+                        <Attack<Input, any>
+                            type={AttackType.HotFlip}
+                            target="question"
+                            gradient={GradientInputField.Input2}
+                            input={input}>
+                            {({ output }) => <PrettyPrintedJSON json={output} />}
+                        </Attack>
+                    </Collapse.Panel>
+                ) : null}
+            </Collapse>
+        </Output.Section>
+    );
+};

--- a/ui/src/demos/reading-comprehension/Main.tsx
+++ b/ui/src/demos/reading-comprehension/Main.tsx
@@ -19,6 +19,7 @@ import { isWithTokenizedInput } from '../../lib';
 import { config } from './config';
 import { Usage } from './Usage';
 import { Predictions } from './Predictions';
+import { Attacks } from './Attacks';
 import { Input, Prediction } from './types';
 
 export const Main = () => {
@@ -48,6 +49,7 @@ export const Main = () => {
                                                 tokens={output}
                                             />
                                         ) : null}
+                                        <Attacks model={model} input={input} />
                                     </Output.Sections>
                                 )}
                             </Output>

--- a/ui/src/demos/reading-comprehension/Main.tsx
+++ b/ui/src/demos/reading-comprehension/Main.tsx
@@ -14,12 +14,11 @@ import {
     Passage,
     Submit,
 } from '../../tugboat/components';
-import { MultiModelDemo, Predict, Interpreters } from '../../components';
+import { MultiModelDemo, Predict, Interpreters, Attacks } from '../../components';
 import { isWithTokenizedInput } from '../../lib';
 import { config } from './config';
 import { Usage } from './Usage';
 import { Predictions } from './Predictions';
-import { Attacks } from './Attacks';
 import { Input, Prediction } from './types';
 
 export const Main = () => {
@@ -49,7 +48,7 @@ export const Main = () => {
                                                 tokens={output}
                                             />
                                         ) : null}
-                                        <Attacks model={model} input={input} />
+                                        <Attacks model={model} input={input} target="question" />
                                     </Output.Sections>
                                 )}
                             </Output>

--- a/ui/src/demos/reading-comprehension/Main.tsx
+++ b/ui/src/demos/reading-comprehension/Main.tsx
@@ -14,10 +14,11 @@ import {
     Passage,
     Submit,
 } from '../../tugboat/components';
-import { MultiModelDemo, Predict, Interpreters, Attacks } from '../../components';
+import { MultiModelDemo, Predict, Interpreters } from '../../components';
 import { isWithTokenizedInput } from '../../lib';
 import { config } from './config';
 import { Usage } from './Usage';
+import { Attacks } from './Attacks';
 import { Predictions } from './Predictions';
 import { Input, Prediction } from './types';
 

--- a/ui/src/demos/reading-comprehension/Predictions.tsx
+++ b/ui/src/demos/reading-comprehension/Predictions.tsx
@@ -4,7 +4,7 @@ import { Collapse } from 'antd';
 import { PrettyPrintedJSON, TextWithHighlight, Output, Result } from '../../tugboat/components';
 import { Model } from '../../tugboat/lib';
 import { ModelId } from '../../lib';
-import { UnexpectedModel } from '../../tugboat/error';
+import { UnexpectedModelError } from '../../tugboat/error';
 import {
     Input,
     Prediction,
@@ -69,7 +69,7 @@ const OutputByModel = ({
         }
     }
     // If we dont have an output throw.
-    throw new UnexpectedModel(model.id);
+    throw new UnexpectedModelError(model.id);
 };
 
 const BasicPrediction = ({

--- a/ui/src/demos/reading-comprehension/Usage.tsx
+++ b/ui/src/demos/reading-comprehension/Usage.tsx
@@ -7,48 +7,70 @@ import React from 'react';
 
 import { ModelUsage } from '../../components';
 import { Models, Examples } from '../../tugboat/context';
-import { NoSelectedModelError, InvalidExamplesFormatError } from '../../tugboat/error';
+import { NoSelectedModelError } from '../../tugboat/error';
 import { isGroupedExamples } from '../../tugboat/lib';
+
+class UngroupedExamplesError extends Error {
+    constructor() {
+        super(`The examples aren't grouped but are expected to be.`);
+    }
+}
 
 export const Usage = () => {
     const models = React.useContext(Models);
-    const examples = React.useContext(Examples);
+    const { examples } = React.useContext(Examples);
+
     if (!models.selectedModel) {
         throw new NoSelectedModelError();
     }
-    const x = examples.examples;
-    // Reading comp uses GroupedExamples
-    if (isGroupedExamples(x)) {
-        const ex = x['SQuAD-like Argument Finding'][2]; // matrix example
-        // TODO: we need to get these paths from model card
-        const evalDataPath =
-            'https://s3-us-west-2.amazonaws.com/allennlp/datasets/squad/squad-dev-v1.1.json';
-        const trainingDataPath =
-            'https://raw.githubusercontent.com/allenai/allennlp-models/v1.0.0/training_config/rc/bidaf_elmo.jsonnet';
-        return (
-            <ModelUsage
-                installCommand={'pip install allennlp==1.0.0 allennlp-models==1.0.0'}
-                bashCommand={`echo '{"passage": "${ex.passage.slice(0, 182)}.", "question": "${
-                    ex.question
-                }"}' | \\
-    allennlp predict ${models.selectedModel.card.archive_file} -`}
-                pythonCommand={`from allennlp.predictors.predictor import Predictor
-    import allennlp_models.rc
-    predictor = Predictor.from_path("${models.selectedModel.card.archive_file}")
-    predictor.predict(
-        passage="${ex.passage.slice(0, 182)}.",
-        question="${ex.question}"
-    )`}
-                evaluationCommand={`allennlp evaluate \\
-    ${models.selectedModel.card.archive_file} \\
-    ${evalDataPath}`}
-                trainingCommand={`allennlp train ${trainingDataPath} \\
-    -s output_path`}
-            />
-        );
-    } else {
-        throw new InvalidExamplesFormatError(
-            `The examples aren't grouped, but we expect them to be`
-        );
+
+    if (!isGroupedExamples(examples)) {
+        throw new UngroupedExamplesError();
     }
+
+    // TODO: This seems brittle. If the examples change this will fail at runtime.
+    const ex = examples['SQuAD-like Argument Finding'][2]; // matrix example
+
+    const installCommand = 'pip install allennlp==1.0.0 allennlp-models==1.0.0';
+
+    const bashCommand = `
+echo '{"passage": "${ex.passage.slice(0, 182)}.", "question": "${ex.question}"}' | \\
+    allennlp predict ${models.selectedModel.card.archive_file} -
+`.trim();
+
+    const pythonCommand = `
+from allennlp.predictors.predictor import Predictor
+import allennlp_models.rc
+
+predictor = Predictor.from_path("${models.selectedModel.card.archive_file}")
+predictor.predict(
+    passage="${ex.passage.slice(0, 182)}.",
+    question="${ex.question}"
+)`.trim();
+
+    // TODO: Get this from the model card.
+    const evalDataPath =
+        'https://s3-us-west-2.amazonaws.com/allennlp/datasets/squad/squad-dev-v1.1.json';
+    const evaluationCommand = `
+allennlp evaluate \\
+    ${models.selectedModel.card.archive_file} \\
+    ${evalDataPath}`.trim();
+
+    // TODO: Get this from the model card.
+    const trainingDataPath =
+        'https://raw.githubusercontent.com/allenai/allennlp-models/v1.0.0/training_config/rc/bidaf_elmo.jsonnet';
+    const trainingCommand = `allennlp train \\
+    ${trainingDataPath} \\
+    -s /path/to/output`.trim();
+
+    // TODO: The AllenNLP version could be pulled from the model's info route.
+    return (
+        <ModelUsage
+            installCommand={installCommand}
+            bashCommand={bashCommand}
+            pythonCommand={pythonCommand}
+            evaluationCommand={evaluationCommand}
+            trainingCommand={trainingCommand}
+        />
+    );
 };

--- a/ui/src/demos/reading-comprehension/Usage.tsx
+++ b/ui/src/demos/reading-comprehension/Usage.tsx
@@ -7,14 +7,14 @@ import React from 'react';
 
 import { ModelUsage } from '../../components';
 import { Models, Examples } from '../../tugboat/context';
-import { NoSelectedModel, InvalidExamplesFormat } from '../../tugboat/error';
+import { NoSelectedModelError, InvalidExamplesFormatError } from '../../tugboat/error';
 import { isGroupedExamples } from '../../tugboat/lib';
 
 export const Usage = () => {
     const models = React.useContext(Models);
     const examples = React.useContext(Examples);
     if (!models.selectedModel) {
-        throw new NoSelectedModel();
+        throw new NoSelectedModelError();
     }
     const x = examples.examples;
     // Reading comp uses GroupedExamples
@@ -47,6 +47,8 @@ export const Usage = () => {
             />
         );
     } else {
-        throw new InvalidExamplesFormat(`The examples aren't grouped, but we expect them to be`);
+        throw new InvalidExamplesFormatError(
+            `The examples aren't grouped, but we expect them to be`
+        );
     }
 };

--- a/ui/src/lib/AttackType.ts
+++ b/ui/src/lib/AttackType.ts
@@ -1,0 +1,4 @@
+export enum AttackType {
+    InputReduction = 'input_reduction',
+    HotFlip = 'hotflip',
+}

--- a/ui/src/lib/GradientInputField.ts
+++ b/ui/src/lib/GradientInputField.ts
@@ -1,0 +1,4 @@
+export enum GradientInputField {
+    Input1 = 'grad_input_1',
+    Input2 = 'grad_input_2',
+}

--- a/ui/src/lib/index.ts
+++ b/ui/src/lib/index.ts
@@ -2,3 +2,5 @@ export * from './ModelInfo';
 export * from './TaskCard';
 export * from './InterpreterId';
 export * from './InterpretResponse';
+export * from './AttackType';
+export * from './GradientInputField';

--- a/ui/src/tugboat/components/ModelCard.tsx
+++ b/ui/src/tugboat/components/ModelCard.tsx
@@ -4,13 +4,13 @@ import styled from 'styled-components';
 import { belowOrEqualTo } from '@allenai/varnish/theme/breakpoints';
 
 import { Models } from '../context';
-import { NoSelectedModel } from '../error';
+import { NoSelectedModelError } from '../error';
 import { Markdown } from './Markdown';
 
 export const ModelCard = () => {
     const models = React.useContext(Models);
     if (!models.selectedModel) {
-        throw new NoSelectedModel();
+        throw new NoSelectedModelError();
     }
 
     return (

--- a/ui/src/tugboat/components/form/Form.tsx
+++ b/ui/src/tugboat/components/form/Form.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Divider, Form as AntForm } from 'antd';
 
 import { Models, Examples } from '../../context';
-import { NoSelectedModel } from '../../error';
+import { NoSelectedModelError } from '../../error';
 import { Promised } from '../Promised';
 
 class EmptyFormError extends Error {
@@ -61,7 +61,7 @@ export const Form = <I, O>(props: Props) => {
             throw new EmptyFormError();
         }
         if (!models.selectedModel) {
-            throw new NoSelectedModel();
+            throw new NoSelectedModelError();
         }
         const url = props.action(models.selectedModel.id);
         const opt = { method: 'POST', body: JSON.stringify(i) };
@@ -91,7 +91,6 @@ export const Form = <I, O>(props: Props) => {
     }, [examples.selectedExample]);
 
     // We do our best to make sure the children match the format we expect. That said we can't
-    // actually make sure that they're the specific compoent type's we expect -- or at least, I
     // wasn't able to figure out how to do that.
     const children = React.Children.toArray(props.children);
     if (!children || children.length !== 2) {

--- a/ui/src/tugboat/error/index.ts
+++ b/ui/src/tugboat/error/index.ts
@@ -10,13 +10,13 @@ export class ModelNotFoundError extends Error {
     }
 }
 
-export class NoSelectedModel extends Error {
+export class NoSelectedModelError extends Error {
     constructor() {
         super('No selected model.');
     }
 }
 
-export class UnexpectedModel extends Error {
+export class UnexpectedModelError extends Error {
     constructor(msg: string) {
         super(`Unexpected model: ${msg}`);
     }
@@ -40,7 +40,7 @@ export class InvalidHighlightRangeError extends Error {
     }
 }
 
-export class InvalidExamplesFormat extends Error {
+export class InvalidExamplesFormatError extends Error {
     constructor(msg: string) {
         super(`Examples are in the wrong format: ${msg}`);
     }

--- a/ui/src/tugboat/error/index.ts
+++ b/ui/src/tugboat/error/index.ts
@@ -39,9 +39,3 @@ export class InvalidHighlightRangeError extends Error {
         super(`Invalid Highlight Range: ${msg}`);
     }
 }
-
-export class InvalidExamplesFormatError extends Error {
-    constructor(msg: string) {
-        super(`Examples are in the wrong format: ${msg}`);
-    }
-}


### PR DESCRIPTION
This wires up model attacks in the new demo architecture. As part of
this effort I discovered that the use of `<Form />` was causing some
interesting side-effects. Specifically, the `useEffect()` calls in
`<Form />` were mutating the data in the `<Interpret />` and
`<Attack />` instances. In retrospect this makes sense, and might
suggest that the `<Form />` name is too generic.

I left the `<Form />` abstraction alone and instead decided to wire
`<Attack />` and `<Interpret />` up as straight XHR calls (via
`<Promised />`. This makes it clear there's no user-input in either
case. The `<Interpret />` interface wasn't changed -- as the two
implementation are functionally equivalent.