### PR TITLE
Port the bidaf endpoint to the new id format.

### DIFF
--- a/api/allennlp_demo/bidaf/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/bidaf/.skiff/webapp.jsonnet
@@ -14,4 +14,5 @@ function(image, cause, sha, env, branch, repo, buildId)
     // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
     local cpu = '50m';
     local memory = '1Gi';
-    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)
+    local altPaths = [ '/api/bidaf' ];
+    common.v1.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId, altPaths=altPaths)

--- a/api/allennlp_demo/bidaf/model.json
+++ b/api/allennlp_demo/bidaf/model.json
@@ -1,4 +1,4 @@
 {
-    "id": "bidaf",
+    "id": "rc-bidaf",
     "pretrained_model_id": "rc-bidaf"
 }

--- a/api/allennlp_demo/common/.skiff/common.libsonnet
+++ b/api/allennlp_demo/common/.skiff/common.libsonnet
@@ -9,8 +9,266 @@
 local config = import '../../../../skiff.json';
 local db = import 'db.libsonnet';
 
+// There are several methods for creating an APIEndpoint. This local function represents the common
+// bits that can be shared by the individual, public interfaces. Once the non `v1` interface is
+// removed this can all be inlined there.
+local APIEndpoint(id, image, cause, sha, cpu, memory, env, branch, repo, buildId, startupTime=120,
+                  useDb=false, maxBodySize = '0.5m'
+) =
+    // Different environments are deployed to the same namespace. This serves to prevent
+    // collissions.
+    local fullyQualifiedName = config.appName + '-api-' + id + '-' + env;
+
+    // Every resource is tagged with the same set of labels. These labels serve the
+    // following purposes:
+    //  - They make it easier to query the resources, i.e.
+    //      kubectl get pod -l app=my-app,env=staging
+    //  - The service definition uses them to find the pods it directs traffic to.
+    local namespaceLabels = {
+        app: config.appName,
+        contact: config.contact,
+        team: config.team
+    };
+
+    local namespace = {
+        apiVersion: 'v1',
+        kind: 'Namespace',
+        metadata: {
+            name: config.appName + '-api-' + id,
+            labels: namespaceLabels
+        }
+    };
+
+    local labels = namespaceLabels + {
+        env: env,
+        endpoint: id
+    };
+
+    // By default multiple instances of your application could get scheduled
+    // to the same node. This means if that node goes down your application
+    // does too. We use the label below to avoid that.
+    local antiAffinityLabels = {
+        onlyOneOfPerNode: config.appName + '-' + env
+    };
+    local podLabels = labels + antiAffinityLabels;
+
+    // Annotations carry additional information about your deployment that
+    // we use for auditing, debugging and administrative purposes
+    local annotations = {
+        'apps.allenai.org/sha': sha,
+        'apps.allenai.org/branch': branch,
+        'apps.allenai.org/repo': repo,
+        'apps.allenai.org/build': buildId
+    };
+
+    // The port the Flask application listens on.
+    local apiPort = 8000;
+
+    // In production we run two versions of your application, as to ensure that
+    // if one instance goes down or is busy, end users can still use the application.
+    // In all other environments we run a single instance to save money.
+    local replicas =
+        if env == 'prod' then
+            2
+        else
+            1;
+
+    local deployment = {
+        apiVersion: 'apps/v1',
+        kind: 'Deployment',
+        metadata: {
+            labels: labels,
+            name: fullyQualifiedName,
+            namespace: namespace.metadata.name,
+            annotations: annotations + {
+                'kubernetes.io/change-cause': cause
+            }
+        },
+        spec: {
+            revisionHistoryLimit: 3,
+            replicas: replicas,
+            selector: {
+                matchLabels: labels
+            },
+            template: {
+                metadata: {
+                    name: fullyQualifiedName,
+                    namespace: namespace.metadata.name,
+                    labels: podLabels,
+                    annotations: annotations
+                },
+                spec: {
+                    # This block tells the cluster that we'd like to make sure
+                    # each instance of your application is on a different node. This
+                    # way if a node goes down, your application doesn't:
+                    # See: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-isolation-restriction
+                    affinity: {
+                        podAntiAffinity: {
+                            requiredDuringSchedulingIgnoredDuringExecution: [
+                                {
+                                labelSelector: {
+                                        matchExpressions: [
+                                            {
+                                                    key: labelName,
+                                                    operator: 'In',
+                                                    values: [ antiAffinityLabels[labelName], ],
+                                            } for labelName in std.objectFields(antiAffinityLabels)
+                                    ],
+                                    },
+                                    topologyKey: 'kubernetes.io/hostname'
+                                },
+                            ]
+                        },
+                    },
+                    containers: [
+                        {
+                            name: fullyQualifiedName,
+                            image: image,
+                            # Stop serving traffic if the container is busy doing something
+                            # else.
+                            readinessProbe: {
+                                httpGet: {
+                                    port: apiPort,
+                                    scheme: 'HTTP',
+                                    path: '/?check=readiness_probe'
+                                },
+                                periodSeconds: 10,
+                                failureThreshold: 1,
+                            },
+
+                            # Restart the container if the container doesn't respond for a
+                            # a full minute.
+                            livenessProbe: {
+                                httpGet: {
+                                    port: apiPort,
+                                    scheme: 'HTTP',
+                                    path: '/?check=liveness_probe'
+                                },
+                                periodSeconds: 10,
+                                failureThreshold: 6,
+                                initialDelaySeconds: startupTime,
+                            },
+                            resources: {
+                                requests: {
+                                    cpu: cpu,
+                                    memory: memory
+                                }
+                            },
+                        # Add the database configuration as environment variables if we need
+                        # them.
+                        } + if useDb then
+                                { env: db.EnvironmentVariables() }
+                            else
+                                {},
+                    # If we need the DB we run Google's Cloud SQL Proxy which provides
+                    # a secure tunnel to the database. Connecting to localhost:5432 routes
+                    # to the database via a mTLS encrypted tunnel.
+                    ] + if useDb then
+                            [ db.containers.CloudSQLProxy() ]
+                        else
+                            []
+                # This volume provides the secrets required by the CloudSQL proxy. They're
+                # mounted in as files. This is a better setup for Kubernetes and something
+                # we should transition the database configuration to at some point. It allows
+                # secrets to be updated without a container restart, which make rotating them
+                # easier.
+                } + if useDb then
+                        { volumes: [ db.volumes.CloudSQLServiceAccountCreds() ] }
+                    else
+                        {}
+            }
+        }
+    };
+
+    local service = {
+        apiVersion: 'v1',
+        kind: 'Service',
+        metadata: {
+            name: fullyQualifiedName,
+            namespace: namespace.metadata.name,
+            labels: labels,
+            annotations: annotations
+        },
+        spec: {
+            selector: labels,
+            ports: [
+                {
+                    port: apiPort,
+                    name: 'http'
+                }
+            ]
+        }
+    };
+
+    // In production we use demos.allennlp.org, everywhere else we use the Skiff TLD.
+    local topLevelDomain =
+        if env == 'prod' then
+            'demo.allennlp.org'
+        else
+            '.apps.allenai.org';
+    local hosts = [
+        if env == 'prod' then
+            topLevelDomain
+        else
+            config.appName + '.' + env + topLevelDomain
+    ];
+
+
+    local ingress = {
+        apiVersion: 'networking.k8s.io/v1beta1',
+        kind: 'Ingress',
+        metadata: {
+            name: fullyQualifiedName,
+            namespace: namespace.metadata.name,
+            labels: labels,
+            annotations: annotations + {
+                'kubernetes.io/ingress.class': 'nginx',
+                'nginx.ingress.kubernetes.io/ssl-redirect': 'true',
+                'nginx.ingress.kubernetes.io/proxy-body-size': maxBodySize,
+                // We trim the prefix before sending requests to the container, so a request for
+                // /api/$path_prefix/foo becomes /foo.
+                'nginx.ingress.kubernetes.io/rewrite-target': '/$2'
+            }
+        },
+        spec: {
+            tls: [
+                // We explicitly omit secretName here, which is optional, so that the root
+                // certificate that's managed by the UI is used instead.
+                {
+                    hosts: hosts
+                }
+            ],
+            rules: [
+                {
+                    host: host,
+                    http: {
+                        paths: [
+                            {
+                                backend: {
+                                    serviceName: service.metadata.name,
+                                    servicePort: apiPort
+                                },
+                                path: '/api/' + id + '(/(.*))?$'
+                            }
+                        ]
+                    }
+                } for host in hosts
+            ]
+        }
+    };
+
+    {
+        namespace: namespace,
+        deployment: deployment,
+        service: service,
+        ingress: ingress
+    };
+
 {
     /**
+     * @deprecated          Use v1.APIEndpoint() instead.
+     *
+     *
      * @param id            {string}    A unique identifier for the endpoint. This identifier
      *                                  must be URL safe, as it's used to determine what requests
      *                                  are routed to the endpoint. For instance, if the id is
@@ -38,253 +296,87 @@ local db = import 'db.libsonnet';
      *                                      "1024”, "8k”, "1m”.
      *                                  NGINX docs: http://nginx.org/en/docs/syntax.html
      */
-    APIEndpoint(id, image, cause, sha, cpu, memory, env, branch, repo, buildId, startupTime=120, useDb=false, maxBodySize = '0.5m'):
-        // Different environments are deployed to the same namespace. This serves to prevent
-        // collissions.
-        local fullyQualifiedName = config.appName + '-api-' + id + '-' + env;
-
-        // Every resource is tagged with the same set of labels. These labels serve the
-        // following purposes:
-        //  - They make it easier to query the resources, i.e.
-        //      kubectl get pod -l app=my-app,env=staging
-        //  - The service definition uses them to find the pods it directs traffic to.
-        local namespaceLabels = {
-            app: config.appName,
-            contact: config.contact,
-            team: config.team
-        };
-
-        local namespace = {
-            apiVersion: 'v1',
-            kind: 'Namespace',
-            metadata: {
-                name: config.appName + '-api-' + id,
-                labels: namespaceLabels
-            }
-        };
-
-        local labels = namespaceLabels + {
-            env: env,
-            endpoint: id
-        };
-
-        // By default multiple instances of your application could get scheduled
-        // to the same node. This means if that node goes down your application
-        // does too. We use the label below to avoid that.
-        local antiAffinityLabels = {
-            onlyOneOfPerNode: config.appName + '-' + env
-        };
-        local podLabels = labels + antiAffinityLabels;
-
-        // Annotations carry additional information about your deployment that
-        // we use for auditing, debugging and administrative purposes
-        local annotations = {
-            'apps.allenai.org/sha': sha,
-            'apps.allenai.org/branch': branch,
-            'apps.allenai.org/repo': repo,
-            'apps.allenai.org/build': buildId
-        };
-
-        // The port the Flask application listens on.
-        local apiPort = 8000;
-
-        // In production we run two versions of your application, as to ensure that
-        // if one instance goes down or is busy, end users can still use the application.
-        // In all other environments we run a single instance to save money.
-        local replicas =
-            if env == 'prod' then
-                2
-            else
-                1;
-
-        local deployment = {
-            apiVersion: 'apps/v1',
-            kind: 'Deployment',
-            metadata: {
-                labels: labels,
-                name: fullyQualifiedName,
-                namespace: namespace.metadata.name,
-                annotations: annotations + {
-                    'kubernetes.io/change-cause': cause
-                }
-            },
-            spec: {
-                revisionHistoryLimit: 3,
-                replicas: replicas,
-                selector: {
-                    matchLabels: labels
-                },
-                template: {
-                    metadata: {
-                        name: fullyQualifiedName,
-                        namespace: namespace.metadata.name,
-                        labels: podLabels,
-                        annotations: annotations
-                    },
-                    spec: {
-                        # This block tells the cluster that we'd like to make sure
-                        # each instance of your application is on a different node. This
-                        # way if a node goes down, your application doesn't:
-                        # See: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-isolation-restriction
-                        affinity: {
-                            podAntiAffinity: {
-                                requiredDuringSchedulingIgnoredDuringExecution: [
-                                    {
-                                    labelSelector: {
-                                            matchExpressions: [
-                                                {
-                                                        key: labelName,
-                                                        operator: 'In',
-                                                        values: [ antiAffinityLabels[labelName], ],
-                                                } for labelName in std.objectFields(antiAffinityLabels)
-                                        ],
-                                        },
-                                        topologyKey: 'kubernetes.io/hostname'
-                                    },
-                                ]
-                            },
-                        },
-                        containers: [
-                            {
-                                name: fullyQualifiedName,
-                                image: image,
-                                # Stop serving traffic if the container is busy doing something
-                                # else.
-                                readinessProbe: {
-                                    httpGet: {
-                                        port: apiPort,
-                                        scheme: 'HTTP',
-                                        path: '/?check=readiness_probe'
-                                    },
-                                    periodSeconds: 10,
-                                    failureThreshold: 1,
-                                },
-
-                                # Restart the container if the container doesn't respond for a
-                                # a full minute.
-                                livenessProbe: {
-                                    httpGet: {
-                                        port: apiPort,
-                                        scheme: 'HTTP',
-                                        path: '/?check=liveness_probe'
-                                    },
-                                    periodSeconds: 10,
-                                    failureThreshold: 6,
-                                    initialDelaySeconds: startupTime,
-                                },
-                                resources: {
-                                    requests: {
-                                        cpu: cpu,
-                                        memory: memory
-                                    }
-                                },
-                            # Add the database configuration as environment variables if we need
-                            # them.
-                            } + if useDb then
-                                    { env: db.EnvironmentVariables() }
-                                else
-                                    {},
-                        # If we need the DB we run Google's Cloud SQL Proxy which provides
-                        # a secure tunnel to the database. Connecting to localhost:5432 routes
-                        # to the database via a mTLS encrypted tunnel.
-                        ] + if useDb then
-                                [ db.containers.CloudSQLProxy() ]
-                            else
-                                []
-                    # This volume provides the secrets required by the CloudSQL proxy. They're
-                    # mounted in as files. This is a better setup for Kubernetes and something
-                    # we should transition the database configuration to at some point. It allows
-                    # secrets to be updated without a container restart, which make rotating them
-                    # easier.
-                    } + if useDb then
-                            { volumes: [ db.volumes.CloudSQLServiceAccountCreds() ] }
-                        else
-                            {}
-                }
-            }
-        };
-
-        local service = {
-            apiVersion: 'v1',
-            kind: 'Service',
-            metadata: {
-                name: fullyQualifiedName,
-                namespace: namespace.metadata.name,
-                labels: labels,
-                annotations: annotations
-            },
-            spec: {
-                selector: labels,
-                ports: [
-                    {
-                        port: apiPort,
-                        name: 'http'
-                    }
-                ]
-            }
-        };
-
-        // In production we use demos.allennlp.org, everywhere else we use the Skiff TLD.
-        local topLevelDomain =
-            if env == 'prod' then
-                'demo.allennlp.org'
-            else
-                '.apps.allenai.org';
-        local hosts = [
-            if env == 'prod' then
-                topLevelDomain
-            else
-                config.appName + '.' + env + topLevelDomain
-        ];
-
-
-        local ingress = {
-            apiVersion: 'networking.k8s.io/v1beta1',
-            kind: 'Ingress',
-            metadata: {
-                name: fullyQualifiedName,
-                namespace: namespace.metadata.name,
-                labels: labels,
-                annotations: annotations + {
-                    'kubernetes.io/ingress.class': 'nginx',
-                    'nginx.ingress.kubernetes.io/ssl-redirect': 'true',
-                    'nginx.ingress.kubernetes.io/proxy-body-size': maxBodySize,
-                    // We trim the prefix before sending requests to the container, so a request for
-                    // /api/$path_prefix/foo becomes /foo.
-                    'nginx.ingress.kubernetes.io/rewrite-target': '/$2'
-                }
-            },
-            spec: {
-                tls: [
-                    // We explicitly omit secretName here, which is optional, so that the root
-                    // certificate that's managed by the UI is used instead.
-                    {
-                        hosts: hosts
-                    }
-                ],
-                rules: [
-                    {
-                        host: host,
-                        http: {
-                            paths: [
-                                {
-                                    backend: {
-                                        serviceName: service.metadata.name,
-                                        servicePort: apiPort
-                                    },
-                                    path: '/api/' + id + '(/(.*))?$'
-                                }
-                            ]
-                        }
-                    } for host in hosts
-                ]
-            }
-        };
-
+    APIEndpoint(id, image, cause, sha, cpu, memory, env, branch, repo, buildId, startupTime=120,
+                useDb=false, maxBodySize = '0.5m'
+    ):
+        local endpoint = APIEndpoint(id, image, cause, sha, cpu, memory, env, branch, repo, buildId,
+                                     startupTime, useDb, maxBodySize);
         [
-            namespace,
-            deployment,
-            service,
-            ingress
-        ]
+            endpoint.namespace,
+            endpoint.deployment,
+            endpoint.service,
+            endpoint.ingress
+        ],
+
+    v1: {
+        /**
+         * @param id            {string}    A unique identifier for the endpoint. This identifier
+         *                                  must be URL safe, as it's used to determine what requests
+         *                                  are routed to the endpoint. For instance, if the id is
+         *                                  `foo`, requests beginning with `/api/foo` are routed
+         *                                  to the endpoint.
+         * @param image         {string}    The image tag to deploy.
+         * @param cause         {string}    A message describing the reason for the deployment.
+         * @param sha           {string}    The git sha.
+         * @param env           {string}    A unique identifier for the environment. This determines the
+         *                                  the hostname that'll be used, the number of replicas, and more.
+         *                                  If set the 'prod' this deploys to demo.allennlp.org.
+         * @param branch        {string}    The branch name.
+         * @param repo          {string}    The repo name.
+         * @param buildId       {string}    The Google Cloud Build ID.
+         * @param startupTime   {number}    The amount of time in seconds the container should take to
+         *                                  start. If this is set too low your container will get into
+         *                                  a restart loop when it's started. Defaults to 120 seconds.
+         * @param useDb         {boolean}   If true the required resources will provision to provide
+         *                                  a secure connection to the database. The required secrets
+         *                                  must be manually provisioned by system administrator.
+         * @param maxBodySize   {string}    Maximum size of allowed HTTP body payload. For example,
+         *                                  '10M'. See NGINX docs for syntax:
+         *                                      Sizes can be specified in bytes, kilobytes (suffixes k
+         *                                      and K) or megabytes (suffixes m and M), for example,
+         *                                      "1024”, "8k”, "1m”.
+         *                                  NGINX docs: http://nginx.org/en/docs/syntax.html
+         * @param altPaths      {string[]}  A list of additional paths that will be routed to the model.
+         */
+        APIEndpoint(
+            id, image, cause, sha, cpu, memory, env, branch, repo, buildId, startupTime=120,
+            useDb=false, maxBodySize = '0.5m', altPaths = []
+        ):
+            local endpoint = APIEndpoint(id, image, cause, sha, cpu, memory, env, branch, repo,
+                                         buildId, startupTime, useDb, maxBodySize);
+
+            // The only difference between the `v1.APIEndpoint` instance and its former version
+            // is the `altPaths` parameter, which was added for backwards compatibility sake.
+            // Here we built up a list of paths which we'll use to override those produced
+            // by the former mechanism.
+            local pathPrefixes = [ '/api/model/' + id ] + altPaths;
+            local paths = [
+                {
+                    backend: {
+                        serviceName: endpoint.service.metadata.name,
+                        servicePort: endpoint.service.spec.ports[0].port
+                    },
+                    path: path + '(/(.*))?$'
+                } for path in pathPrefixes
+            ];
+
+            local ingress = endpoint.ingress + {
+                spec +: {
+                    rules: [
+                        endpoint.ingress.spec.rules[0] + {
+                            http +: {
+                                paths: paths
+                            }
+                        }
+                    ]
+                }
+            };
+
+            [
+                endpoint.namespace,
+                endpoint.deployment,
+                endpoint.service,
+                ingress
+            ],
+    }
 }


### PR DESCRIPTION
The AllenNLP team is porting model IDs to a new format, of
the form `{task}-{model}`. This PR makes changes to the
way the `bidaf` endpoint is deployed so that it uses the
new id form, which is `rc-bidaf`.

To do this in an iterative way without downtime, in this PR
I did the following:

1. Introduced `common.v1.APIEndpoint()`, which supports the
   `altPaths` argument.  The `altPaths` argument is a list of
   additional paths that will be routed to the endpoint being
   deployed. The resulting Kubernetes config sets up both
   `/api/model/:id` and `altPaths` to be directed to the
   endpoint being deployed.

2. Modified `bidaf` to use the new ID format (`rc-bidaf`) and
   the new API for configuring Kubernetes, with `altPaths` to
   to `['/api/bidaf']`. This ensures the UI code that depends
   on that path will keep working.

It's worth noting that deploying this will orphan the existing
deployment, since the ID is used to produce the name of the
Kubernetes things we deploy. This is actually nice, as if I
screw things up nothing will stop working.

If things go well and I can confirm that the new endpoint is
working after I deploy, I plan on manually cleaning up the
old environment.

Here's a diff that shows what's changed in the Kubernetes manifest:

```diff
--- prod-webapp.yml	2021-01-14 11:50:40.000000000 -0800
+++ new-webapp.yml	2021-01-14 11:58:10.000000000 -0800
@@ -7,9 +7,9 @@
          "app": "allennlp-demo",
          "contact": "allennlp-contact",
          "team": "allennlp"
       },
-      "name": "allennlp-demo-api-bidaf"
+      "name": "allennlp-demo-api-rc-bidaf"
    }
 }
 ---
 {
@@ -25,23 +25,23 @@
       },
       "labels": {
          "app": "allennlp-demo",
          "contact": "allennlp-contact",
-         "endpoint": "bidaf",
+         "endpoint": "rc-bidaf",
          "env": "prod",
          "team": "allennlp"
       },
-      "name": "allennlp-demo-api-bidaf-prod",
-      "namespace": "allennlp-demo-api-bidaf"
+      "name": "allennlp-demo-api-rc-bidaf-prod",
+      "namespace": "allennlp-demo-api-rc-bidaf"
    },
    "spec": {
       "replicas": 2,
       "revisionHistoryLimit": 3,
       "selector": {
          "matchLabels": {
             "app": "allennlp-demo",
             "contact": "allennlp-contact",
-            "endpoint": "bidaf",
+            "endpoint": "rc-bidaf",
             "env": "prod",
             "team": "allennlp"
          }
       },
@@ -55,15 +55,15 @@
             },
             "labels": {
                "app": "allennlp-demo",
                "contact": "allennlp-contact",
-               "endpoint": "bidaf",
+               "endpoint": "rc-bidaf",
                "env": "prod",
                "onlyOneOfPerNode": "allennlp-demo-prod",
                "team": "allennlp"
             },
-            "name": "allennlp-demo-api-bidaf-prod",
-            "namespace": "allennlp-demo-api-bidaf"
+            "name": "allennlp-demo-api-rc-bidaf-prod",
+            "namespace": "allennlp-demo-api-rc-bidaf"
          },
          "spec": {
             "affinity": {
                "podAntiAffinity": {
@@ -97,9 +97,9 @@
                      },
                      "initialDelaySeconds": 120,
                      "periodSeconds": 10
                   },
-                  "name": "allennlp-demo-api-bidaf-prod",
+                  "name": "allennlp-demo-api-rc-bidaf-prod",
                   "readinessProbe": {
                      "failureThreshold": 1,
                      "httpGet": {
                         "path": "/?check=readiness_probe",
@@ -133,14 +133,14 @@
       },
       "labels": {
          "app": "allennlp-demo",
          "contact": "allennlp-contact",
-         "endpoint": "bidaf",
+         "endpoint": "rc-bidaf",
          "env": "prod",
          "team": "allennlp"
       },
-      "name": "allennlp-demo-api-bidaf-prod",
-      "namespace": "allennlp-demo-api-bidaf"
+      "name": "allennlp-demo-api-rc-bidaf-prod",
+      "namespace": "allennlp-demo-api-rc-bidaf"
    },
    "spec": {
       "ports": [
          {
@@ -150,9 +150,9 @@
       ],
       "selector": {
          "app": "allennlp-demo",
          "contact": "allennlp-contact",
-         "endpoint": "bidaf",
+         "endpoint": "rc-bidaf",
          "env": "prod",
          "team": "allennlp"
       }
    }
@@ -174,14 +174,14 @@
       },
       "labels": {
          "app": "allennlp-demo",
          "contact": "allennlp-contact",
-         "endpoint": "bidaf",
+         "endpoint": "rc-bidaf",
          "env": "prod",
          "team": "allennlp"
       },
-      "name": "allennlp-demo-api-bidaf-prod",
-      "namespace": "allennlp-demo-api-bidaf"
+      "name": "allennlp-demo-api-rc-bidaf-prod",
+      "namespace": "allennlp-demo-api-rc-bidaf"
    },
    "spec": {
       "rules": [
          {
@@ -189,9 +189,16 @@
             "http": {
                "paths": [
                   {
                      "backend": {
-                        "serviceName": "allennlp-demo-api-bidaf-prod",
+                        "serviceName": "allennlp-demo-api-rc-bidaf-prod",
+                        "servicePort": 8000
+                     },
+                     "path": "/api/model/rc-bidaf(/(.*))?$"
+                  },
+                  {
+                     "backend": {
+                        "serviceName": "allennlp-demo-api-rc-bidaf-prod",
                         "servicePort": 8000
                      },
                      "path": "/api/bidaf(/(.*))?$"
```