### PR TITLE
Redact `<SelectExample />` tweaks; Small fixes here and there.

### DIFF
--- a/ui/src/demos/visual-question-answering/Main.tsx
+++ b/ui/src/demos/visual-question-answering/Main.tsx
@@ -3,7 +3,7 @@
  * control.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import { Tabs } from 'antd';
 
 import {
@@ -15,8 +15,9 @@ import {
     TaskDescription,
     TaskTitle,
     Fields,
+    UploadedImage,
 } from '../../tugboat/components';
-import { Example } from '../../tugboat/lib';
+import { Examples } from '../../tugboat/context';
 import { MultiModelDemo, Predict } from '../../components';
 import { config } from './config';
 import { Usage } from './Usage';
@@ -28,13 +29,19 @@ import busStopSrc from '../exampleImages/bus_stop.jpg';
 import kitchenSrc from '../exampleImages/kitchen.jpg';
 import livingRoomSrc from '../exampleImages/living_room.jpg';
 
+interface Props {
+    onChange: (i: UploadedImage) => void;
+}
+
+const UploadImage = ({ onChange }: Props) => {
+    const examples = useContext(Examples);
+    return <Field.Image value={examples.selectedExample?.image} onChange={onChange} />;
+};
+
 export const Main = () => {
     // Fields on the form to force an update to the value, this is needed because the input control
     // does not know about the form, and the form is not available at field construction time.
     const [overrides, setOverrides] = useState<Fields>();
-    // Holding on to selected example because the fields need to know about changes and the Example
-    // context is not ready at form construction time.
-    const [selectedExample, setSelectedExample] = useState<Example>();
 
     // Need to override examples so we have access to the images.
     // TODO: get the backend to supply the images in examples and update ui to be able to point to a
@@ -68,18 +75,11 @@ export const Main = () => {
             <TaskDescription />
             <Tabs>
                 <Tabs.TabPane tab="Demo" key="Demo">
-                    <SelectExample
-                        displayProp="snippet"
-                        placeholder="Select an Example"
-                        onChange={(ex?: Example) => setSelectedExample(ex)}
-                    />
+                    <SelectExample displayProp="snippet" placeholder="Select an Example" />
                     <Predict<Input, Prediction>
                         fields={
                             <>
-                                <Field.Image
-                                    value={selectedExample?.image}
-                                    onChange={(v) => setOverrides(v)}
-                                />
+                                <UploadImage onChange={(image) => setOverrides({ image })} />
                                 <Field.Question />
                                 <Submit>Run Model</Submit>
                             </>

--- a/ui/src/tugboat/components/ImageUpload.tsx
+++ b/ui/src/tugboat/components/ImageUpload.tsx
@@ -237,7 +237,7 @@ export const downscaleImage = ({
         };
         reader.onerror = (error) => {
             Sentry.captureException(error);
-            console.log(error);
+            console.error(error);
             if (onError) {
                 onError('Error compressing image.');
             }

--- a/ui/src/tugboat/components/SelectExample.tsx
+++ b/ui/src/tugboat/components/SelectExample.tsx
@@ -10,7 +10,6 @@ import { InvalidDisplayPropError, DuplicateDisplayPropValueError } from '../erro
 interface Props {
     displayProp: string;
     placeholder?: string;
-    onChange?: (val?: Example) => void;
 }
 
 /**
@@ -23,7 +22,7 @@ interface Props {
  *
  * See: https://github.com/allenai/allennlp-models/blob/master/allennlp_models/pretrained.py#L24
  */
-export const SelectExample = ({ displayProp, placeholder, onChange }: Props) => {
+export const SelectExample = ({ displayProp, placeholder }: Props) => {
     const ctx = React.useContext(Examples);
 
     // The `<Select />` component we use expects that each value has a string value for uniquely
@@ -51,11 +50,7 @@ export const SelectExample = ({ displayProp, placeholder, onChange }: Props) => 
             <FieldItem label="Example Inputs">
                 <Select
                     value={ctx.selectedExample ? ctx.selectedExample[displayProp] : undefined}
-                    onChange={(id) => {
-                        const selValue = examplesById[`${id}`];
-                        onChange && onChange(selValue);
-                        return ctx.selectExample(selValue);
-                    }}
+                    onChange={(id) => ctx.selectExample(examplesById[`${id}`])}
                     placeholder={placeholder || 'Select an Example…'}>
                     {isGroupedExamples(ctx.examples)
                         ? Object.entries(ctx.examples).map(([g, ex]) => (

--- a/ui/src/tugboat/components/form/Image.tsx
+++ b/ui/src/tugboat/components/form/Image.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import * as Sentry from '@sentry/react';
 
 import { FieldItem } from './controls';
-import { ImageUpload, blobToString } from '../ImageUpload';
+import { UploadedImage, ImageUpload, blobToString } from '../ImageUpload';
 
 /**
  * A component that renders an image uploader for capturing an image to be processed by a model.
@@ -11,7 +11,7 @@ import { ImageUpload, blobToString } from '../ImageUpload';
  */
 interface Props {
     value?: string;
-    onChange: (v: any) => void;
+    onChange: (i: UploadedImage) => void;
 }
 
 export const Image = (props: Props) => {
@@ -22,13 +22,11 @@ export const Image = (props: Props) => {
                     blobToString(image.image)
                         .then((str) => {
                             image.image_base64 = str;
-                            props.onChange({
-                                image,
-                            });
+                            props.onChange(image);
                         })
                         .catch((e) => {
                             Sentry.captureException(e);
-                            console.log(e);
+                            console.error(e);
                         });
                 }}
                 uploadedImage={{ imageSrc: props.value }}


### PR DESCRIPTION
This removes the changes made to `<SelectExample />`, since they're
no longer necessary.

I tested this and things seemed to work (I can't test that things
can be submitted, due to the fact that it's pointed at the
constituency parser right now).