### PR TITLE
Fix hook use.

### DIFF
--- a/ui/src/components/TaskDemo.tsx
+++ b/ui/src/components/TaskDemo.tsx
@@ -46,17 +46,18 @@ interface Props {
  * of a model (which is queried via API routes) to the shape expected by the tugboat module.
  */
 export const TaskDemo = ({ ids, taskId, children, examples }: Props) => {
+    const tasksById = useContext(TaskCards);
+    if (!(taskId in tasksById)) {
+        throw new TaskNotFoundError(taskId);
+    }
+    const task = tasksById[taskId];
+
+    const cardsById = useContext(ModelCards);
+
     const fetchInfoForIncludedModels = () => Promise.all(ids.map(fetchModelInfo));
     return (
         <Promised promise={fetchInfoForIncludedModels} deps={ids}>
             {(infos) => {
-                const tasksById = useContext(TaskCards);
-                if (!(taskId in tasksById)) {
-                    throw new TaskNotFoundError(taskId);
-                }
-                const task = tasksById[taskId];
-
-                const cardsById = useContext(ModelCards);
                 const models: Model[] = [];
                 for (const info of infos) {
                     const modelCardId = getModelCardId(info);


### PR DESCRIPTION
In f7ab071742e4f917a2e9bf1f06b461470554ce1a I modified `<TaskDemo />`
to fetch the model info as part of it's initialization. When doing so
I missed the fact that I caused a big ole' error to be emitted by
React about the fact that the hooks used in the function body were
not being invoked at the top level. This fixes that error.