### PR TITLE
Add a pod disruption budget.

### DIFF
--- a/ui/.skiff/webapp.jsonnet
+++ b/ui/.skiff/webapp.jsonnet
@@ -74,6 +74,12 @@ local deployment = {
     },
     spec: {
         revisionHistoryLimit: 3,
+        strategy: {
+            type: 'RollingUpdate',
+            rollingUpdate: {
+                maxSurge: num_replicas // This makes deployments faster.
+            }
+        },
         replicas: num_replicas,
         selector: {
             matchLabels: ui_labels
@@ -169,9 +175,27 @@ local ingress = {
     }
 };
 
+
+local pdb = {
+    apiVersion: 'policy/v1beta1',
+    kind: 'PodDisruptionBudget',
+    metadata: {
+        name: fqn,
+        namespace: namespace_name,
+        labels: labels,
+    },
+    spec: {
+        minAvailable: if num_replicas > 1 then 1 else 0,
+        selector: {
+            matchLabels: ui_labels,
+        },
+    },
+};
+
 [
     namespace,
     ingress,
     deployment,
-    service
+    service,
+    pdb
 ]


### PR DESCRIPTION
This change does two things:

1. Adds a `PodDisruptionBudget`, which ensures that a single replica
   is always available. This prevents downtime while updating the
   cluster version.
2. Changes the deployment spec so that Kubernetes can deploy 2X the
   number of replicas. This should make things a little faster and
   improve capacity during deploys.