### PR TITLE
Add Sentry for capturing client-side exceptions.

### DIFF
--- a/dev/check_models_ci.py
+++ b/dev/check_models_ci.py
@@ -7,7 +7,7 @@ import os
 import logging
 from typing import Iterable
 
-WORKFLOW_FILE_PATH = ".github/workflows/ci.yml"
+WORKFLOW_FILE_PATH = ".github/workflows/api_ci.yml"
 logging.basicConfig()
 
 # These are endpoints we have tests for that aren't models. This script skips these.

--- a/ui/.skiff/cloudbuild-deploy.yaml
+++ b/ui/.skiff/cloudbuild-deploy.yaml
@@ -20,6 +20,8 @@ steps:
     'build',
     '-t', 'gcr.io/$PROJECT_ID/$REPO_NAME-ui:$COMMIT_SHA',
     '-t', 'gcr.io/$PROJECT_ID/$REPO_NAME-ui:latest',
+    '--build-arg', 'env=$_ENV',
+    '--build-arg', 'sha=$COMMIT_SHA',
     '--cache-from', 'gcr.io/$PROJECT_ID/$REPO_NAME-ui:latest',
     '.'
   ]

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -5,6 +5,12 @@ WORKDIR /ui
 COPY package.json yarn.lock ./
 RUN yarn
 
+ARG env
+ARG sha
+
+ENV SENTRY_ENVIRONMENT=${env}
+ENV SENTRY_RELEASE=${sha}
+
 COPY . .
 RUN yarn build
 

--- a/ui/Dockerfile.dev
+++ b/ui/Dockerfile.dev
@@ -10,5 +10,8 @@ RUN yarn
 
 COPY . .
 
+ENV SENTRY_ENVIRONMENT=dev
+ENV SENTRY_RELEASE=none
+
 ENTRYPOINT [ "yarn" ]
 CMD [ "start" ]

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,6 +11,7 @@
     "@babel/plugin-proposal-class-properties": "^7.12.1",
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.12.1",
+    "@sentry/react": "^6.0.0",
     "@types/commonmark": "^0.27.4",
     "@types/node": "^14.14.7",
     "@types/react": "^16.9.56",

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -30,8 +30,6 @@ import '@allenai/varnish/dist/theme.css';
 Sentry.init({
     dsn: "https://59686a41b9664bf2a8bbc51a602428c2@o226626.ingest.sentry.io/5599301",
     autoSessionTracking: true,
-    // This value should be tweaked for production, and should be a value between 0 and 1.
-    tracesSampleRate: 1.0,
     environment: process.env.SENTRY_ENVIRONMENT || 'dev',
     release: process.env.SENTRY_RELEASE || 'none'
 });

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -28,10 +28,10 @@ import '@allenai/varnish/dist/theme.css';
 // Sentry is a tool that captures JavaScript errors at runtime and aggregates them.
 // If you need access, ask someone on the AllenNLP team.
 Sentry.init({
-    dsn: "https://59686a41b9664bf2a8bbc51a602428c2@o226626.ingest.sentry.io/5599301",
+    dsn: 'https://59686a41b9664bf2a8bbc51a602428c2@o226626.ingest.sentry.io/5599301',
     autoSessionTracking: true,
     environment: process.env.SENTRY_ENVIRONMENT || 'dev',
-    release: process.env.SENTRY_RELEASE || 'none'
+    release: process.env.SENTRY_RELEASE || 'none',
 });
 
 /*******************************************************************************

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import * as Sentry from '@sentry/react';
 import { BrowserRouter as Router, Route, Redirect, Switch } from 'react-router-dom';
 import { Content, Footer, Header, Layout, VarnishApp } from '@allenai/varnish/components';
 import { ScrollToTopOnPageChange } from '@allenai/varnish-react-router';
@@ -23,6 +24,17 @@ import './css/icons.css';
 import './css/hierplane-overrides.css';
 import './css/visualization-types.css';
 import '@allenai/varnish/dist/theme.css';
+
+// Sentry is a tool that captures JavaScript errors at runtime and aggregates them.
+// If you need access, ask someone on the AllenNLP team.
+Sentry.init({
+    dsn: "https://59686a41b9664bf2a8bbc51a602428c2@o226626.ingest.sentry.io/5599301",
+    autoSessionTracking: true,
+    // This value should be tweaked for production, and should be a value between 0 and 1.
+    tracesSampleRate: 1.0,
+    environment: process.env.SENTRY_ENVIRONMENT || 'dev',
+    release: process.env.SENTRY_RELEASE || 'none'
+});
 
 /*******************************************************************************
   <App /> Container

--- a/ui/src/demos/reading-comprehension/Main.tsx
+++ b/ui/src/demos/reading-comprehension/Main.tsx
@@ -29,6 +29,10 @@ import {
 } from './types';
 
 export const Main = () => {
+    // TODO (@codeviking): Remove this once we've verified Sentry is working.
+    if (document.location.search.indexOf('?throw=true') !== -1) {
+        throw Error('⚡️ This is a test error to verify that Sentry is wired up correctly.');
+    }
     return (
         <MultiModelDemo ids={config.modelIds} taskId={config.taskId}>
             <TaskTitle />

--- a/ui/src/tugboat/components/ErrorBoundary.tsx
+++ b/ui/src/tugboat/components/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Alert } from 'antd';
+
+import { ErrorMessage } from './ErrorMessage';
 
 interface Props {
     children: React.ReactNode;
@@ -33,7 +34,7 @@ export class ErrorBoundary extends React.PureComponent<Props, State> {
             <>Sorry, something went wrong. Please try again.</>
         );
 
-        return <Alert type="error" message="Error" description={description} showIcon />;
+        return <ErrorMessage message={description} />;
     }
 }
 

--- a/ui/src/tugboat/components/ErrorMessage.tsx
+++ b/ui/src/tugboat/components/ErrorMessage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Alert } from 'antd';
 
 interface Props {
-    message?: string;
+    message?: string | React.ReactNode | JSX.Element;
 }
 
 export const ErrorMessage = ({ message }: Props) => (

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -64,7 +64,7 @@ module.exports = {
         }),
         // Environment variables named here are embedded into the JavaScript payload so they
         // can be used at runtime.
-        new webpack.EnvironmentPlugin('SENTRY_RELEASE', 'SENTRY_ENVIRONMENT')
+        new webpack.EnvironmentPlugin('SENTRY_RELEASE', 'SENTRY_ENVIRONMENT'),
     ],
     output: {
         filename: 'main.[hash:6].js',

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
+const webpack = require('webpack');
 
 module.exports = {
     entry: './src/index.js',
@@ -61,6 +62,9 @@ module.exports = {
                 },
             ],
         }),
+        // Environment variables named here are embedded into the JavaScript payload so they
+        // can be used at runtime.
+        new webpack.EnvironmentPlugin('SENTRY_RELEASE', 'SENTRY_ENVIRONMENT')
     ],
     output: {
         filename: 'main.[hash:6].js',
@@ -82,4 +86,5 @@ module.exports = {
         lazy: false,
         sockPort: 8080,
     },
+    devtool: 'source-map',
 };

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -986,6 +986,70 @@
   dependencies:
     mkdirp "^1.0.4"
 
+"@sentry/browser@6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.0.0.tgz#599ba0b64b0fb4045135a7b544dd6876df12e785"
+  integrity sha512-R4+MHb5FyVZCz3EVnaquvT1mwOM2MWP4gBqjYEADY5m0XWoHiJf0skFkWt8iEKJanzGbhl4PMb9gHuJj6YfVLw==
+  dependencies:
+    "@sentry/core" "6.0.0"
+    "@sentry/types" "6.0.0"
+    "@sentry/utils" "6.0.0"
+    tslib "^1.9.3"
+
+"@sentry/core@6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.0.0.tgz#831c1737cad10c48a299e6ded4a3b4539657a25b"
+  integrity sha512-afAiOachs/WfGWc9LsJBFnJMhqQVENyzfSMnf7sLRvxPAw8n7IrXY0R09MKmG0SlAnTKN2pWoQFzFF+J3NuHBA==
+  dependencies:
+    "@sentry/hub" "6.0.0"
+    "@sentry/minimal" "6.0.0"
+    "@sentry/types" "6.0.0"
+    "@sentry/utils" "6.0.0"
+    tslib "^1.9.3"
+
+"@sentry/hub@6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.0.0.tgz#c0d8cf1d1f19384d1d3f23fe8c00bc6b7134b002"
+  integrity sha512-s8IsW6LvEH7ACnniQcxxb/9uEyjmoQ/TAoryTJN2qyPzzrHTw8NCyMuJvK+8ivUvRViz5AvtuOFf8AJlh9lzeA==
+  dependencies:
+    "@sentry/types" "6.0.0"
+    "@sentry/utils" "6.0.0"
+    tslib "^1.9.3"
+
+"@sentry/minimal@6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.0.0.tgz#f38e1325937770c7d038fdde11737e70804eb444"
+  integrity sha512-daYdEzTr+ERMwViu6RpWHOfk0oZrSNqdx+7bejTqmFHqO4pt+9ZrMiw3vinL+MWQcKXwD95uXBz6O/ryrVdPtg==
+  dependencies:
+    "@sentry/hub" "6.0.0"
+    "@sentry/types" "6.0.0"
+    tslib "^1.9.3"
+
+"@sentry/react@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-6.0.0.tgz#e8dc43fe6864463735e6a562c7c5521858f7f084"
+  integrity sha512-GYX110NSodd8wGUbnyxemndTijM+U7dI/WjFSPOyJdLB2hzzPjJ9kUqtuobT/JlGzbWE2278WysAuySne6bUGw==
+  dependencies:
+    "@sentry/browser" "6.0.0"
+    "@sentry/minimal" "6.0.0"
+    "@sentry/types" "6.0.0"
+    "@sentry/utils" "6.0.0"
+    hoist-non-react-statics "^3.3.2"
+    tslib "^1.9.3"
+
+"@sentry/types@6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.0.0.tgz#250ae7287875bf729eddfe30346611bb11034f47"
+  integrity sha512-yueRSRGPCahuju/UMdtOt8LIIncbpwLINQd9Q8E4OXtoPpMHR6Oun8sMKCPd+Wq3piI5yRDzKkGCl+sH7mHVrA==
+
+"@sentry/utils@6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.0.0.tgz#87a8e7c29c3b05483d31654c106df6b7ed95d10a"
+  integrity sha512-dMMWOT69bQ4CF1R33dOnXIOyiHRWsUAON3nFVljV1JNNTDA69YwaF9f5FIT0DKpO4qhgTlElsm8WgHI9prAVEQ==
+  dependencies:
+    "@sentry/types" "6.0.0"
+    tslib "^1.9.3"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
@@ -7474,7 +7538,7 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
This adds client-side error capturing powered by
[Sentry.io](https://sentry.io).

I added a query string argument that we can use temporarily
to throw an error to make sure things are working. I'll
remove it after we've verified everything.

I also wired things up so that errors should include the
associated environment and SHA, which should make it easier
to debug things.

Lastly I enabled source maps so that the line-numbers
included in the stack traces that Sentry captures are
useful. I can't test this locally, so I'll need to create
an ad-hoc to do so. There's no risk of doing this since
the source code is already public (and arguably there isn't
even if that's not the case, as it's fairly well known
how to reverse minification and obfuscation these days).

Pass through relevant environment variables at build time.