### PR TITLE
fix collapse panel issue

### DIFF
--- a/ui/src/components/Attackers.tsx
+++ b/ui/src/components/Attackers.tsx
@@ -12,6 +12,7 @@ import {
 } from '.';
 import { ModelInfoList, findModelInfo } from '../context';
 import { AttackType } from '../lib';
+import { CollapsePanel } from './CollapsePanel';
 
 interface Props<I, O> {
     input: I;
@@ -42,7 +43,7 @@ export const Attackers = <I, O>({
         <Output.Section title="Model Attacks">
             <Collapse>
                 {supportedAttackTypes.has(AttackType.InputReduction) ? (
-                    <Collapse.Panel key={AttackType.InputReduction} header="Input Reduction">
+                    <CollapsePanel key={AttackType.InputReduction} header="Input Reduction">
                         <Attack<I, InputReductionAttackOutput>
                             type={AttackType.InputReduction}
                             target={target}
@@ -63,10 +64,10 @@ export const Attackers = <I, O>({
                             }>
                             {(output) => <InputReduction {...output} />}
                         </Attack>
-                    </Collapse.Panel>
+                    </CollapsePanel>
                 ) : null}
                 {supportedAttackTypes.has(AttackType.HotFlip) ? (
-                    <Collapse.Panel key={AttackType.HotFlip} header="HotFlip">
+                    <CollapsePanel key={AttackType.HotFlip} header="HotFlip">
                         <Attack<I, HotflipAttackOutput<O>>
                             type={AttackType.HotFlip}
                             target={target}
@@ -99,7 +100,7 @@ export const Attackers = <I, O>({
                                 />
                             )}
                         </Attack>
-                    </Collapse.Panel>
+                    </CollapsePanel>
                 ) : null}
             </Collapse>
         </Output.Section>

--- a/ui/src/components/CollapsePanel.tsx
+++ b/ui/src/components/CollapsePanel.tsx
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+import Collapse from 'antd/es/collapse';
+
+/**
+ * The latest version of antd has a bug with setting the height of a dynamic collapse panel.
+ * This is a hammer to fix that.
+ * TODO: we should remove this when we can.
+ */
+export const CollapsePanel = styled(Collapse.Panel)`
+    .ant-collapse-content-active {
+        height: 100% !important;
+    }
+`;

--- a/ui/src/components/Interpreters.tsx
+++ b/ui/src/components/Interpreters.tsx
@@ -8,6 +8,8 @@ import { NoSelectedModelError } from '@allenai/tugboat/error';
 import { Interpret } from '.';
 import { ModelInfoList, findModelInfo } from '../context';
 import { InterpreterId } from '../lib';
+import { CollapsePanel } from './CollapsePanel';
+
 interface Props<I, O> {
     input: I;
     children: (output: O) => React.ReactNode;
@@ -53,7 +55,7 @@ export const Interpreters = <I, O>({ input, children }: Props<I, O>) => {
             }>
             <Collapse>
                 {supportedInterpreters.has(InterpreterId.SimpleGradient) ? (
-                    <Collapse.Panel
+                    <CollapsePanel
                         key={InterpreterId.SimpleGradient}
                         header="Simple Gradient Visualization">
                         <Interpret<I, O>
@@ -73,10 +75,10 @@ export const Interpreters = <I, O>({ input, children }: Props<I, O>) => {
                             }>
                             {(output) => children(output)}
                         </Interpret>
-                    </Collapse.Panel>
+                    </CollapsePanel>
                 ) : null}
                 {supportedInterpreters.has(InterpreterId.IntegratedGradient) ? (
-                    <Collapse.Panel
+                    <CollapsePanel
                         key={InterpreterId.IntegratedGradient}
                         header="Integrated Gradient Visualization">
                         <Interpret<I, O>
@@ -96,10 +98,10 @@ export const Interpreters = <I, O>({ input, children }: Props<I, O>) => {
                             }>
                             {(output) => children(output)}
                         </Interpret>
-                    </Collapse.Panel>
+                    </CollapsePanel>
                 ) : null}
                 {supportedInterpreters.has(InterpreterId.SmoothGradient) ? (
-                    <Collapse.Panel
+                    <CollapsePanel
                         key={InterpreterId.SmoothGradient}
                         header="Smooth Gradient Visualization">
                         <Interpret<I, O>
@@ -119,7 +121,7 @@ export const Interpreters = <I, O>({ input, children }: Props<I, O>) => {
                             }>
                             {(output) => children(output)}
                         </Interpret>
-                    </Collapse.Panel>
+                    </CollapsePanel>
                 ) : null}
             </Collapse>
         </Output.Section>

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -1,5 +1,6 @@
 export * from './Attack';
 export * from './Attackers';
+export * from './CollapsePanel';
 export * from './DebugInfo';
 export * from './Hierplane';
 export * from './Hotflip';


### PR DESCRIPTION
antd has a broken component, this is a quick hacky fix to deal with that
simply forcing the content area of a panel to be 100% tall