### PR TITLE
Fix the demo script.

### DIFF
--- a/demo
+++ b/demo
@@ -33,6 +33,7 @@ from typing import List, Tuple, Optional
 from pathlib import Path
 from urllib.request import urlopen
 from urllib.error import URLError
+from urllib.parse import urlparse
 from http.client import HTTPResponse, RemoteDisconnected
 
 # When we spawn docker things they need a name that prevents them from colliding with other
@@ -582,11 +583,20 @@ class Proxy(Container):
                     proxy_set_header X-Forwarded-For $remote_addr;
                 """
 
+            # If we're proxying to something that uses SSL, set the server name to that of 
+            # the remote resource. Otherwise SSL won't work.
+            upstream_url = urlparse(route.upstream)
+            if upstream_url.scheme == "https":
+                host = upstream_url.netloc.split(":")[0]
+                extra += f"""
+                    proxy_ssl_name {host};
+                    proxy_ssl_server_name on;
+                """
             locs.append(f"""
                 location {route.path} {{
                     {rewrites}
-                    proxy_pass {route.upstream};
                     proxy_set_header X-Forwarded-For $remote_addr;
+                    proxy_pass {route.upstream};
 
                     # Add a header that clients can use to determine where a response is
                     # coming from.

--- a/demo
+++ b/demo
@@ -595,8 +595,8 @@ class Proxy(Container):
             locs.append(f"""
                 location {route.path} {{
                     {rewrites}
-                    proxy_set_header X-Forwarded-For $remote_addr;
                     proxy_pass {route.upstream};
+                    proxy_set_header X-Forwarded-For $remote_addr;
 
                     # Add a header that clients can use to determine where a response is
                     # coming from.


### PR DESCRIPTION
This fixes the demo script by setting the server name
when negotiating a SSL connection. I'm not sure why
things stopped working -- my guess is something changed
in Google LoadBalancers (which Skiff uses) which makes
the SSL handshake more restrictive (which seems like
a good thing).

This fixes #966.