### PR TITLE
Ignore empty directories.

### DIFF
--- a/demo
+++ b/demo
@@ -459,6 +459,8 @@ class APIEndpoint(Container):
                 continue
             if p.name == "common" or p.name.startswith(".") or p.name == "__pycache__":
                 continue
+            if len(list(p.iterdir())) == 0:
+                continue
             endpoint = APIEndpoint(p.name)
             status = Status.UP if endpoint.fqn in running else Status.DOWN
             endpoints.append((endpoint, status))


### PR DESCRIPTION
If we delete a module using `git` it'll leave behind an empty directory
which can make the `demo` script fail in confusing ways. This fixes
this by silently ignoring directories that are empty.