### PR TITLE
cancel redundant GH Actions builds

### DIFF
--- a/.github/workflows/api_ci.yml
+++ b/.github/workflows/api_ci.yml
@@ -1,5 +1,9 @@
 name: API CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:
@@ -46,19 +50,19 @@ jobs:
 
     - name: Format
       working-directory: api
-      if: always()
+      if: '! cancelled()'
       run: |
         make format
 
     - name: Lint
       working-directory: api
-      if: always()
+      if: '! cancelled()'
       run: |
         make lint
 
     - name: Type check
       working-directory: api
-      if: always()
+      if: '! cancelled()'
       run: |
         make typecheck
 

--- a/.github/workflows/ui_ci.yml
+++ b/.github/workflows/ui_ci.yml
@@ -1,4 +1,7 @@
 name: UI CI
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   push:
     branches:


### PR DESCRIPTION
Same changes as https://github.com/allenai/allennlp/pull/5226. See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.