### PR TITLE
dont throw when there is no answer

### DIFF
--- a/ui/src/demos/reading-comprehension/Predictions.tsx
+++ b/ui/src/demos/reading-comprehension/Predictions.tsx
@@ -97,8 +97,8 @@ const BasicPrediction = ({
     // so we just find the highlightSpan locally.
     const start = input.passage.indexOf(output.best_span_str);
     const highlightSpan = [start, start + output.best_span_str.length];
-
-    if (highlightSpan[0] < 0 || highlightSpan[1] <= highlightSpan[0]) {
+    const hasBestSpan = output.best_span_str !== '';
+    if (hasBestSpan && (highlightSpan[0] < 0 || highlightSpan[1] <= highlightSpan[0])) {
         throw new InvalidModelResponseError(
             `"${output.best_span_str}" does not exist in the passage.`
         );
@@ -109,15 +109,19 @@ const BasicPrediction = ({
             <BasicAnswer output={output} />
 
             <Output.SubSection title="Passage Context">
-                <TextWithHighlight
-                    text={input.passage}
-                    highlights={[
-                        {
-                            start: highlightSpan[0],
-                            end: highlightSpan[1],
-                        },
-                    ]}
-                />
+                {hasBestSpan ? (
+                    <TextWithHighlight
+                        text={input.passage}
+                        highlights={[
+                            {
+                                start: highlightSpan[0],
+                                end: highlightSpan[1],
+                            },
+                        ]}
+                    />
+                ) : (
+                    <div>{input.passage}</div>
+                )}
             </Output.SubSection>
 
             <Output.SubSection title="Question">

--- a/ui/src/demos/reading-comprehension/types.ts
+++ b/ui/src/demos/reading-comprehension/types.ts
@@ -227,17 +227,18 @@ export interface InterpreterData {
 }
 
 export const getBasicAnswer = (pred: Prediction): number | string => {
+    const noAnswer = 'Answer not found.';
     if (isBiDAFPrediction(pred) || isTransformerQAPrediction(pred)) {
-        return pred.best_span_str;
+        return pred.best_span_str || noAnswer;
     }
     if (isNAQANetPredictionSpan(pred) || isNAQANetPredictionArithmetic(pred)) {
-        return pred.answer.value;
+        return pred.answer.value || noAnswer;
     }
     if (isNAQANetPredictionCount(pred)) {
         return pred.answer.count;
     }
     if (isNMNPrediction(pred)) {
-        return pred.answer;
+        return pred.answer || noAnswer;
     }
-    throw new InvalidModelResponseError('Answer not found.');
+    throw new InvalidModelResponseError(noAnswer);
 };


### PR DESCRIPTION
When the model is poorly trained, it may return `""` when there is no answer found.
This fix catches this case and tells the user that no answer was found, rather than throwing an error.