### PR TITLE
port sentiment analysis to new UI framework

### DIFF
--- a/ui/src/demos/sentiment-analysis/Main.tsx
+++ b/ui/src/demos/sentiment-analysis/Main.tsx
@@ -17,7 +17,7 @@ import { AppId } from '../../AppId';
 import { MultiModelDemo, Predict, Interpreters } from '../../components';
 import { config } from './config';
 import { Predictions } from './Predictions';
-import { Version, Input, Prediction, InterpreterData, isWithTokenizedInput } from './types';
+import { Version, Input, Prediction, InterpreterData, } from './types';
 
 export const Main = () => {
     // The hidden fields below are passing parameters to the api that the user does not need to set
@@ -31,7 +31,7 @@ export const Main = () => {
                     <Predict<Input, Prediction>
                         fields={
                             <>
-							    <Field.Sentence />
+                                <Field.Sentence />
                                 <Submit>Run Model</Submit>
                             </>
                         }>

--- a/ui/src/demos/sentiment-analysis/Main.tsx
+++ b/ui/src/demos/sentiment-analysis/Main.tsx
@@ -1,17 +1,62 @@
-/*
-    Note: this file is in development and should only be viewed as example code direction
-*/
-
 import React from 'react';
-import { Content } from '@allenai/varnish/components';
+import { Tabs } from 'antd';
+import { RuleObject } from 'antd/lib/form';
 
-import { TaskTitle } from '../../tugboat/components';
+import {
+    ModelCard,
+    Output,
+    Saliency,
+    SelectExample,
+    Field,
+    Share,
+    Submit,
+    TaskDescription,
+    TaskTitle,
+} from '../../tugboat/components';
+import { AppId } from '../../AppId';
+import { MultiModelDemo, Predict, Interpreters } from '../../components';
+import { config } from './config';
+import { Predictions } from './Predictions';
+import { Version, Input, Prediction, InterpreterData, isWithTokenizedInput } from './types';
 
 export const Main = () => {
+    // The hidden fields below are passing parameters to the api that the user does not need to set
     return (
-        <Content>
+        <MultiModelDemo ids={config.modelIds} taskId={config.taskId}>
             <TaskTitle />
-            NOTE: This task is under development
-        </Content>
+            <TaskDescription />
+            <Tabs>
+                <Tabs.TabPane tab="Demo" key="Demo">
+                    <SelectExample displayProp="sentence" placeholder="Select a Sentence" />
+                    <Predict<Input, Prediction>
+                        fields={
+                            <>
+							    <Field.Sentence />
+                                <Submit>Run Model</Submit>
+                            </>
+                        }>
+                        {({ input, model, output }) => (
+                            <Output>
+                                <Output.Section
+                                    title="Model Output"
+                                    extra={
+                                        <Share.ShareButton
+                                            doc={input}
+                                            slug={Share.makeSlug(input.sentence)}
+                                            type={Version}
+                                            app={AppId}
+                                        />
+                                    }>
+                                    <Predictions input={input} model={model} output={output} />
+                                </Output.Section>
+                            </Output>
+                        )}
+                    </Predict>
+                </Tabs.TabPane>
+                <Tabs.TabPane tab="Model Card" key="Card">
+                    <ModelCard />
+                </Tabs.TabPane>
+            </Tabs>
+        </MultiModelDemo>
     );
 };

--- a/ui/src/demos/sentiment-analysis/Main.tsx
+++ b/ui/src/demos/sentiment-analysis/Main.tsx
@@ -16,7 +16,7 @@ import { AppId } from '../../AppId';
 import { MultiModelDemo, Predict, Interpreters } from '../../components';
 import { config } from './config';
 import { Predictions } from './Predictions';
-import { Version, Input, Prediction, InterpreterData, } from './types';
+import { Version, Input, Prediction, InterpreterData } from './types';
 
 export const Main = () => {
     // The hidden fields below are passing parameters to the api that the user does not need to set

--- a/ui/src/demos/sentiment-analysis/Main.tsx
+++ b/ui/src/demos/sentiment-analysis/Main.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Tabs } from 'antd';
-import { RuleObject } from 'antd/lib/form';
 
 import {
     ModelCard,

--- a/ui/src/demos/sentiment-analysis/Main.tsx
+++ b/ui/src/demos/sentiment-analysis/Main.tsx
@@ -48,6 +48,17 @@ export const Main = () => {
                                         />
                                     }>
                                     <Predictions input={input} model={model} output={output} />
+                                    <Interpreters<Input, InterpreterData> input={input}>
+                                        {(interpreterOutput) => (
+                                            <Saliency
+                                                interpretData={[
+                                                    interpreterOutput.instance_1.grad_input_1,
+                                                ]}
+                                                inputTokens={[output.tokens]}
+                                                inputHeaders={['Sentence']}
+                                            />
+                                        )}
+                                    </Interpreters>
                                 </Output.Section>
                             </Output>
                         )}

--- a/ui/src/demos/sentiment-analysis/Main.tsx
+++ b/ui/src/demos/sentiment-analysis/Main.tsx
@@ -13,7 +13,7 @@ import {
     TaskTitle,
 } from '../../tugboat/components';
 import { AppId } from '../../AppId';
-import { MultiModelDemo, Predict, Interpreters } from '../../components';
+import { MultiModelDemo, Predict, Interpreters, Attackers } from '../../components';
 import { config } from './config';
 import { Predictions } from './Predictions';
 import { Version, Input, Prediction, InterpreterData } from './types';
@@ -58,6 +58,13 @@ export const Main = () => {
                                             />
                                         )}
                                     </Interpreters>
+                                    // TODO: [jon] this needs to be "grad_input_1" here
+                                    <Attackers
+                                        input={input}
+                                        model={model}
+                                        prediction={output}
+                                        target="tokens"
+                                    />
                                 </Output.Section>
                             </Output>
                         )}

--- a/ui/src/demos/sentiment-analysis/Predictions.tsx
+++ b/ui/src/demos/sentiment-analysis/Predictions.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Table } from 'antd';
 
 import { DebugInfo } from '../../components';
 import { Output } from '../../tugboat/components';
@@ -15,7 +14,7 @@ interface Props {
 export const Predictions = ({ input, model, output }: Props) => {
     return (
         <Output.Section>
-			<SummaryText output={output} />
+            <SummaryText output={output} />
 
             <DebugInfo input={input} output={output} model={model} />
         </Output.Section>
@@ -71,9 +70,9 @@ const SummaryText = ({ output }: { output: Prediction }) => {
         summaryText = <div>The model is not confident in its judgment.</div>;
     }
 
-	return (
-	    <>
+    return (
+        <>
             <Output.SubSection>{summaryText}</Output.SubSection>
-		</>
+        </>
     );
 };

--- a/ui/src/demos/sentiment-analysis/Predictions.tsx
+++ b/ui/src/demos/sentiment-analysis/Predictions.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Table } from 'antd';
+
+import { DebugInfo } from '../../components';
+import { Output } from '../../tugboat/components';
+import { Input, Prediction } from './types';
+import { Model } from '../../tugboat/lib';
+
+interface Props {
+    input: Input;
+    model: Model;
+    output: Prediction;
+}
+
+export const Predictions = ({ input, model, output }: Props) => {
+    return (
+        <Output.Section>
+			<SummaryText output={output} />
+
+            <DebugInfo input={input} output={output} model={model} />
+        </Output.Section>
+    );
+};
+
+const SummaryText = ({ output }: { output: Prediction }) => {
+    const [positive, negative] = output.probs;
+
+    const judgments = {
+        negative: (
+            <span>
+                the sentence has a <strong>negative</strong> sentiment
+            </span>
+        ),
+        positive: (
+            <span>
+                the sentence has a <strong>positive</strong> sentiment
+            </span>
+        ),
+    };
+
+    // Find judgment and confidence.
+    let judgment;
+    let confidence;
+
+    if (negative > positive) {
+        judgment = judgments.negative;
+        confidence = negative;
+    } else {
+        judgment = judgments.positive;
+        confidence = positive;
+    }
+
+    // Create summary text.
+    const veryConfident = 0.75;
+    const somewhatConfident = 0.5;
+    let summaryText;
+
+    if (confidence >= veryConfident) {
+        summaryText = (
+            <div>
+                The model is <strong>very confident</strong> that {judgment}.
+            </div>
+        );
+    } else if (confidence >= somewhatConfident) {
+        summaryText = (
+            <div>
+                The model is <strong>somewhat confident</strong> that {judgment}.
+            </div>
+        );
+    } else {
+        summaryText = <div>The model is not confident in its judgment.</div>;
+    }
+
+	return (
+	    <>
+            <Output.SubSection>{summaryText}</Output.SubSection>
+		</>
+    );
+};

--- a/ui/src/demos/sentiment-analysis/types.ts
+++ b/ui/src/demos/sentiment-analysis/types.ts
@@ -3,7 +3,28 @@ import { emory } from '../../tugboat/lib';
 export const Version = emory.getVersion('sa-v1');
 
 export interface Input {
-    input: string; // TODO: rename?
+    sentence: string;
 }
 
-export interface Prediction {}
+export interface WithTokenizedInput {
+    words: string[][];
+}
+
+export const isWithTokenizedInput = (pred: any): pred is WithTokenizedInput => {
+    const xx = pred as WithTokenizedInput;
+    return Array.isArray(xx.words);
+};
+
+export interface Prediction {
+    probs: number[];
+	logits: number[];
+	token_ids: number[];
+	tokens: string[];
+	label: string;
+}
+
+export interface InterpreterData {
+    instance_1: {
+        grad_input_1: number[];
+    };
+}

--- a/ui/src/demos/sentiment-analysis/types.ts
+++ b/ui/src/demos/sentiment-analysis/types.ts
@@ -6,21 +6,12 @@ export interface Input {
     sentence: string;
 }
 
-export interface WithTokenizedInput {
-    words: string[][];
-}
-
-export const isWithTokenizedInput = (pred: any): pred is WithTokenizedInput => {
-    const xx = pred as WithTokenizedInput;
-    return Array.isArray(xx.words);
-};
-
 export interface Prediction {
     probs: number[];
-	logits: number[];
-	token_ids: number[];
-	tokens: string[];
-	label: string;
+    logits: number[];
+    token_ids: number[];
+    tokens: string[];
+    label: string;
 }
 
 export interface InterpreterData {


### PR DESCRIPTION
Still TODO:
- [x] Add interpret section
- [x] Add attackers
- [ ] ~~Add model selection (only does glove right now)~~ never mind
- [ ] Fix this formatting in model card info. Seeing raw markdown. Not sure if this is something that should be fixed on the UI or the backend.
<img width="1131" alt="image" src="https://user-images.githubusercontent.com/8812459/106202895-6e04bb00-616f-11eb-9d63-ab25607fb295.png">


This should be reviewed very carefully when it's ready because I have no idea what I'm doing with front-end code.