### PR TITLE
custom Dockerfile to model-cards service

### DIFF
--- a/api/allennlp_demo/model_cards/Dockerfile
+++ b/api/allennlp_demo/model_cards/Dockerfile
@@ -1,0 +1,20 @@
+FROM allennlp/models:v1.4.0-cuda11.0
+
+WORKDIR /app/
+
+COPY allennlp_demo/model_cards/requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
+COPY allennlp_demo/__init__.py allennlp_demo/__init__.py
+COPY allennlp_demo/common allennlp_demo/common
+COPY allennlp_demo/model_cards allennlp_demo/model_cards
+
+# Ensure allennlp_demo module can be found by Python.
+ENV PYTHONPATH /app/
+
+# Ensure log messages written immediately instead of being buffered, which is
+# useful if the app crashes so the logs won't get swallowed.
+ENV PYTHONUNBUFFERED 1
+
+ENTRYPOINT [ "python" ]
+CMD [ "allennlp_demo/model_cards/api.py" ]

--- a/api/allennlp_demo/model_cards/requirements.txt
+++ b/api/allennlp_demo/model_cards/requirements.txt
@@ -1,0 +1,4 @@
+allennlp==1.4.1
+allennlp-models==1.4.1
+Flask==1.1.2
+pytest==6.2.1


### PR DESCRIPTION
This is just so we can more easily get model card updates deployed. Now we can just pin `allennlp-models` to a commit SHA in this `requirements.txt` file and not worry about doing a new release and re-deploying every demo model.