### PR TITLE
Fix the model identifier.

### DIFF
--- a/api/allennlp_demo/binary_gender_bias_mitigated_roberta_snli/.skiff/webapp.jsonnet
+++ b/api/allennlp_demo/binary_gender_bias_mitigated_roberta_snli/.skiff/webapp.jsonnet
@@ -15,4 +15,4 @@ function(image, cause, sha, env, branch, repo, buildId)
     local cpu = '50m';
     local memory = '4Gi';
     local startupTime = 180;
-    common.APIEndpoint('bin-gender-bias-mitigated-roberta-snli', image, cause, sha, cpu, memory, env, branch, repo, buildId)
+    common.APIEndpoint(model.id, image, cause, sha, cpu, memory, env, branch, repo, buildId)

--- a/api/allennlp_demo/binary_gender_bias_mitigated_roberta_snli/model.json
+++ b/api/allennlp_demo/binary_gender_bias_mitigated_roberta_snli/model.json
@@ -1,5 +1,5 @@
 {
-    "id": "binary-gender-bias-mitigated-roberta-snli",
+    "id": "bin-gender-bias-mitigated-roberta-snli",
     "pretrained_model_id": "pair-classification-binary-gender-bias-mitigated-roberta-snli",
     "attackers": [],
     "interpreters": []

--- a/ui/src/lib/ModelInfo.ts
+++ b/ui/src/lib/ModelInfo.ts
@@ -20,7 +20,7 @@ export enum ModelId {
     SemanticRollLabeling = 'semantic-role-labeling',
     TransformerQA = 'transformer-qa',
     VilbertVQA = 'vilbert-vqa',
-    BinaryGenderBiasMitigatedRobertaSNLI = 'binary-gender-bias-mitigated-roberta-snli',
+    BinaryGenderBiasMitigatedRobertaSNLI = 'bin-gender-bias-mitigated-roberta-snli',
 }
 
 /**


### PR DESCRIPTION
Sadly, it turns out we can't override them locally. So this
modifies the model identifer so that it's the shorter form
in all places.