### PR TITLE
Add an endpoint for returning model cards.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,8 @@ jobs:
           "transformer_qa",
           "vilbert_vqa",
           "wikitables_parser",
-          "tasks"
+          "tasks",
+          "model-card"
         ]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           "vilbert_vqa",
           "wikitables_parser",
           "tasks",
-          "model-card"
+          "model_card"
         ]
     steps:
     - uses: actions/checkout@v2

--- a/api/allennlp_demo/model_card/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/model_card/.skiff/webapp.jsonnet
@@ -1,0 +1,18 @@
+/**
+ * This file defines the infrastructure we need to run the API endpoint on Kubernetes.
+ *
+ * For more information on the JSONNET language, see:
+ * https://jsonnet.org/learning/getting_started.html
+ */
+
+local common = import '../../common/.skiff/common.libsonnet';
+
+function(image, cause, sha, env, branch, repo, buildId)
+    // This tells Kubernetes what resources we need to run.
+    // For more information see:
+    // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+    local cpu = '50m';
+    local memory = '200Mi';
+    local startupTime = 30;
+    common.APIEndpoint('model-card', image, cause, sha, cpu, memory, env, branch, repo, buildId,
+                       startupTime)

--- a/api/allennlp_demo/model_card/api.py
+++ b/api/allennlp_demo/model_card/api.py
@@ -1,0 +1,40 @@
+"""
+The model-card endpoint serves AllenNLP models for pretrained models. The data is served from
+a single endpoint so that the latest allennlp_models package can be used. Some modules (like NMN)
+include an older version that doesn't include the model card information.
+"""
+import logging
+import flask
+from werkzeug.exceptions import NotFound
+
+from allennlp_demo.common.logs import configure_logging
+from allennlp_models.pretrained import get_pretrained_models
+from allennlp_models.version import VERSION
+
+
+logger = logging.getLogger(__name__)
+
+
+class ModelCardService(flask.Flask):
+    def __init__(self, name: str = "model-card"):
+        super().__init__(name)
+        configure_logging(self)
+
+        @self.route("/", methods=["GET"])
+        def info():
+            return flask.jsonify({"id": "model-cards", "allennlp_models": VERSION})
+
+        @self.route("/<string:model_id>", methods=["GET"])
+        def model_card(model_id: str):
+            from pprint import pprint
+
+            pprint(get_pretrained_models())
+            card = get_pretrained_models().get(model_id)
+            if card is None:
+                raise NotFound(f"No model with id {model_id} found.")
+            return flask.jsonify(card.to_dict())
+
+
+if __name__ == "__main__":
+    app = ModelCardService()
+    app.run(host="0.0.0.0", port=8000)

--- a/api/allennlp_demo/model_card/test_api.py
+++ b/api/allennlp_demo/model_card/test_api.py
@@ -1,0 +1,17 @@
+from .api import ModelCardService
+
+
+def test_model_card():
+    app = ModelCardService()
+    client = app.test_client()
+    response = client.get("/rc-bidaf")
+    assert response.status_code == 200
+    assert response.json["display_name"] == "BiDAF"
+    assert response.json["contact"] == "allennlp-contact@allenai.org"
+
+
+def task_not_found():
+    app = ModelCardService()
+    client = app.test_client()
+    response = client.get("/✨")
+    assert response.status_code == 404

--- a/api/allennlp_demo/tasks/api.py
+++ b/api/allennlp_demo/tasks/api.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 class TasksService(flask.Flask):
-    def __init__(self, name: str = "info"):
+    def __init__(self, name: str = "tasks"):
         super().__init__(name)
         configure_logging(self)
 

--- a/dev/check_models_ci.py
+++ b/dev/check_models_ci.py
@@ -11,7 +11,7 @@ WORKFLOW_FILE_PATH = ".github/workflows/ci.yml"
 logging.basicConfig()
 
 # These are endpoints we have tests for that aren't models. This script skips these.
-NON_MODEL_ENDPOINTS = set([ "tasks", "model-card" ])
+NON_MODEL_ENDPOINTS = set([ "tasks", "model_card" ])
 
 def find_models() -> Iterable[str]:
     for name in os.listdir("api/allennlp_demo"):

--- a/dev/check_models_ci.py
+++ b/dev/check_models_ci.py
@@ -11,7 +11,7 @@ WORKFLOW_FILE_PATH = ".github/workflows/ci.yml"
 logging.basicConfig()
 
 # These are endpoints we have tests for that aren't models. This script skips these.
-NON_MODEL_ENDPOINTS = set([ "tasks" ])
+NON_MODEL_ENDPOINTS = set([ "tasks", "model-card" ])
 
 def find_models() -> Iterable[str]:
     for name in os.listdir("api/allennlp_demo"):


### PR DESCRIPTION
This adds a single, shared endpoint for returning model cards.

We need this because some models (like NMN) use an older version
of `allennlp` or `allennlp_models` (or both) that doesn't have the
`ModelCard` stuff.

So instead we have a single endpoint that uses the latest (1.3)
n' greatest and serves model cards for all pretrained models.
The endpoint will be: `/api/model-card/:pretrained-model-id`.