### PR TITLE
Warn if a model isn't included.

### DIFF
--- a/ui/src/components/TaskDemo.tsx
+++ b/ui/src/components/TaskDemo.tsx
@@ -50,6 +50,15 @@ export const TaskDemo = ({ ids, taskId, children, examples }: Props) => {
     const infos = useContext(ModelInfoList);
     const included = new Set(ids);
     const demoInfos = infos.filter((info) => included.has(info.id));
+    const missingIds = ids.filter((id) => !demoInfos.find((mi) => mi.id === id));
+    if (missingIds.length > 0) {
+        console.log(
+            "The following models were requested but skipped because they weren't found in the " +
+                "info response. This usually means the API for that model is down, or that there's " +
+                'a typo: ',
+            missingIds
+        );
+    }
 
     const tasksById = useContext(TaskCards);
     if (!(taskId in tasksById)) {

--- a/ui/src/demos/textual-entailment/Predictions.tsx
+++ b/ui/src/demos/textual-entailment/Predictions.tsx
@@ -172,7 +172,7 @@ const BasicPrediction = ({ probs }: { probs: number[] }) => {
                         neutral={neutral}
                         entailment={entailment}
                     />
-                    <Table dataSource={dataSource} columns={columns} pagination={false} />;
+                    <Table dataSource={dataSource} columns={columns} pagination={false} />
                 </Columns>
             </Output.SubSection>
         </>


### PR DESCRIPTION
This adds a warning when a model is dropped because it's not
in the `/info` response. This happens when the ID is a typo, or
if the API is down (as is the case currently for the `elmo-snli`
model).

I also removed a stray `;`.