### PR TITLE
Force usage information to update.

### DIFF
--- a/ui/src/components/ModelUsage.tsx
+++ b/ui/src/components/ModelUsage.tsx
@@ -53,14 +53,25 @@ export const ModelUsage = (props: Props) => {
             {props.bashNote ? <p>{props.bashNote}</p> : null}
             {props.bashCommand ? (
                 <UsageCode>
-                    <SyntaxHighlight language="bash">{props.bashCommand}</SyntaxHighlight>
+                    {/* We use key below to fix an issue in Safari where the text that's rendered
+                        doesn't update without it. Using a key tells React to replace the DOM node
+                        entirely when the value changes, which prevents whatever fancy diff
+                        mechanism is causing the problem. See:
+                        https://github.com/allenai/allennlp-demo/issues/827 */}
+                    <SyntaxHighlight key={props.bashCommand} language="bash">
+                        {props.bashCommand}
+                    </SyntaxHighlight>
                 </UsageCode>
             ) : null}
             <h6>As a library (Python):</h6>
             {props.pythonNote ? <p>{props.pythonNote}</p> : null}
             {props.pythonCommand ? (
                 <UsageCode>
-                    <SyntaxHighlight language="python">{props.pythonCommand}</SyntaxHighlight>
+                    {/* Again we use key for the same purpose as above. We're not sure why
+                        we only have to do this for these two instances. */}
+                    <SyntaxHighlight key={props.pythonCommand} language="python">
+                        {props.pythonCommand}
+                    </SyntaxHighlight>
                 </UsageCode>
             ) : null}
 


### PR DESCRIPTION
Fix #827; Use the `key` attribute to force React to ditch the whole
DOM node and rerender it when it changes. This fixes an issue where
Safari wasn't updating the displayed text.

What's bizarre is Safari *was* updating the HTML that's displayed
in the inspector, just not what's rendered. This leads me to think
it's Safari's fault and that React isn't to blame.

It's also worth noting that I tried lots of things, none of which
worked, which led me here:

- I tried replacing the syntax highlighter we use with an alternative
  one (`prism-react-renderer`).
- I tried replacing the syntax highlighting with a simple `<code />`
  tag.

Also, here's a bug that seems somewhat similar and provides further
evidence that this is some sort of low-level, nuanced issue:
https://bugzilla.mozilla.org/show_bug.cgi?id=1105835#c11