### PR TITLE
Fix the run command.

### DIFF
--- a/demo
+++ b/demo
@@ -220,8 +220,9 @@ class Container:
             cmd = shlex.split(f"{self.exec_cmd()} {entrypoint}")
         else:
             cmd = shlex.split(self.start_cmd())
-            cmd.append("--entrypoint")
-            cmd.append(entrypoint)
+            # The tag to run is always the last argument, so we insert the `--entrypoint`
+            # before then.
+            cmd = cmd[:len(cmd)-1] + [ "--entrypoint", entrypoint ] + cmd[len(cmd)-1:]
         for a in args:
             cmd.append(a)
         subprocess.check_call(cmd)


### PR DESCRIPTION
This fixes a bug Dirk discovered in the run command. The
`--entrypoint` option was being passed to the command being
ran in the container instead of `docker run`.