### PR TITLE
Fix #733; Make the model card endpoint faster.

### DIFF
--- a/api/allennlp_demo/model_card/api.py
+++ b/api/allennlp_demo/model_card/api.py
@@ -41,7 +41,7 @@ class ModelCardService(flask.Flask):
                 cards.append(card)
             if len(cards) == 1:
                 return flask.jsonify(cards.pop().to_dict())
-            return flask.jsonify([ c.to_dict() for c in cards ])
+            return flask.jsonify([c.to_dict() for c in cards])
 
 
 if __name__ == "__main__":

--- a/api/allennlp_demo/model_card/api.py
+++ b/api/allennlp_demo/model_card/api.py
@@ -20,16 +20,28 @@ class ModelCardService(flask.Flask):
         super().__init__(name)
         configure_logging(self)
 
+        self.cards_by_id = get_pretrained_models()
+
         @self.route("/", methods=["GET"])
         def info():
-            return flask.jsonify({"id": "model-cards", "allennlp_models": VERSION})
+            return flask.jsonify({"id": "model-card", "allennlp_models": VERSION})
 
         @self.route("/<string:model_id>", methods=["GET"])
         def model_card(model_id: str):
-            card = get_pretrained_models().get(model_id)
-            if card is None:
-                raise NotFound(f"No model with id {model_id} found.")
-            return flask.jsonify(card.to_dict())
+            """
+            Returns the model card for a model. Multiple model cards can be requested at once
+            by passing several model ids, comma delimited.
+            """
+            cards = []
+            model_ids = model_id.split(",")
+            for model_id in model_ids:
+                card = self.cards_by_id.get(model_id)
+                if card is None:
+                    raise NotFound(f"No model with id {model_id} found.")
+                cards.append(card)
+            if len(cards) == 1:
+                return flask.jsonify(cards.pop().to_dict())
+            return flask.jsonify([ c.to_dict() for c in cards ])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This makes the model card endpoint ~250x faster by calling
`get_pretrained_models()` once (which hits the disk).

Since the files won't change out from under us, this is perfectly
safe to do.

To validate the perf improvement I used `ab` locally. Here's
the results:

**Before the change:**

Percentage of the requests served within a certain time (ms)
  50%   4025
  66%   4210
  75%   4341
  80%   4433
  90%   4661
  95%   4879
  98%   5168
  99%   5599
 100%   5616 (longest request)

**After the change:**

Percentage of the requests served within a certain time (ms)
  50%     21
  66%     23
  75%     24
  80%     24
  90%     25
  95%     27
  98%     29
  99%     31
 100%     32 (longest request)

This was pretty surprising to me. It's possible my tests exacerbated
the problem a bit by loading up some sort of FS queue or something.
That said it's clearly faster by some margin and worth doing, since
memory is cheap and abundant.

Oh, and this increases the memory used by the container by ~4 MB.
So we've got *plenty* of room for this :).

Lastly, I also added support for querying several at once, so that we
can batch requests for the models we know we'll want info for. This
will turn 4-5 requests into 1.