### PR TITLE
Fix Sentry in production.

### DIFF
--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -19,8 +19,6 @@
     <meta property="og:image" content="https://demo.allennlp.org/allennlpdemo-social-card.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <link rel="icon" href={favicon} type="image/x-icon" />
-    <link rel="apple-touch-icon" href="https://demo.allennlp.org/favicon.ico"/>
     <script>
       if (document.location.hostname === 'demo.allennlp.org') {
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -6,7 +6,7 @@ import { Content, Footer, Header, Layout, VarnishApp } from '@allenai/varnish/co
 import { ScrollToTopOnPageChange } from '@allenai/varnish-react-router';
 
 import { Demos } from './tugboat/lib';
-import { ErrorBoundary, Promised } from './tugboat/components';
+import { ErrorBoundaryView, Promised } from './tugboat/components';
 
 import allenNlpLogo from './components/allennlp_logo.svg';
 import Menu from './components/Menu';
@@ -70,7 +70,10 @@ const App = () => (
         <Router>
             <ScrollToTopOnPageChange />
             <DemoWrapper>
-                <ErrorBoundary>
+                <Sentry.ErrorBoundary
+                    fallback={({ error, resetError }) => (
+                        <ErrorBoundaryView error={error} resetError={resetError} />
+                    )}>
                     <Promised
                         promise={() =>
                             Promise.all([fetchModelInfo(), fetchTaskCards(), fetchModelCards()])
@@ -88,7 +91,15 @@ const App = () => (
                                             />
                                             {demos.all().map(({ config, Component }) => (
                                                 <Route key={config.path} path={config.path}>
-                                                    <Component />
+                                                    <Sentry.ErrorBoundary
+                                                        fallback={({ error, resetError }) => (
+                                                            <ErrorBoundaryView
+                                                                error={error}
+                                                                resetError={resetError}
+                                                            />
+                                                        )}>
+                                                        <Component />
+                                                    </Sentry.ErrorBoundary>
                                                 </Route>
                                             ))}
                                             <Route path="/:model/:slug?" component={Demo} />
@@ -98,7 +109,7 @@ const App = () => (
                             </ModelInfoList.Provider>
                         )}
                     </Promised>
-                </ErrorBoundary>
+                </Sentry.ErrorBoundary>
             </DemoWrapper>
         </Router>
     </VarnishApp>

--- a/ui/src/tugboat/components/ErrorBoundary.tsx
+++ b/ui/src/tugboat/components/ErrorBoundary.tsx
@@ -1,7 +1,36 @@
 import React from 'react';
 import styled from 'styled-components';
+import { Button, Space } from 'antd';
 
 import { ErrorMessage } from './ErrorMessage';
+
+interface ErrorBoundaryViewProps {
+    error: Error;
+    resetError: () => void;
+}
+
+export const ErrorBoundaryView = ({ error, resetError }: ErrorBoundaryViewProps) => {
+    const showErrorDetails = process.env.NODE_ENV === 'development';
+    const details = showErrorDetails ? (
+        <>
+            <b>{error.message}:</b>
+            <DebugInfo>
+                <pre>{error.stack || JSON.stringify(error, null, 2)}</pre>
+            </DebugInfo>
+        </>
+    ) : (
+        <>Sorry, something went wrong. Please try again.</>
+    );
+
+    const message = (
+        <Space direction="vertical">
+            <span>{details}</span>
+            <Button onClick={resetError}>Reset</Button>
+        </Space>
+    );
+
+    return <ErrorMessage message={message} />;
+};
 
 interface Props {
     children: React.ReactNode;
@@ -22,19 +51,12 @@ export class ErrorBoundary extends React.PureComponent<Props, State> {
             return this.props.children;
         }
 
-        const showErrorDetails = process.env.NODE_ENV === 'development';
-        const description = showErrorDetails ? (
-            <>
-                <b>{this.state.error.message}:</b>
-                <DebugInfo>
-                    <pre>{this.state.error.stack || JSON.stringify(this.state.error, null, 2)}</pre>
-                </DebugInfo>
-            </>
-        ) : (
-            <>Sorry, something went wrong. Please try again.</>
+        return (
+            <ErrorBoundaryView
+                error={this.state.error}
+                resetError={() => window.location.reload()}
+            />
         );
-
-        return <ErrorMessage message={description} />;
     }
 }
 

--- a/ui/src/tugboat/components/Promised.tsx
+++ b/ui/src/tugboat/components/Promised.tsx
@@ -1,4 +1,5 @@
 import React, { DependencyList } from 'react';
+import * as Sentry from '@sentry/react';
 
 import { usePromise, PromiseState } from '../lib';
 import { Loading } from './shared';
@@ -39,6 +40,12 @@ export const Promised = <T,>({ promise, deps, children }: Props<T>) => {
 
     if (state === PromiseState.Failure || !payload) {
         console.error('Promise failure:', err);
+
+        // TODO (@codeviking): I'm not sure if we'll want to couple all demos tightly to Sentry.
+        // When we lift @allenai/tugboat into it's own package, we may need to come up with a more
+        // elegant way doing this, so applications are free to pick a client-side error tracker
+        // of their choice (or opt out of one entirely).
+        Sentry.captureException(err);
         return <ErrorMessage />;
     }
 

--- a/ui/src/tugboat/components/share/Controller.tsx
+++ b/ui/src/tugboat/components/share/Controller.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import * as Sentry from '@sentry/react';
 import { useRouteMatch } from 'react-router-dom';
 import { notification } from 'antd';
 
@@ -55,6 +56,7 @@ export const Controller = <T,>({ type, children }: Props<T>) => {
     }
 
     if (state === PromiseState.Failure) {
+        Sentry.captureException(err);
         console.error('Shared document failed to load:', err);
         notification.error({
             message: 'Something went wrong.',

--- a/ui/src/tugboat/components/share/Link.tsx
+++ b/ui/src/tugboat/components/share/Link.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import * as Sentry from '@sentry/react';
 import { generatePath } from 'react-router';
 import { useRouteMatch } from 'react-router-dom';
 import styled from 'styled-components';
@@ -69,6 +70,7 @@ export const Link = <T,>({ app, type, doc, slug }: LinkProps<T>) => {
     // load what they're trying to view.
     if (state === PromiseState.Failure || !docId) {
         console.error('Failed to create shareable link:', err);
+        Sentry.captureException(err);
         notification.warning({
             message: 'Something went Wrong',
             description:


### PR DESCRIPTION
I'm not sure why, but right now errors handled by the
`<ErrorBoundary />` aren't being sent to Sentry. This works
in development, but not in production, which leads me to believe
it has something to do with the fact that I decided to *not*
use `<Sentry.ErrorBoundary />`.

This PR factors things out a bit so that we can use the display
logic we already have in place, but use it within the context
of Sentry's `<ErrorBoundary />` I'll test this out in an ad-hoc
to verify that errors get captured.